### PR TITLE
Load the start page for a form when accessing it

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 DATABASE_USERNAME=forms_runner_development
 DATABASE_PASSWORD=forms_runner_development
 DATABASE_HOST=localhost
-API_BASE=http://localhost:9292/api
 NOTIFY_API_KEY=
+API_BASE=http://localhost:9292

--- a/.env.test
+++ b/.env.test
@@ -2,4 +2,4 @@ DATABASE_USERNAME=forms_runner_development
 DATABASE_PASSWORD=forms_runner_development
 DATABASE_HOST=localhost
 FORMS_API_ENDPOINT=https://forms-api
-API_BASE=http://localhost:9292/api
+API_BASE=http://localhost:9292

--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  gem "pry"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     cssbundling-rails (1.1.0)
@@ -168,6 +169,9 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pg (1.3.4)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.6)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -319,6 +323,7 @@ DEPENDENCIES
   nokogiri (~> 1.13.6)
   notifications-ruby-client
   pg (~> 1.1)
+  pry
   puma (~> 5.6.4)
   rails (~> 7.0.2, >= 7.0.2.3)
   redis

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ from the [notify service](https://www.notifications.service.gov.uk/) Add it as
 an environment vairable under `NOTIFY_API_KEY=` in `.env.development.local` and
 use the 'api intergration' tab on notify dashboard to check emails sent.
 
+### Environment variables
+
+| Name           | Purpose                                                            |
+| -------------- | ------------------------------------------------------------------ |
+| `DATABASE_URL` | The URL to the postgres instance (without the database at the end) |
+| `REDIS_URL`    | The URL for Redis (optional)                                       |
+| `SENTRY_DSN`   | The DSN provided by Sentry                                         |
+| `API_BASE`     | The base url for the API - E.g. `http://localhost:9090`            |
+
 ### Running the app
 
 You can either run the development task:

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -1,0 +1,6 @@
+class FormController < ApplicationController
+  def show
+    form = Form.find(params.require(:id))
+    redirect_to form_page_path(form_id: params.require(:id), id: form.start_page)
+  end
+end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -1,6 +1,8 @@
 class FormController < ApplicationController
   def show
-    form = Form.find(params.require(:id))
-    redirect_to form_page_path(form_id: params.require(:id), id: form.start_page)
+    @form = Form.find(params.require(:id))
+    if @form.start_page
+      redirect_to form_page_path(form_id: params.require(:id), id: @form.start_page)
+    end
   end
 end

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -1,0 +1,7 @@
+class PageController < ApplicationController
+  def show
+    form_id = params.require(:form_id)
+    page_id = params.require(:id)
+    @page = Page.find(page_id, params: {form_id: form_id})
+  end
+end

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -2,6 +2,6 @@ class PageController < ApplicationController
   def show
     form_id = params.require(:form_id)
     page_id = params.require(:id)
-    @page = Page.find(page_id, params: {form_id: form_id})
+    @page = Page.find(page_id, params: { form_id: form_id })
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,4 +1,7 @@
 class Form < ActiveResource::Base
-  self.site = "#{ENV.fetch('API_BASE')}/v1"
+  self.site = "#{ENV.fetch('API_BASE')}"
+  self.prefix = "/api/v1/"
   self.include_format_in_path = false
+
+  has_many :pages
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,5 +1,5 @@
 class Form < ActiveResource::Base
-  self.site = "#{ENV.fetch('API_BASE')}"
+  self.site = ENV.fetch("API_BASE").to_s
   self.prefix = "/api/v1/"
   self.include_format_in_path = false
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,13 +1,7 @@
-class Page
-  include ActiveModel::Model
-  include ActiveModel::Validations
-  include ActiveModel::Serialization
+class Page < ActiveResource::Base
+  self.site = "#{ENV.fetch('API_BASE')}"
+  self.prefix = "/api/v1/forms/:form_id/"
+  self.include_format_in_path = false
 
-  attr_accessor :text
-
-  validates :text, presence: true
-
-  def attributes
-    { "text" => nil }
-  end
+  belongs_to :form
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,5 +1,5 @@
 class Page < ActiveResource::Base
-  self.site = "#{ENV.fetch('API_BASE')}"
+  self.site = ENV.fetch("API_BASE").to_s
   self.prefix = "/api/v1/forms/:form_id/"
   self.include_format_in_path = false
 

--- a/app/models/page_old.rb
+++ b/app/models/page_old.rb
@@ -1,0 +1,13 @@
+class PageOld
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  include ActiveModel::Serialization
+
+  attr_accessor :text
+
+  validates :text, presence: true
+
+  def attributes
+    { "text" => nil }
+  end
+end

--- a/app/views/form/show.html.erb
+++ b/app/views/form/show.html.erb
@@ -1,0 +1,6 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l"><%= @form.name %></h1>
+    <p class="govuk-body"><%= t('form.no_pages') %>
+  </div>
+</div>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -1,0 +1,1 @@
+<h1 class="govuk-heading-l"><%= @page.question_text %></h1>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -1,1 +1,5 @@
-<h1 class="govuk-heading-l"><%= @page.question_text %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l"><%= @page.question_text %></h1>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,30 +25,30 @@ module FormsRunner
     # Get redis url based on VCAP_SERVICES or REDIS_URL depending on environment
     # GovPaaS provides the URI in VCAP_SERVICES
 
-    if ENV['VCAP_SERVICES']
-      vcap_services = JSON.parse(ENV['VCAP_SERVICES'])
-      if(vcap_services["redis"])
+    if ENV["VCAP_SERVICES"]
+      vcap_services = JSON.parse(ENV["VCAP_SERVICES"])
+      if vcap_services["redis"]
         host = vcap_services["redis"][0]["credentials"]["host"]
         password = vcap_services["redis"][0]["credentials"]["password"]
         port = vcap_services["redis"][0]["credentials"]["port"]
 
         config.session_store :redis_session_store,
-          key: '_app_session_key',
-          redis: {
-            host: host,
-            password: password,
-            port: port,
-            ssl: true
-          },
-          on_redis_down: ->(e, env, sid) { puts "Redis down" }
+                             key: "_app_session_key",
+                             redis: {
+                               host: host,
+                               password: password,
+                               port: port,
+                               ssl: true,
+                             },
+                             on_redis_down: ->(_e, _env, _sid) { Rails.logger.debug "Redis down" }
       end
-    elsif ENV['REDIS_URL']
+    elsif ENV["REDIS_URL"]
       config.session_store :redis_session_store,
-        key: '_app_session_key',
-        redis: {
-          url: ENV['REDIS_URL']
-        },
-        on_redis_down: ->(e, env, sid) { puts "Redis down" }
+                           key: "_app_session_key",
+                           redis: {
+                             url: ENV["REDIS_URL"],
+                           },
+                           on_redis_down: ->(_e, _env, _sid) { Rails.logger.debug "Redis down" }
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  form:
+    no_pages: "This form has no pages"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,8 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "home#index"
 
-  resources :form, only: [], path: "/" do
-    resource :page, only: %i[new create], module: "forms", path_names: { new: "/" }, path: "/" do
+  resources :form, only: %i[show], path: "/" do
+    resources :page, only: %i[show], path: "/" do
       get :submitted
     end
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,15 +1,32 @@
 require "rails_helper"
 
 RSpec.describe Form, type: :model do
-  let(:response_data) { { person: { "id" => 1, "name" => "form name", "submission_email" => "user@example.com" } }.to_json }
+  let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", start_page: 1 }.to_json }
+
+  let(:pages_data) do
+    [
+      {id: 9, next: 10, answer_type: "date", question_text: "Question one"},
+      {id: 10, answer_type: "address", question_text: "Question two"}
+    ].to_json
+  end
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms/1", {}, response_data, 200
+      mock.get "/api/v1/forms/1/pages", {}, pages_data, 200
     end
   end
 
   it "returns a simple form" do
     expect(described_class.find(1)).to have_attributes(id: 1, name: "form name", submission_email: "user@example.com")
+  end
+
+  describe "Getting the pages for a form" do
+    it "returns the pages for a form" do
+      pages = described_class.find(1).pages
+      expect(pages.length).to eq(2)
+      expect(pages[0]).to have_attributes(id: 9, next: 10, answer_type: "date", question_text: "Question one")
+      expect(pages[1]).to have_attributes(id: 10, answer_type: "address", question_text: "Question two")
+    end
   end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Form, type: :model do
 
   let(:pages_data) do
     [
-      {id: 9, next: 10, answer_type: "date", question_text: "Question one"},
-      {id: 10, answer_type: "address", question_text: "Question two"}
+      { id: 9, next: 10, answer_type: "date", question_text: "Question one" },
+      { id: 10, answer_type: "address", question_text: "Question two" },
     ].to_json
   end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,5 +1,21 @@
 require "rails_helper"
 
 RSpec.describe Page, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:response_data) do
