### PR TITLE
WIP: Add hosting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,8 +56,11 @@ gem "bootsnap", require: false
 # For forms-api
 gem "activeresource"
 
-gem "govuk-components", "~> 3.0.3"
-gem "govuk_design_system_formbuilder", "~> 3.0.2"
+# For local descriptions of forms
+gem 'active_hash'
+
+gem 'govuk-components', '~> 3.0.3'
+gem 'govuk_design_system_formbuilder', '~> 3.0.2'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "webdrivers"
+  gem "climate_control"
 end
 
 gem "bundler-audit", "~> 0.9.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.1.0)
+      activesupport (>= 5.0.0)
     activejob (7.0.2.4)
       activesupport (= 7.0.2.4)
       globalid (>= 0.3.6)
@@ -300,6 +302,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_hash
   activeresource
   bootsnap
   brakeman (~> 5.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    climate_control (1.0.1)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     cssbundling-rails (1.1.0)
@@ -308,6 +309,7 @@ DEPENDENCIES
   brakeman (~> 5.2)
   bundler-audit (~> 0.9.0)
   capybara
+  climate_control
   cssbundling-rails
   debug
   dotenv-rails

--- a/app/controllers/forms/pages_controller.rb
+++ b/app/controllers/forms/pages_controller.rb
@@ -27,7 +27,15 @@ module Forms
     end
 
     def prepare_form
-      @form = Form.find(params.require(:form_id))
+      @form = form_repository.find(params.require(:form_id))
+    end
+
+    def form_repository
+      if HostingEnvironment.sandbox_mode?
+        FormRepository.new(resource: FormLocalResource)
+      else
+        FormRepository.new
+      end
     end
 
     def submit

--- a/app/lib/form_api_resource.rb
+++ b/app/lib/form_api_resource.rb
@@ -1,0 +1,5 @@
+class FormApiResource < ActiveResource::Base
+  self.site = "#{ENV.fetch('API_BASE')}/v1"
+  self.include_format_in_path = false
+  self.element_name = "form"
+end

--- a/app/lib/form_local_resource.rb
+++ b/app/lib/form_local_resource.rb
@@ -1,0 +1,9 @@
+class FormLocalResource < ActiveYaml::Base
+  set_root_path Rails.root.join("data")
+  set_filename "forms"
+
+  def self.find(*args, &block)
+    reload(true)
+    super(*args, &block)
+  end
+end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,0 +1,35 @@
+module HostingEnvironment
+  TEST_ENVIRONMENTS = %w[development test].freeze
+
+  def self.application_url
+    if Rails.env.production?
+      "https://#{hostname}"
+    else
+      "http://localhost:#{ENV.fetch('PORT', 3000)}"
+    end
+  end
+
+  def self.environment_name
+    ENV.fetch("HOSTING_ENVIRONMENT_NAME", "unknown-environment")
+  end
+
+  def self.development?
+    environment_name == "development"
+  end
+
+  def self.staging?
+    environment_name == "staging"
+  end
+
+  def self.production?
+    environment_name == "production"
+  end
+
+  def self.sandbox_mode?
+    ENV.fetch("SANDBOX", "false") == "true"
+  end
+
+  def self.test_environment?
+    TEST_ENVIRONMENTS.include?(HostingEnvironment.environment_name)
+  end
+end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,14 +1,6 @@
 module HostingEnvironment
   TEST_ENVIRONMENTS = %w[development test].freeze
 
-  def self.application_url
-    if Rails.env.production?
-      "https://#{hostname}"
-    else
-      "http://localhost:#{ENV.fetch('PORT', 3000)}"
-    end
-  end
-
   def self.environment_name
     ENV.fetch("HOSTING_ENVIRONMENT_NAME", "unknown-environment")
   end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,4 +1,5 @@
-class Form < ActiveResource::Base
-  self.site = "#{ENV.fetch('API_BASE')}/v1"
-  self.include_format_in_path = false
+class Form
+  include ActiveModel::Model
+
+  attr_accessor :id, :name, :submission_email
 end

--- a/app/repositories/form_repository.rb
+++ b/app/repositories/form_repository.rb
@@ -1,0 +1,10 @@
+class FormRepository
+  def initialize(resource: FormApiResource)
+    @resource = resource
+  end
+
+  def find(id)
+    form_data = @resource.find(id).attributes
+    Form.new(**form_data)
+  end
+end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -2,10 +2,12 @@ require "notifications/client"
 
 class NotifyService
   def initialize
-    @notify_api_key = ENV["NOTIFY_API_KEY"]
+    @notify_api_key = ENV.fetch("NOTIFY_API_KEY")
   end
 
   def send_email(email_address, title, text_input, submission_time)
+    return if HostingEnvironment.sandbox_mode?
+
     unless @notify_api_key
       Rails.logger.warn "Warning: no NOTIFY_API_KEY set."
       return nil

--- a/app/views/forms/pages/new.erb
+++ b/app/views/forms/pages/new.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l"><%= @form.name %></h1>
-<%= form_with(model: @page, url: form_page_path(@form, @page)) do |form| %>
+<%= form_with(model: @page, url: form_page_path(@form.id, @page)) do |form| %>
   <% if @page&.errors.any? %>
     <%= form.govuk_error_summary %>
   <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,9 @@ require_relative "boot"
 
 require "rails/all"
 
+# Add here so we don't need to require it in initializers
+require './app/lib/hosting_environment'
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -21,5 +24,12 @@ module FormsRunner
     config.generators do |g|
       g.test_framework :rspec
     end
+
+    # when generating components, add preview too
+    # config.view_component.generate.preview = true
+
+    # when generating components, a locale file for each supported language
+    # config.view_component.generate.locale = true
+    # config.view_component.generate_distinct_locale_files = true
   end
 end

--- a/data/forms.yml
+++ b/data/forms.yml
@@ -1,0 +1,6 @@
+- id: 1
+  name: The Test form
+  submission_email: test@exmple.org
+- id: 2
+  name: The Second Test form
+  submission_email: test@exmple.org

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe HostingEnvironment do
+  it "sandbox mode returns true" do
+    ClimateControl.modify SANDBOX: "true" do
+      expect(described_class.sandbox_mode?).to be(true)
+    end
+  end
+end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,15 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Form, type: :model do
-  let(:response_data) { { person: { "id" => 1, "name" => "form name", "submission_email" => "user@example.com" } }.to_json }
-
-  before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1", {}, response_data, 200
-    end
+  it "initializes correctly" do
+    expect(Form.new({id: 1, name: "form name", submission_email: "user@example.com"})).to have_attributes({id: 1, name: "form name", submission_email: "user@example.com"})
   end
 
-  it "returns a simple form" do
-    expect(described_class.find(1)).to have_attributes(id: 1, name: "form name", submission_email: "user@example.com")
+  it "initializes correctly" do
+    expect{Form.new({id: 1, name: "form name", submission_email: "user@example.com", extra_field: 'hetsh'})}.to raise_error
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)

Add Form repositories

Currently the project needs to have the Form API project running to work.

This is OK but coupling the two in development slows work down.

There are a few ways round this:
 - Run the API alongside the runner in development (maybe both in a
   docker compose environment)
 - Run an API stub alongside the runner
 - Use something like web-mock to mock responses
 - Make changes in the code to allow the project to run without the API

They all have advantages and disadvantages. This commit implements the
last option, adding a repository for Form which can read them locally
from a yaml file in /data when the project is run in SANDBOX. `/data` might not be the best place - these files are almost like test data so they could go in `spec/` they aren't test data though so I've kept them there.

This should make development more independent from the API project and allow testing forms faster.

Add HostingEnivronment

We need to be able to configure the application in different
environments - mainly dev and 'production' ATM.

Environments are modelled in their own class - HostingEnivronment. This
stops config spreading across the app and gives us a simple way to set
policies about what happens in dev/staging and production.

The main draw is to add a sandbox mode to allow running the project
without external dependencies - Notify and the form API.

This commit stops notify being run if SANDBOX=true env var is set before
running the project.

Inspired by
https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/lib/hosting_environment.rb



