### PR TITLE
Add initial codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @alphagov/forms-devs will be requested for
+# review when someone opens a pull request.
+* @alphagov/forms-devs


### PR DESCRIPTION
Initially marks all files as owned by the forms-devs team, as we go forward this will likely be more granular

Closes #2 