+    {
+      id: 1,
+      question_text: "Question text",
+      answer_type: "date"
+    }.to_json
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms/2/pages/1", {}, response_data, 200
+    end
+  end
+
+  it "returns the page for a form" do
+    expect(described_class.find(1, params: {form_id: 2})).to have_attributes(id: 1, question_text: "Question text", answer_type: "date")
+  end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Page, type: :model do
     {
       id: 1,
       question_text: "Question text",
-      answer_type: "date"
+      answer_type: "date",
     }.to_json
   end
 
@@ -16,6 +16,6 @@ RSpec.describe Page, type: :model do
   end
 
   it "returns the page for a form" do
-    expect(described_class.find(1, params: {form_id: 2})).to have_attributes(id: 1, question_text: "Question text", answer_type: "date")
+    expect(described_class.find(1, params: { form_id: 2 })).to have_attributes(id: 1, question_text: "Question text", answer_type: "date")
   end
 end

--- a/spec/requests/forms/pages_spec.rb
+++ b/spec/requests/forms/pages_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe "Forms::Pages", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1,7 +1,28 @@
 require "rails_helper"
 
-RSpec.describe "Forms", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+RSpec.describe "Form controller", type: :request do
+  let(:form_response_data) do
+    {
+      id: 2,
+      name: "Form name",
+      submission_email: "submission@email.com",
+      start_page: 1
+    }.to_json
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms/2", {}, form_response_data, 200
+    end
+  end
+
+  describe "#show" do
+    before do
+      get form_path(id: 2)
+    end
+
+    it "Redirects to the first page" do
+      expect(response).to redirect_to(form_page_path(form_id: 2, id: 1))
+    end
   end
 end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -21,8 +21,26 @@ RSpec.describe "Form controller", type: :request do
       get form_path(id: 2)
     end
 
