### PR TITLE
41 allow form completers to submit their answers

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,4 @@
 DATABASE_USERNAME=forms_runner_development
 DATABASE_PASSWORD=forms_runner_development
 DATABASE_HOST=localhost
-NOTIFY_API_KEY=
 API_BASE=http://localhost:9292

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,9 @@ gem "activeresource"
 gem "govuk-components", "~> 3.0.3"
 gem "govuk_design_system_formbuilder", "~> 3.0.2"
 
+# Very simple date validation
+gem "date_validator"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,9 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.1.0)
       railties (>= 6.0.0)
+    date_validator (0.12.0)
+      activemodel (>= 3)
+      activesupport (>= 3)
     debug (1.4.0)
       irb (>= 1.3.6)
       reline (>= 0.2.7)
@@ -314,6 +317,7 @@ DEPENDENCIES
   bundler-audit (~> 0.9.0)
   capybara
   cssbundling-rails
+  date_validator
   debug
   dotenv-rails
   govuk-components (~> 3.0.3)

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -8,6 +8,7 @@ class FormController < ApplicationController
 
   def check_your_answers
     @form = Form.find(params.require(:form_id))
+    @answers = session[:answers]
     last_page = @form.pages.find { |p| !p.has_next? }
     @back_link = form_page_path(@form.id, last_page.id)
   end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -43,7 +43,7 @@ private
   def check_your_answers_rows(form, answers = {})
     form.pages.map do |page|
       answer = answers[page.id.to_s]
