### PR TITLE
Add Sentry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 !/app/assets/builds/.keep
 
 /node_modules
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,10 @@ gem "cssbundling-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
+# Use Sentry (https://sentry.io/for/ruby/?platform=sentry.ruby.rails#)
+gem "sentry-ruby"
+gem "sentry-rails"
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem "jbuilder"
 gem "sentry-ruby"
 gem "sentry-rails"
 
+gem 'dotenv-rails', groups: [:development, :test]
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,10 @@ GEM
       irb (>= 1.3.6)
       reline (>= 0.2.7)
     digest (3.1.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -177,6 +181,14 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
+    sentry-rails (5.2.1)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 5.2.1)
+    sentry-ruby (5.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      sentry-ruby-core (= 5.2.1)
+    sentry-ruby-core (5.2.1)
+      concurrent-ruby
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -213,12 +225,15 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  dotenv-rails
   jbuilder
   jsbundling-rails
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.3)
   selenium-webdriver
+  sentry-rails
+  sentry-ruby
   sprockets-rails
   tzinfo-data
   web-console

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,19 @@
+require 'dotenv/load'
+
+Sentry.init do |config|
+    config.dsn = ENV["SENTRY_DSN"]
+    config.breadcrumbs_logger = [:sentry_logger, :http_logger]
+    config.debug = true
+    config.traces_sample_rate = 1.0
+  end
+
+# Uncomment out the below to test Sentry - this
+# will raise 2 issues in Sentry
+
+# begin
+#   1 / 0
+# rescue ZeroDivisionError => exception
+#   Sentry.capture_exception(exception)
+# end
+
+# Sentry.capture_message("test message")


### PR DESCRIPTION
I've added a very basic set up for Sentry here, the configuration is largely untouched, but I figure we can add to this once we've started developing.

This requires the use of an API key, which I've put into a .env file for the time being, and pulled in with ruby using the `dotenv` gem - let me know if there's a better or more standard way of doing this in ruby. 
I've imported  `dotenv/load` at the top of  `config/initializers/sentry.rb` but I have a feeling there's a better place to put this. 

To use this, sign up to sentry and add the sentry dns to .env as SENTRY_DNS. I've left in some exceptions to triggers entries to Sentry in `config/initializers/sentry.rb` ll13-19 - uncomment these, run the project, and see entries appear in Sentry.

relates #3 