-    it "Redirects to the first page" do
-      expect(response).to redirect_to(form_page_path(form_id: 2, id: 1))
+    context "When the form has a start page" do
+      it "Redirects to the first page" do
+        expect(response).to redirect_to(form_page_path(form_id: 2, id: 1))
+      end
+    end
+
+    context "When the form has no start page" do
+      let(:form_response_data) do
+        {
+          id: 2,
+          name: "Form name",
+          submission_email: "submission@email.com",
+          start_page: nil,
+        }.to_json
+      end
+
+      it "Displays the form show page" do
+        expect(response.status).to eq(200)
+        expect(response.body).to include("Form name")
+      end
     end
   end
 end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Form controller", type: :request do
       id: 2,
       name: "Form name",
       submission_email: "submission@email.com",
-      start_page: 1
+      start_page: 1,
     }.to_json
   end
 

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Page Controller", type: :request do
+  let(:response_data) do
+    {
+      question_text: "Question text"
+    }.to_json
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms/2/pages/1", {}, response_data, 200
+    end
+  end
+
+  describe "#show" do
+    before do
+      get form_page_path(form_id: 2, id: 1)
+    end
+
+    it "Returns a 200" do
+      expect(response.status).to eq(200)
+    end
+
+    it "Displays the question text on the page" do
+      expect(response.body).to include("Question text")
+    end
+  end
+end

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Page Controller", type: :request do
   let(:response_data) do
     {
-      question_text: "Question text"
+      question_text: "Question text",
     }.to_json
   end
 


### PR DESCRIPTION
#### What problem does the pull request solve?

We want to be able to access a form (e.g. `/2` for a form with an ID of 2) which then redirects you to the first page. This involves:
- Setting up the routing to more accurately map the end result
- Setting up the form/page models with relationships
- Creating the route on the form controller to map to the first page
- Creating the page controller to display the question text for the first page

This requires a [corresponding set of changes required in the forms API](https://github.com/alphagov/forms-api/pull/29).

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [x] I've updated the documentation in (If any documentation requires updating)
    - [x] README.md
    - [x] Elsewhere (please link)