-      question = page.question.new(answer)
+      question = QuestionRegister.from_page(page).new(answer)
       {
         key: { text: page.question_text },
         value: { text: question.show_answer },

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -8,8 +8,48 @@ class FormController < ApplicationController
 
   def check_your_answers
     @form = Form.find(params.require(:form_id))
-    @answers = session[:answers]
+    @answers = session[:answers][@form.id.to_s]
     last_page = @form.pages.find { |p| !p.has_next? }
     @back_link = form_page_path(@form.id, last_page.id)
+    @rows = check_your_answers_rows(@form, @answers)
+  end
+
+  def submit_answers
+    @form = Form.find(params.require(:form_id))
+    # Comment out submission until we are ready to use notify to send answers
+    # answers = session[:answers]
+    # submit(answers)
+    clear_answers(:form_id)
+    redirect_to :form_submitted
+  end
+
+  def submitted
+    @form = Form.find(params.require(:form_id))
+  end
+
+private
+
+  def submit(answers)
+    # in the controller for now but can be moved to service object, maybe use actionmailer fo easier testing?
+    NotifyService.new.send_email(@form.submission_email, @form.name, answers, Time.zone.now)
+    # forms always submit corectly, to add error handling
+    true
+  end
+
+  def clear_answers(form_id)
+    session[:answers][form_id] = nil
+  end
+
+  def check_your_answers_rows(form, answers = {})
+    logger.info "answers: #{answers}"
+    answers&.to_a&.sort_by(&:first)&.map do |page_id, answer|
+      page = form.pages.find { |p| p.id == page_id.to_i }
+      logger.info "p = #{page_id}"
+      {
+        key: { text: page.question_text },
+        value: { text: page.question.new(answer).value },
+        actions: [{ href: form_page_url(form, page), visually_hidden_text: "" }],
+      }
+    end
   end
 end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -41,14 +41,13 @@ private
   end
 
   def check_your_answers_rows(form, answers = {})
-    logger.info "answers: #{answers}"
-    answers&.to_a&.sort_by(&:first)&.map do |page_id, answer|
-      page = form.pages.find { |p| p.id == page_id.to_i }
-      logger.info "p = #{page_id}"
+    form.pages.map do |page|
+      answer = answers[page.id.to_s]
+      question = page.question.new(answer)
       {
         key: { text: page.question_text },
-        value: { text: page.question.new(answer).value },
-        actions: [{ href: form_page_url(form, page), visually_hidden_text: "" }],
+        value: { text: question.show_answer },
+        actions: [{ href: form_page_url(form, page) }],
       }
     end
   end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -8,7 +8,7 @@ class FormController < ApplicationController
 
   def check_your_answers
     @form = Form.find(params.require(:form_id))
-    @answers = session[:answers][@form.id.to_s] || {}
+    @answers = session.fetch(:answers, {}).fetch(@form.id.to_s, {})
     last_page = @form.pages.find { |p| !p.has_next? }
     @back_link = form_page_path(@form.id, last_page.id)
     @rows = check_your_answers_rows(@form, @answers)
@@ -16,7 +16,7 @@ class FormController < ApplicationController
 
   def submit_answers
     @form = Form.find(params.require(:form_id))
-    answers = session[:answers][@form.id.to_s]
+    answers = session.fetch(:answers, {}).fetch(@form.id.to_s, {})
     submit_form(formatted_answers(@form, answers))
     logger.info session[:answers]
     clear_answers(@form)
@@ -38,7 +38,7 @@ private
   end
 
   def clear_answers(form)
-    session[:answers][form.id.to_s] = nil
+    session[:answers][form.id.to_s] = nil if session[:answers]
   end
 
   def check_your_answers_rows(form, answers = {})

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -8,7 +8,7 @@ class FormController < ApplicationController
 
   def check_your_answers
     @form = Form.find(params.require(:form_id))
-    @answers = session[:answers][@form.id.to_s]
+    @answers = session[:answers][@form.id.to_s] || {}
     last_page = @form.pages.find { |p| !p.has_next? }
     @back_link = form_page_path(@form.id, last_page.id)
     @rows = check_your_answers_rows(@form, @answers)
@@ -16,10 +16,11 @@ class FormController < ApplicationController
 
   def submit_answers
     @form = Form.find(params.require(:form_id))
-    # Comment out submission until we are ready to use notify to send answers
-    # answers = session[:answers]
-    # submit(answers)
-    clear_answers(:form_id)
+    answers = session[:answers][@form.id.to_s]
+    submit_form(formatted_answers(@form, answers))
+    logger.info session[:answers]
+    clear_answers(@form)
+    logger.info session[:answers]
     redirect_to :form_submitted
   end
 
@@ -29,15 +30,15 @@ class FormController < ApplicationController
 
 private
 
-  def submit(answers)
+  def submit_form(text)
     # in the controller for now but can be moved to service object, maybe use actionmailer fo easier testing?
-    NotifyService.new.send_email(@form.submission_email, @form.name, answers, Time.zone.now)
+    NotifyService.new.send_email(@form.submission_email, @form.name, text, Time.zone.now)
     # forms always submit corectly, to add error handling
     true
   end
 
-  def clear_answers(form_id)
-    session[:answers][form_id] = nil
+  def clear_answers(form)
+    session[:answers][form.id.to_s] = nil
   end
 
   def check_your_answers_rows(form, answers = {})
@@ -50,5 +51,13 @@ private
         actions: [{ href: form_page_url(form, page) }],
       }
     end
+  end
+
+  def formatted_answers(form, answers = {})
+    form.pages.map { |page|
+      answer = answers[page.id.to_s]
+      question = QuestionRegister.from_page(page).new(answer)
+      "#{page.question_text}: #{question.show_answer}"
+    }.join("\n")
   end
 end

--- a/app/lib/question_register.rb
+++ b/app/lib/question_register.rb
@@ -1,0 +1,20 @@
+class QuestionRegister
+  def self.from_page(page)
+    case page.answer_type.to_sym
+    when :single_line
+      Question::SingleLine
+    when :date
+      Question::Date
+    when :address
+      Question::Address
+    when :email
+      Question::Email
+    when :national_insurance_number
+      Question::NationalInsuranceNumber
+    when :phone_number
+      Question::PhoneNumber
+    else
+      raise ArgumentError, "Unexpected answer_type for page #{page.id}: #{page.answer_type}"
+    end
+  end
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -12,4 +12,23 @@ class Page < ActiveResource::Base
   def has_next?
     @attributes.include?("next") && !@attributes["next"].nil?
   end
