### PR TITLE
Move setup steps into Rails setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,14 @@ We recommend using a version manager to install and manage these, such as:
 git clone git@github.com:alphagov/forms-runner.git
 cd forms-runner
 
-# 2. Install the ruby dependencies
-bundle install
-
-# 3. Set up the database
-# You can check the DB details in .env.development and overide them if needed using .env.development.local
-rake db:prepare
-
-# 4. Install the node dependencies
-yarn
-
-# 5. Run the frontend build tasks
-yarn build & yarn build:css
+# 2. Run the setup script
+bin/setup
 ```
 
+`bin/setup` is idempotent, so you can also run it whenever you pull new changes.
+
 #### Add Notify API Keys (Optional)
+
 If you want to test the notify function, you will need to get a test API key
 from the [notify service](https://www.notifications.service.gov.uk/) Add it as
 an environment vairable under `NOTIFY_API_KEY=` in `.env.development.local` and

--- a/bin/setup
+++ b/bin/setup
@@ -28,6 +28,12 @@ FileUtils.chdir APP_ROOT do
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 
+  puts "\n== Installing frontend dependencies =="
+  system! "yarn"
+
+  puts "\n== Building frontend assets =="
+  system! "yarn build & yarn build:css"
+
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
By default Rails provides a setup file which can be used for initial setup and update tasks. Previouslty we weren't really using this, so this PR moves some of our setup tasks into this file. 
Tem members and contributors can now run `bin/setup` when first cloning the repo or when pulling changes to make sure that their dependencies, FE assets and database are up to date.

#### Checklist

- [x] I've used the pull request template
- [x] I've updated the documentation in (If any documentation requires updating)
    - [x] README.md

