### PR TITLE
Add README and CONTRIBUTING files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contribution guidelines
+
+We love contributions! We've compiled these docs to help you understand our contribution guidelines.
+
+## Contents of this file
+
+### For contributors
+
+- [Code of conduct](#code-of-conduct)
+- [Conventions to follow](#conventions-to-follow)
+  - [Indentation and whitespace](#indentation-and-whitespace)
+  - [Coding style](#coding-style)
+- [Supported browsers](#supported-browsers)
+- [Supported assistive technology](#supported-assistive-technology)
+- [Commit hygiene](#commit-hygiene)
+
+## Code of Conduct
+
+Please read [the `alphagov` CODE_OF_CONDUCT.md](https://github.com/alphagov/.github/blob/main/CODE_OF_CONDUCT.md) before contributing.
+
+## Conventions to follow
+
+### Indentation and whitespace
+
+2-space, soft-tabs only. No trailing whitespace. The repository contains an .editorconfig file to enforce this if your editor supports this.
+
+### Coding style
+
+We follow the style conventions detailed in [the GDS Way](https://gds-way.cloudapps.digital/manuals/programming-languages.html).
+
+## Supported browsers
+
+TODO: Add browser support, once we know what we're supporting. For now, let's assume that we're using [the Service Manual's browsers to test in](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices).
+
+## Supported assistive technology
+
+TODO: Add assistive technology support, once we know what we're supporting. For now, let's assume that we're using [the Service Manual's assistive technologies to test with](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies).
+
+## Commit hygiene
+
+Please see our [Git style guide in the 'How to store source code' page of the GDS Way](https://gds-way.cloudapps.digital/standards/source-code.html#commit-messages), which describes how we prefer Git history and commit messages to read.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,86 @@
-# README
+# GOV.UK Forms Runner [![Ruby on Rails CI](https://github.com/alphagov/forms-runner/actions/workflows/rubyonrails.yml/badge.svg)](https://github.com/alphagov/forms-runner/actions/workflows/rubyonrails.yml) [![Deploy to GOV.UK PaaS](https://github.com/alphagov/forms-runner/actions/workflows/deploy.yml/badge.svg)](https://github.com/alphagov/forms-runner/actions/workflows/deploy.yml)
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+GOV.UK Forms is a service for creating forms. GOV.UK Forms Runner is a an application which displays those forms to end users so that they can be filled in. It's a Ruby on Rails application built on a PostgreSQL database.
 
-Things you may want to cover:
+## Before you start
 
-* Ruby version
+To run the project you will need to install:
 
-* System dependencies
+- [Ruby](https://www.ruby-lang.org/en/) - we use version 3 of Ruby. Before running the project, double check the [.ruby-version] file to see the exact version.
+- [Node.js](https://nodejs.org/en/) - the frontend build requires Node.js. We use Node 16 LTS versions.
+- a running [PostgreSQL](https://www.postgresql.org/) database
+- [Yarn](https://yarnpkg.com/) - we use Yarn rather than `npm` to install and run the frontend.
 
-* Configuration
+We recommend using a version manager to install and manage these, such as:
 
-* Database creation
+- [RVM](https://rvm.io/) or [rbenv](https://github.com/rbenv/rbenv) for Ruby
+- [nvm](https://github.com/nvm-sh/nvm) for Node.js
+- [asdf](https://github.com/asdf-vm/asdf) for both
 
-* Database initialization
+## Getting started
 
-* How to run the test suite
+### Installing for the first time
 
-* Services (job queues, cache servers, search engines, etc.)
+```bash
+# 1. Clone the git repository and change directory to the new folder
+git clone git@github.com:alphagov/forms-runner.git
+cd forms-runner
 
-* Deployment instructions
+# 2. Install the ruby dependencies
+bundle install
 
-* ...
+# 3. Set up the database
+rake db:prepare
+
+# 4. Install the node dependencies
+yarn
+
+# 5. Run the frontend build tasks
+yarn build & yarn build:css
+```
+
+### Running the app
+
+You can either run the development task:
+
+```bash
+# Run the foreman dev server. This will also start the frontend dev task
+bin/dev
+```
+
+or run the rails server:
+
+```bash
+# Run a local Rails server
+bin/rails server
+
+# When running the server, you can use any of the frontend tasks, e.g.:
+yarn dev
+```
+
+## Configuration and deployment
+
+TODO: Add these details once we've got our deployment running.
+
+## Explain how to test the project
+
+```bash
+# Run the Ruby test suite
+bin/rake
+# To run the Javascript test suite, run
+yarn test
+# To run the end-to-end tests, run
+yarn cypress
+```
+
+## Support
+
+Raise a Github issue if you need support.
+
+## Explain how users can contribute
+
+We welcome contributions - please read [CONTRIBUTING.md](CONTRIBUTING.md) and the [alphagov Code of Conduct](https://github.com/alphagov/.github/blob/main/CODE_OF_CONDUCT.md) before contributing.
+
+## License
+
+We use the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
Adds a largely unchanged copy of the README and CONTRIBUTING files from the admin repo. The main differences are the project description and badges at the top of the README.