+
+  def question
+    case answer_type.to_sym
+    when :single_line
+      Question::SingleLine
+    when :date
+      Question::Date
+    when :address
+      Question::Address
+    when :email
+      Question::Email
+    when :national_insurance_number
+      Question::NationalInsuranceNumber
+    when :phone_number
+      Question::PhoneNumber
+    else
+      raise ArgumentError, "Unexpected answer_type: #{answer_type}"
+    end
+  end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -12,23 +12,4 @@ class Page < ActiveResource::Base
   def has_next?
     @attributes.include?("next") && !@attributes["next"].nil?
   end
-
-  def question
-    case answer_type.to_sym
-    when :single_line
-      Question::SingleLine
-    when :date
-      Question::Date
-    when :address
-      Question::Address
-    when :email
-      Question::Email
-    when :national_insurance_number
-      Question::NationalInsuranceNumber
-    when :phone_number
-      Question::PhoneNumber
-    else
-      raise ArgumentError, "Unexpected answer_type: #{answer_type}"
-    end
-  end
 end

--- a/app/models/question/address.rb
+++ b/app/models/question/address.rb
@@ -1,4 +1,4 @@
-class Question::Address < Question::ApplicationQuestion
+class Question::Address < Question::QuestionBase
   attribute :address1
   attribute :address2
   attribute :city

--- a/app/models/question/address.rb
+++ b/app/models/question/address.rb
@@ -12,4 +12,8 @@ class Question::Address
   def attributes
     { "address1" => nil, "address2" => nil, "city" => nil, "postcode" => nil }
   end
+
+  def value
+    [address1, address2, city, postcode].join(",")
+  end
 end

--- a/app/models/question/address.rb
+++ b/app/models/question/address.rb
@@ -1,19 +1,10 @@
-class Question::Address
-  include ActiveModel::Model
-  include ActiveModel::Validations
-  include ActiveModel::Serialization
-
-  attr_accessor :address1, :address2, :city, :postcode
+class Question::Address < Question::ApplicationQuestion
+  attribute :address1
+  attribute :address2
+  attribute :city
+  attribute :postcode
 
   validates :address1, presence: true
   validates :city, presence: true
   validates :postcode, presence: true
-
-  def attributes
-    { "address1" => nil, "address2" => nil, "city" => nil, "postcode" => nil }
-  end
-
-  def value
-    [address1, address2, city, postcode].join(",")
-  end
 end

--- a/app/models/question/address.rb
+++ b/app/models/question/address.rb
@@ -1,0 +1,15 @@
+class Question::Address
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  include ActiveModel::Serialization
+
+  attr_accessor :address1, :address2, :city, :postcode
+
+  validates :address1, presence: true
+  validates :city, presence: true
+  validates :postcode, presence: true
+
+  def attributes
+    { "address1" => nil, "address2" => nil, "city" => nil, "postcode" => nil }
+  end
+end

--- a/app/models/question/application_question.rb
+++ b/app/models/question/application_question.rb
@@ -1,0 +1,14 @@
+class Question::ApplicationQuestion
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  include ActiveModel::Serialization
+  include ActiveModel::Attributes
+
+  def attributes
+    attribute_names.index_with { |_k| nil }
+  end
+
+  def show_answer
+    attribute_names.map { |attribute| send(attribute) }.reject(&:blank?)&.join(",")
+  end
+end

--- a/app/models/question/date.rb
+++ b/app/models/question/date.rb
@@ -1,0 +1,15 @@
+class Question::Date
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  include ActiveModel::Serialization
+  include ActiveRecord::AttributeAssignment
+  include ActiveModel::Attributes
+
+  attribute :date, :date
+
+  validates :date, date: true
+
+  def attributes
+    { "date" => nil }
+  end
+end

--- a/app/models/question/date.rb
+++ b/app/models/question/date.rb
@@ -1,19 +1,10 @@
-class Question::Date
-  include ActiveModel::Model
-  include ActiveModel::Validations
-  include ActiveModel::Serialization
+class Question::Date < Question::ApplicationQuestion
   include ActiveRecord::AttributeAssignment
-  include ActiveModel::Attributes
 
   attribute :date, :date
-
   validates :date, date: true
 
-  def attributes
-    { "date" => nil }
-  end
-
-  def value
-    date.strftime("%m/%d/%Y")
+  def show_answer
+    date&.strftime("%m/%d/%Y")
   end
 end

--- a/app/models/question/date.rb
+++ b/app/models/question/date.rb
@@ -1,4 +1,4 @@
-class Question::Date < Question::ApplicationQuestion
+class Question::Date < Question::QuestionBase
   include ActiveRecord::AttributeAssignment
 
   attribute :date, :date

--- a/app/models/question/date.rb
+++ b/app/models/question/date.rb
@@ -12,4 +12,8 @@ class Question::Date
   def attributes
     { "date" => nil }
   end
+
+  def value
+    date.strftime("%m/%d/%Y")
+  end
 end

--- a/app/models/question/email.rb
+++ b/app/models/question/email.rb
@@ -1,17 +1,4 @@
-class Question::Email
-  include ActiveModel::Model
-  include ActiveModel::Validations
-  include ActiveModel::Serialization
-
-  attr_accessor :email
-
+class Question::Email < Question::ApplicationQuestion
+  attribute :email
   validates :email, presence: true
-
-  def attributes
-    { "email" => nil }
-  end
-
-  def value
-    email
-  end
 end

--- a/app/models/question/email.rb
+++ b/app/models/question/email.rb
@@ -1,0 +1,13 @@
+class Question::Email
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  include ActiveModel::Serialization
+
+  attr_accessor :email
+
+  validates :email, presence: true
+
+  def attributes
+    { "email" => nil }
+  end
+end

--- a/app/models/question/email.rb
+++ b/app/models/question/email.rb
@@ -10,4 +10,8 @@ class Question::Email
   def attributes
     { "email" => nil }
   end
+
+  def value
+    email
+  end
 end

--- a/app/models/question/email.rb
+++ b/app/models/question/email.rb
@@ -1,4 +1,4 @@
-class Question::Email < Question::ApplicationQuestion
+class Question::Email < Question::QuestionBase
   attribute :email
   validates :email, presence: true
 end

--- a/app/models/question/national_insurance_number.rb
+++ b/app/models/question/national_insurance_number.rb
@@ -10,4 +10,8 @@ class Question::NationalInsuranceNumber
   def attributes
     { "national_insurance_number" => nil }
   end
+
+  def value
+    national_insurance_number
+  end
 end

--- a/app/models/question/national_insurance_number.rb
+++ b/app/models/question/national_insurance_number.rb
@@ -1,0 +1,13 @@
+class Question::NationalInsuranceNumber
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  include ActiveModel::Serialization
+
+  attr_accessor :national_insurance_number
+
+  validates :national_insurance_number, presence: true
+
+  def attributes
+    { "national_insurance_number" => nil }
+  end
+end

--- a/app/models/question/national_insurance_number.rb
+++ b/app/models/question/national_insurance_number.rb
@@ -1,4 +1,4 @@
-class Question::NationalInsuranceNumber < Question::ApplicationQuestion
+class Question::NationalInsuranceNumber < Question::QuestionBase
   attribute :national_insurance_number
   validates :national_insurance_number, presence: true
 end

--- a/app/models/question/national_insurance_number.rb
+++ b/app/models/question/national_insurance_number.rb
@@ -1,17 +1,4 @@
-class Question::NationalInsuranceNumber
-  include ActiveModel::Model
-  include ActiveModel::Validations
-  include ActiveModel::Serialization
-
-  attr_accessor :national_insurance_number
-
+class Question::NationalInsuranceNumber < Question::ApplicationQuestion
+  attribute :national_insurance_number
   validates :national_insurance_number, presence: true
-
-  def attributes
-    { "national_insurance_number" => nil }
-  end
-
-  def value
-    national_insurance_number
-  end
 end

--- a/app/models/question/phone_number.rb
+++ b/app/models/question/phone_number.rb
@@ -10,4 +10,8 @@ class Question::PhoneNumber
   def attributes
     { "phone_number" => nil }
   end
+
+  def value
+    phone_number
+  end
 end

--- a/app/models/question/phone_number.rb
+++ b/app/models/question/phone_number.rb
@@ -1,0 +1,13 @@
+class Question::PhoneNumber
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  include ActiveModel::Serialization
+
+  attr_accessor :phone_number
+
+  validates :phone_number, presence: true
+
+  def attributes
+    { "phone_number" => nil }
+  end
+end

--- a/app/models/question/phone_number.rb
+++ b/app/models/question/phone_number.rb
@@ -1,4 +1,4 @@
-class Question::PhoneNumber < Question::ApplicationQuestion
+class Question::PhoneNumber < Question::QuestionBase
   attribute :phone_number
   validates :phone_number, presence: true
 end

--- a/app/models/question/phone_number.rb
+++ b/app/models/question/phone_number.rb
@@ -1,17 +1,4 @@
-class Question::PhoneNumber
-  include ActiveModel::Model
-  include ActiveModel::Validations
-  include ActiveModel::Serialization
-
-  attr_accessor :phone_number
-
+class Question::PhoneNumber < Question::ApplicationQuestion
+  attribute :phone_number
   validates :phone_number, presence: true
-
-  def attributes
-    { "phone_number" => nil }
-  end
-
-  def value
-    phone_number
-  end
 end

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -1,4 +1,4 @@
-class Question::ApplicationQuestion
+class Question::QuestionBase
   include ActiveModel::Model
   include ActiveModel::Validations
   include ActiveModel::Serialization

--- a/app/models/question/single_line.rb
+++ b/app/models/question/single_line.rb
@@ -1,4 +1,4 @@
-class Question::SingleLine < Question::ApplicationQuestion
+class Question::SingleLine < Question::QuestionBase
   attribute :text
   validates :text, presence: true
 end

--- a/app/models/question/single_line.rb
+++ b/app/models/question/single_line.rb
@@ -10,4 +10,8 @@ class Question::SingleLine
   def attributes
     { "text" => nil }
   end
+
+  def value
+    text
+  end
 end

--- a/app/models/question/single_line.rb
+++ b/app/models/question/single_line.rb
@@ -1,17 +1,4 @@
-class Question::SingleLine
-  include ActiveModel::Model
-  include ActiveModel::Validations
-  include ActiveModel::Serialization
-
-  attr_accessor :text
-
+class Question::SingleLine < Question::ApplicationQuestion
+  attribute :text
   validates :text, presence: true
-
-  def attributes
-    { "text" => nil }
-  end
-
-  def value
-    text
-  end
 end

--- a/app/models/question/single_line.rb
+++ b/app/models/question/single_line.rb
@@ -1,0 +1,13 @@
+class Question::SingleLine
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  include ActiveModel::Serialization
+
+  attr_accessor :text
+
+  validates :text, presence: true
+
+  def attributes
+    { "text" => nil }
+  end
+end

--- a/app/views/form/check_your_answers.html.erb
+++ b/app/views/form/check_your_answers.html.erb
@@ -4,5 +4,14 @@
   <% end %>
 <% end %>
 
-Checky check check
-<%= @answers %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">Check your answers</h1>
+  <%= govuk_summary_list(rows: @rows) %>
+
+  <%= form_with url: form_submit_answers_path do |form| %>
+    <%= form.govuk_submit 'Accept and send' %>
+  <% end %>
+  </div>
+</div>

--- a/app/views/form/check_your_answers.html.erb
+++ b/app/views/form/check_your_answers.html.erb
@@ -5,3 +5,4 @@
 <% end %>
 
 Checky check check
+<%= @answers %>

--- a/app/views/form/submitted.html.erb
+++ b/app/views/form/submitted.html.erb
@@ -1,0 +1,1 @@
+<p class="govuk-body">Thanks for submitting the form.</p>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -6,8 +6,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l"><%= @page.question_text %></h1>
-    <%= form_with model: @page, url: submit_form_page_path(@page.form_id, @page.id), method: :post do |form| %>
+    <%= form_with model: @question, url: submit_form_page_path(@page.form_id, @page.id), scope: :question, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: :post do |form| %>
+      <% if @question&.errors&.any? %>
+        <%= form.govuk_error_summary %>
+      <% end %>
+        <%= render :partial => ActiveSupport::Inflector.underscore(@question.model_name.name), :locals => { :page => @page, :form => form } %>
       <%= form.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/question/_address.html.erb
+++ b/app/views/question/_address.html.erb
@@ -1,5 +1,7 @@
 <h1 class="govuk-heading-l"><%=  page.question_text %></h1>
-<%= form.govuk_text_field :address1, label: { tag: 'h2', size: 'm', text: "Address line 1" } %>
-<%= form.govuk_text_field :address2, label: { tag: 'h2', size: 'm', text: "Address line 2"  } %>
-<%= form.govuk_text_field :city, label: { tag: 'h2', size: 'm', text: "Town or City"  } %>
-<%= form.govuk_text_field :postcode, label: { tag: 'h2', size: 'm', text: "Postcode" } %>
+<%= form.govuk_fieldset hint: { text: page.hint_text } do %>
+  <%= form.govuk_text_field :address1, label: { tag: 'h2', size: 'm', text: "Address line 1" }, width: 'one-half' %>
+  <%= form.govuk_text_field :address2, label: { tag: 'h2', size: 'm', text: "Address line 2"  }, width: 'one-half' %>
+  <%= form.govuk_text_field :city, label: { tag: 'h2', size: 'm', text: "Town or City"  }, width: 'one-third' %>
+  <%= form.govuk_text_field :postcode, label: { tag: 'h2', size: 'm', text: "Postcode" }, width: 'one-quarter' %>
+<% end %>

--- a/app/views/question/_address.html.erb
+++ b/app/views/question/_address.html.erb
@@ -1,0 +1,5 @@
+<h1 class="govuk-heading-l"><%=  page.question_text %></h1>
+<%= form.govuk_text_field :address1, label: { tag: 'h2', size: 'm', text: "Address line 1" } %>
+<%= form.govuk_text_field :address2, label: { tag: 'h2', size: 'm', text: "Address line 2"  } %>
+<%= form.govuk_text_field :city, label: { tag: 'h2', size: 'm', text: "Town or City"  } %>
+<%= form.govuk_text_field :postcode, label: { tag: 'h2', size: 'm', text: "Postcode" } %>

--- a/app/views/question/_address.html.erb
+++ b/app/views/question/_address.html.erb
@@ -1,5 +1,4 @@
-<h1 class="govuk-heading-l"><%=  page.question_text %></h1>
-<%= form.govuk_fieldset hint: { text: page.hint_text } do %>
+<%= form.govuk_fieldset legend: { text: page.question_text, tag: 'h1', size: 'l' }, hint: { text: page.hint_text } do %>
   <%= form.govuk_text_field :address1, label: { tag: 'h2', size: 'm', text: "Address line 1" }, width: 'one-half' %>
   <%= form.govuk_text_field :address2, label: { tag: 'h2', size: 'm', text: "Address line 2"  }, width: 'one-half' %>
   <%= form.govuk_text_field :city, label: { tag: 'h2', size: 'm', text: "Town or City"  }, width: 'one-third' %>

--- a/app/views/question/_date.html.erb
+++ b/app/views/question/_date.html.erb
@@ -1,0 +1,1 @@
+<%= form.govuk_date_field :date, legend: { tag: 'h1', size: 'l', text: page.question_text } %>

--- a/app/views/question/_date.html.erb
+++ b/app/views/question/_date.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_date_field :date, legend: { tag: 'h1', size: 'l', text: page.question_text } %>
+<%= form.govuk_date_field :date, legend: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text } %>

--- a/app/views/question/_email.html.erb
+++ b/app/views/question/_email.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :email, label: { tag: 'h1', size: 'l', text: page.question_text } %>
+<%= form.govuk_text_field :email, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, width: 'one-half' %>

--- a/app/views/question/_email.html.erb
+++ b/app/views/question/_email.html.erb
@@ -1,0 +1,1 @@
+<%= form.govuk_text_field :email, label: { tag: 'h1', size: 'l', text: page.question_text } %>

--- a/app/views/question/_national_insurance_number.html.erb
+++ b/app/views/question/_national_insurance_number.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, %>
+<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, width: 'one-half' %>

--- a/app/views/question/_national_insurance_number.html.erb
+++ b/app/views/question/_national_insurance_number.html.erb
@@ -1,0 +1,1 @@
+<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: page.question_text } %>

--- a/app/views/question/_national_insurance_number.html.erb
+++ b/app/views/question/_national_insurance_number.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: page.question_text } %>
+<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, %>

--- a/app/views/question/_phone_number.html.erb
+++ b/app/views/question/_phone_number.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :phone_number, label: { tag: 'h1', size: 'l', text: page.question_text } %>
+<%= form.govuk_text_field :phone_number, label: { tag: 'h1', size: 'l', text: page.question_text }, width: 'one-half' %>

--- a/app/views/question/_phone_number.html.erb
+++ b/app/views/question/_phone_number.html.erb
@@ -1,0 +1,1 @@
+<%= form.govuk_text_field :phone_number, label: { tag: 'h1', size: 'l', text: page.question_text } %>

--- a/app/views/question/_single_line.html.erb
+++ b/app/views/question/_single_line.html.erb
@@ -1,0 +1,1 @@
+<%= form.govuk_text_field :text, label: { tag: 'h1', size: 'l', text: page.question_text } %>

--- a/app/views/question/_single_line.html.erb
+++ b/app/views/question/_single_line.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :text, label: { tag: 'h1', size: 'l', text: page.question_text } %>
+<%= form.govuk_text_field :text, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, width: 'one-half' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources :form, only: %i[show], path: "/" do
     get :check_your_answers
 
-    resources :page, only: %i[show], path: "/", param: :page_id do
+    resources :page, only: %i[show create], path: "/", param: :page_id do
       post :submit, on: :member
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
 
   resources :form, only: %i[show], path: "/" do
     get :check_your_answers
+    get :submitted
+    post :submit_answers
 
     resources :page, only: %i[show create], path: "/", param: :page_id do
       post :submit, on: :member

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -14,13 +14,15 @@ RSpec.describe "Page Controller", type: :request do
       {
         id: 1,
         question_text: "Question one",
-        answer_type: "date",
+        answer_type: "single_line",
+        hint_text: "",
         next: 2,
       },
       {
         id: 2,
         question_text: "Question two",
-        answer_type: "date",
+        hint_text: "Q2 hint text",
+        answer_type: "single_line",
       },
     ].to_json
   end
@@ -58,13 +60,13 @@ RSpec.describe "Page Controller", type: :request do
 
   describe "#submit" do
     it "Redirects to the next page" do
-      post submit_form_page_path(2, 1)
+      post submit_form_page_path(2, 1), :params => { :question => {:text => "answer text"} }
       expect(response).to redirect_to(form_page_path(2, 2))
     end
 
     context "with the final page" do
       it "Redirects to the check your answers page" do
-        post submit_form_page_path(2, 2)
+        post submit_form_page_path(2, 2), :params => { :question => {:text => "answer text"} }
         expect(response).to redirect_to(form_check_your_answers_path(2))
       end
     end


### PR DESCRIPTION
Add forms to runner

This pull request adds forms to the pages in the runner.

It allows users to enter information so that it can be submitted by notify at the end of the jounrey.

Because it was hard to add forms without considering how validation, saving data in the session and CYA would work. The basics of these features have also been added.

The general approach is to create a question model and a partial to represent it in the form. This gives good control and flexibility over creating new question types and validating them. Partials might not be the best way to handle views - it might be interesting to invert things and give questions full control over the form they are presented in.

All current page types have been added, but the validation for email address, postcode and NINO hasn't been completed as we have another ticket in for those. The CYA screen is also only for demonstration purposes and doesn't implement all the functionality needed as there's a ticket for that too. Submission etc could also be tidied up and fleshed out in the future.

There currently aren't any tests, I'll add those in Friday.
#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [x] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


