### PR TITLE
Improve the validation of question pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,9 +61,6 @@ gem "activeresource"
 gem "govuk-components", "~> 3.0.3"
 gem "govuk_design_system_formbuilder", "~> 3.0.2"
 
-# Very simple date validation
-gem "date_validator"
-
 # validate postcodes
 gem "uk_postcode"
 

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,8 @@ gem "govuk_design_system_formbuilder", "~> 3.0.2"
 
 # Very simple date validation
 gem "date_validator"
+# Support for locale tasks
+gem "i18n-tasks", "~> 1.0.11"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,10 @@ gem "govuk_design_system_formbuilder", "~> 3.0.2"
 
 # Very simple date validation
 gem "date_validator"
+
+# validate postcodes
+gem "uk_postcode"
+
 # Support for locale tasks
 gem "i18n-tasks", "~> 1.0.11"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,14 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    better_html (1.0.16)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
@@ -126,8 +134,21 @@ GEM
       activemodel (>= 6.1)
       activesupport (>= 6.1)
       deep_merge (~> 1.2.1)
+    highline (2.0.3)
+    html_tokenizer (0.0.7)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.11)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      better_html (~> 1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     io-console (0.5.11)
     irb (1.4.1)
       reline (>= 0.3.0)
@@ -202,6 +223,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.3)
       actionpack (= 7.0.3)
       activesupport (= 7.0.3)
@@ -281,6 +305,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    smart_properties (1.17.0)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -289,10 +314,13 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     strscan (3.0.3)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
     timeout (0.3.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    uk_postcode (2.1.8)
     unicode-display_width (2.1.0)
     view_component (2.49.1)
       activesupport (>= 5.0.0, < 8.0)
@@ -329,6 +357,7 @@ DEPENDENCIES
   dotenv-rails
   govuk-components (~> 3.0.3)
   govuk_design_system_formbuilder (~> 3.0.2)
+  i18n-tasks (~> 1.0.11)
   jbuilder
   jsbundling-rails
   nokogiri (~> 1.13.6)
@@ -347,6 +376,7 @@ DEPENDENCIES
   simplecov
   sprockets-rails
   tzinfo-data
+  uk_postcode
   web-console
   webdrivers
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,9 +108,6 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.1.0)
       railties (>= 6.0.0)
-    date_validator (0.12.0)
-      activemodel (>= 3)
-      activesupport (>= 3)
     debug (1.4.0)
       irb (>= 1.3.6)
       reline (>= 0.2.7)
@@ -352,7 +349,6 @@ DEPENDENCIES
   bundler-audit (~> 0.9.0)
   capybara
   cssbundling-rails
-  date_validator
   debug
   dotenv-rails
   govuk-components (~> 3.0.3)

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -5,10 +5,18 @@ class PageController < ApplicationController
     changing_existing_answer
     back_link
 
+    # extract an answer from the sesssion, test it to make sure it's still
+    # valid
     form_context = FormContext.new(session, @form)
     answer = form_context.get_stored_answer(@page)
     question_klass = QuestionRegister.from_page(@page)
-    @question = question_klass.new(answer)
+    begin
+      @question = question_klass.new(answer)
+    rescue ActiveModel::UnknownAttributeError
+      @question = question_klass.new
+    end
+
+    @question = question_klass.new unless @question&.valid?
   end
 
   def submit

--- a/app/models/question/address.rb
+++ b/app/models/question/address.rb
@@ -1,10 +1,28 @@
 class Question::Address < Question::QuestionBase
+  # https://design-system.service.gov.uk/patterns/addresses/
   attribute :address1
   attribute :address2
-  attribute :city
+  attribute :town_or_city
+  attribute :county
   attribute :postcode
 
   validates :address1, presence: true
-  validates :city, presence: true
+  validates :town_or_city, presence: true
   validates :postcode, presence: true
+  validate :postcode, :invalid_postcode?
+
+  def postcode=(str)
+    super UKPostcode.parse(str).to_s
+  end
+
+private
+
+  def invalid_postcode?
+    if postcode.present?
+      ukpc = UKPostcode.parse(postcode)
+      unless ukpc.full_valid?
+        errors.add(:postcode, :invalid_postcode)
+      end
+    end
+  end
 end

--- a/app/models/question/date.rb
+++ b/app/models/question/date.rb
@@ -1,10 +1,84 @@
 class Question::Date < Question::QuestionBase
-  include ActiveRecord::AttributeAssignment
+  attribute :date_day
+  attribute :date_month
+  attribute :date_year
+  attribute :date
 
-  attribute :date, :date
-  validates :date, date: true
+  validate :date_valid
+
+  def assign_attributes(new_attributes)
+    translated_attrs = new_attributes.transform_keys { |key| date_field_to_attribute(key) }
+    super(translated_attrs)
+  end
+
+  def date
+    valid_or_invalid_date(date_year, date_month, date_day)
+  end
 
   def show_answer
-    date&.strftime("%d/%m/%Y") || ""
+    if date.is_a?(Date)
+      date.strftime("%d/%m/%Y")
+    else
+      ""
+    end
+  end
+
+private
+
+  def date_valid
+    return errors.add(:date, :blank) if blank?
+    return errors.add(:date, :blank_date_fields, fields: blank_fields.to_sentence) if present? && blank_fields.any?
+    return errors.add(:date, :invalid_date) if invalid?
+  end
+
+  def date_field_to_attribute(key)
+    case key
+    when "date(3i)" then "date_day"
+    when "date(2i)" then "date_month"
+    when "date(1i)" then "date_year"
+    else key
+    end
+  end
+
+  def invalid?
+    !date.is_a?(Date) || outside_acceptable_date_range
+  end
+
+  def blank?
+    return false if date.is_a?(Date)
+
+    date_fields = %i[day month year]
+    date.to_h.slice(*date_fields).all? { |_, v| v.blank? }
+  end
+
+  def blank_fields
+    return [] if date.is_a?(Date)
+
+    date.to_h.select { |_, v| v.blank? }.keys
+  end
+
+  def outside_acceptable_date_range
+    !(150.years.ago.year..2999).cover?(date.year)
+  end
+
+  def valid_or_invalid_date(year, month, day)
+    raise ArgumentError if year.blank?
+
+    # Use Integer here rather than to_i otherwise an string in year can be
+    # transformed to zero, which is a valid year for Date
+    date_args = [year, month, day].map do |i|
+      integer = Integer(i, 10)
+      raise RangeError unless integer.positive?
+
+      integer
+    end
+
+    if date_args[1].zero?
+      date_args[1] = Date.parse(month).month
+    end
+
+    Date.new(*date_args)
+  rescue ArgumentError, RangeError
+    Struct.new(:day, :month, :year).new(day, month, year)
   end
 end

--- a/app/models/question/email.rb
+++ b/app/models/question/email.rb
@@ -1,4 +1,11 @@
 class Question::Email < Question::QuestionBase
+  # see https://design-system.service.gov.uk/patterns/email-addresses/
+  # This model contains very lite checking - only that an @ exists. Pay and
+  # notify both have good examples of better email validation checks and ways
+  # to help users enter the right value
+
+  EMAIL_REGEX = /.*@.*/
   attribute :email
   validates :email, presence: true
+  validates :email, format: { with: EMAIL_REGEX, message: :invalid_email }, allow_blank: true
 end

--- a/app/models/question/national_insurance_number.rb
+++ b/app/models/question/national_insurance_number.rb
@@ -1,4 +1,34 @@
 class Question::NationalInsuranceNumber < Question::QuestionBase
+  # see https://design-system.service.gov.uk/patterns/national-insurance-numbers/
+  NINO_REGEX = /\A(?!BG|GB|NK|KN|TN|NT|ZZ)[ABCEGHJ-PRSTW-Z][ABCEGHJ-NPRSTW-Z]\d{6}[A-D]\z/i
+
+  include ActiveModel::Validations::Callbacks
+
   attribute :national_insurance_number
   validates :national_insurance_number, presence: true
+  # validates :national_insurance_number, format: { with: NINO_REGEX, message: :invalid_national_insurance_number }, allow_blank: true
+  validate :valid_format
+
+  def show_answer
+    # format the NINO in the correct govuk format
+    # show NINOs in the form of "QQ 12 34 56 C"
+    return "" if national_insurance_number.blank?
+
+    nino = normalize_nino(national_insurance_number)
+    nino.blank? ? "" : "#{nino[0..1]} #{nino[2..3]} #{nino[4..5]} #{nino[6..7]} #{nino[8]}"
+  end
+
+private
+
+  def valid_format
+    return if national_insurance_number.blank?
+
+    unless NINO_REGEX.match(normalize_nino(national_insurance_number))
+      errors.add(:national_insurance_number, :invalid_national_insurance_number)
+    end
+  end
+
+  def normalize_nino(nino)
+    nino.gsub(/\s/, "").upcase
+  end
 end

--- a/app/models/question/phone_number.rb
+++ b/app/models/question/phone_number.rb
@@ -1,4 +1,28 @@
 class Question::PhoneNumber < Question::QuestionBase
+  # https://design-system.service.gov.uk/patterns/telephone-numbers/
+  # Allow a large range of values - we would probably need more information to
+  # provide better validation - e.g. UK or international number
+  # We check the characters and that the number is in a reasonable range
+  # some code and tests inspired by git@github.com:DFE-Digital/apply-for-teacher-training.git
+
+  PHONE_REGEX = /\A[ext\-()+.\s 0-9]+\z/
   attribute :phone_number
   validates :phone_number, presence: true
+  validates :phone_number, format: { with: PHONE_REGEX, message: "Enter a telephone number" }, allow_blank: true
+  validate :phone_number, :not_enough_digits?
+  validate :phone_number, :too_many_digits?
+
+private
+
+  def not_enough_digits?
+    if phone_number.present? && phone_number.gsub(/[^0-9]/, "").length < 8
+      errors.add(:phone_number, :phone_too_short)
+    end
+  end
+
+  def too_many_digits?
+    if phone_number.present? && phone_number.gsub(/[^0-9]/, "").length > 15
+      errors.add(:phone_number, :phone_too_long)
+    end
+  end
 end

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -9,6 +9,6 @@ class Question::QuestionBase
   end
 
   def show_answer
-    attribute_names.map { |attribute| send(attribute) }.reject(&:blank?)&.join(",")
+    attribute_names.map { |attribute| send(attribute) }.reject(&:blank?)&.join(", ")
   end
 end

--- a/app/views/question/_address.html.erb
+++ b/app/views/question/_address.html.erb
@@ -1,6 +1,7 @@
 <%= form.govuk_fieldset legend: { text: page.question_text, tag: 'h1', size: 'l' }, hint: { text: page.hint_text } do %>
-  <%= form.govuk_text_field :address1, label: { tag: 'h2', size: 'm', text: "Address line 1" }, width: 'one-half' %>
-  <%= form.govuk_text_field :address2, label: { tag: 'h2', size: 'm', text: "Address line 2"  }, width: 'one-half' %>
-  <%= form.govuk_text_field :city, label: { tag: 'h2', size: 'm', text: "Town or City"  }, width: 'one-third' %>
-  <%= form.govuk_text_field :postcode, label: { tag: 'h2', size: 'm', text: "Postcode" }, width: 'one-quarter' %>
+  <%= form.govuk_text_field :address1, label: { text: "Address line 1" }, autocomplete: "address-line1" %>
+  <%= form.govuk_text_field :address2, label: {  text: "Address line 2"  }, autocomplete: "address-line2" %>
+  <%= form.govuk_text_field :town_or_city, label: {  text: "Town or City" }, width: 'two-thirds', autocomplete: "address-level2" %>
+  <%= form.govuk_text_field :county, label: {  text: "County (optional)" }, width: 'two-thirds' %>
+  <%= form.govuk_text_field :postcode, label: {  text: "Postcode" }, width: 10, autocomplete: "postal-code" %>
 <% end %>

--- a/app/views/question/_email.html.erb
+++ b/app/views/question/_email.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :email, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, width: 'one-half' %>
+<%= form.govuk_text_field :email, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, autocomplete: 'email', type: 'email', spellcheck: false   %>

--- a/app/views/question/_national_insurance_number.html.erb
+++ b/app/views/question/_national_insurance_number.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, width: 'one-half' %>
+<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, width: 10, spellcheck: false %>

--- a/app/views/question/_phone_number.html.erb
+++ b/app/views/question/_phone_number.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :phone_number, label: { tag: 'h1', size: 'l', text: page.question_text }, width: 'one-half' %>
+<%= form.govuk_text_field :phone_number, label: { tag: 'h1', size: 'l', text: page.question_text }, width: 'one-half', autocomplete: 'tel' %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,149 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+base_locale: en
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+# locales: [es, fr]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `File.find` patterns where translations are read from:
+  read:
+    ## Default:
+    # - config/locales/%{locale}.yml
+    ## More files:
+    # - config/locales/**/*.%{locale}.yml
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    ## For example, write devise and simple form keys to their respective files:
+    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  # External locale data (e.g. gems).
+  # This data is not considered unused and is never written to.
+  external:
+    ## Example (replace %#= with %=):
+    # - "<%#= %x[bundle info vagrant --path].chomp %>/templates/locales/%{locale}.yml"
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  # router: conservative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `File.find` patterns to search in:
+  # paths:
+  #  - app/
+
+  ## Root directories for relative keys resolution.
+  # relative_roots:
+  #   - app/controllers
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Directories where method names which should not be part of a relative key resolution.
+  # By default, if a relative translation is used inside a method, the name of the method will be considered part of the resolved key.
+  # Directories listed here will not consider the name of the method part of the resolved key
+  #
+  # relative_exclude_method_name_paths:
+  #  -
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   *.jpg *.jpeg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
+  ##   *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus *.webp *.map *.xlsx
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos
+    - app/assets/builds
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  # strict: true
+
+  ## Allows adding ast_matchers for finding translations using the AST-scanners
+  ## The available matchers are:
+  ## - RailsModelMatcher
+  ##     Matches ActiveRecord translations like
+  ##     User.human_attribute_name(:email) and User.model_name.human
+  ##
+  ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
+  <%# I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher') %>
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+
+## Translation Services
+# translation:
+#   # Google Translate
+#   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
+#   google_translate_api_key: "AbC-dEf5"
+#   # DeepL Pro Translate
+#   # Get an API key and subscription at https://www.deepl.com/pro to use DeepL Pro
+#   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"
+#   # deepl_host: "https://api.deepl.com"
+#   # deepl_version: "v2"
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+## Consider these keys used:
+ignore_unused:
+- 'activemodel.errors.*'
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Exclude these keys from the `i18n-tasks check-consistent-interpolations` report:
+# ignore_inconsistent_interpolations:
+# - 'activerecord.attributes.*'
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       only: %w(*.html.haml *.html.slim),
+#       patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,11 +23,20 @@ en:
             email:
               blank: Enter an email address
               invalid_email: Enter a valid email address
+        question/national_insurance_number:
+          attributes:
+            national_insurance_number:
+              blank: Enter a national insrance number
+              invalid_national_insurance_number: Enter a national insurance number
         question/phone_number:
           attributes:
             phone_number:
               blank: Enter a phone number
               phone_too_long: The phone number is too long, it should have 15 digits or less
               phone_too_short: The phone number is too short, it should have 8 digits or more
+        question/single_line:
+          attributes:
+            text:
+              blank: Enter a value
   form:
     no_pages: This form has no pages

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,16 @@
+---
 en:
+  activemodel:
+    errors:
+      models:
+        question/address:
+          attributes:
+            address1:
+              blank: Enter the first line of your address.
+            postcode:
+              blank: Enter the postcode.
+              invalid_postcode: Enter a valid postcode.
+            town_or_city:
+              blank: Enter the town or city of your address.
   form:
-    no_pages: "This form has no pages"
+    no_pages: This form has no pages

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,5 +23,11 @@ en:
             email:
               blank: Enter an email address
               invalid_email: Enter a valid email address
+        question/phone_number:
+          attributes:
+            phone_number:
+              blank: Enter a phone number
+              phone_too_long: The phone number is too long, it should have 15 digits or less
+              phone_too_short: The phone number is too short, it should have 8 digits or more
   form:
     no_pages: This form has no pages

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,5 +18,10 @@ en:
               blank: Enter a date
               blank_date_fields: Enter a day, month and year
               invalid_date: Enter a date
+        question/email:
+          attributes:
+            email:
+              blank: Enter an email address
+              invalid_email: Enter a valid email address
   form:
     no_pages: This form has no pages

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,5 +12,11 @@ en:
               invalid_postcode: Enter a valid postcode.
             town_or_city:
               blank: Enter the town or city of your address.
+        question/date:
+          attributes:
+            date:
+              blank: Enter a date
+              blank_date_fields: Enter a day, month and year
+              invalid_date: Enter a date
   form:
     no_pages: This form has no pages

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "i18n/tasks"
+
+RSpec.describe I18n do
+  let(:i18n) { I18n::Tasks::BaseTask.new }
+  let(:missing_keys) { i18n.missing_keys }
+  let(:unused_keys) { i18n.unused_keys }
+  let(:inconsistent_interpolations) { i18n.inconsistent_interpolations }
+
+  it "does not have missing keys" do
+    expect(missing_keys).to be_empty,
+                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+  end
+
+  it "does not have unused keys" do
+    expect(unused_keys).to be_empty,
+                           "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+  end
+
+  it "files are normalized" do
+    non_normalized = i18n.non_normalized_paths
+    error_message = "The following files need to be normalized:\n" \
+                    "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
+                    "Please run `i18n-tasks normalize' to fix"
+    expect(non_normalized).to be_empty, error_message
+  end
+
+  it "does not have inconsistent interpolations" do
+    error_message = "#{inconsistent_interpolations.leaves.count} i18n keys have inconsistent interpolations.\n" \
+                    "Run `i18n-tasks check-consistent-interpolations' to show them"
+    expect(inconsistent_interpolations).to be_empty, error_message
+  end
+end

--- a/spec/models/question/address_spec.rb
+++ b/spec/models/question/address_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+require "shared_examples_for_question_models"
+
+RSpec.describe Question::Address, type: :model do
+  let(:question) { described_class.new }
+
+  it_behaves_like "a question model"
+
+  context "when an address is empty" do
+    it "returns invalid" do
+      question.address1 = ""
+      question.address2 = ""
+      question.town_or_city = ""
+      question.county = ""
+      question.postcode = ""
+      question.validate
+      expect(question.errors[:address1]).to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.blank"))
+    end
+
+    it "returns \"\" for show_answer" do
+      question.address1 = ""
+      question.address2 = ""
+      question.town_or_city = ""
+      question.county = ""
+      question.postcode = ""
+      expect(question.show_answer).to eq ""
+    end
+  end
+
+  context "when an address has all mandatory fields filled" do
+    it "is valid" do
+      question.address1 = "The mews"
+      question.address2 = nil
+      question.town_or_city = "Leeds"
+      question.county = nil
+      question.postcode = "LS11AF"
+      question.validate
+      expect(question).to be_valid
+    end
+
+    it "prints correct details" do
+      question.address1 = "The mews"
+      question.address2 = nil
+      question.town_or_city = "Leeds"
+      question.county = nil
+      question.postcode = "LS11AF"
+      expect(question.show_answer).to eq "The mews, Leeds, LS1 1AF"
+    end
+  end
+
+  context "when given an invalid postcode" do
+    it "returns invalid" do
+      question.postcode = "jskladjaksd"
+      question.validate
+      expect(question.errors[:postcode]).to include(I18n.t("activemodel.errors.models.question/address.attributes.postcode.invalid_postcode"))
+    end
+  end
+end

--- a/spec/models/question/date_spec.rb
+++ b/spec/models/question/date_spec.rb
@@ -4,25 +4,86 @@ require "shared_examples_for_question_models"
 RSpec.describe Question::Date, type: :model do
   it_behaves_like "a question model"
 
-  it "validates date" do
-    question = described_class.new
-    question.date = nil
-    question.validate
-    expect(question.errors[:date]).to include("is not a date")
+  context "when a date has an empty day, month and year" do
+    it "returns invalid with blank message" do
+      question = described_class.new
+      question.validate
+      expect(question.errors[:date]).to include(I18n.t("activemodel.errors.models.question/date.attributes.date.blank"))
+    end
 
-    question.date = Date.new
-    question.validate
-    expect(question.errors[:date]).not_to include("is not a date")
-    expect(question).to be_valid
+    it "shows as a blank string" do
+      question = described_class.new
+      expect(question.show_answer).to eq ""
+    end
   end
 
-  it "displays date in the correct format" do
-    question = described_class.new({ date: Date.parse("2021-12-31") })
-    expect(question.show_answer).to eq "31/12/2021"
+  context "when a date has empty day, month or year" do
+    it "returns invalid with a message" do
+      question = described_class.new
+      day_month_years = [
+        [1, nil, 2022],
+        [nil, 1, 2022],
+        [1, 1, nil],
+      ]
+
+      day_month_years.each do |v|
+        question.date_day = v[0]
+        question.date_month = v[1]
+        question.date_year = v[2]
+        question.validate
+        expect(question.errors[:date]).to include(I18n.t("activemodel.errors.models.question/date.attributes.date.blank_date_fields"))
+      end
+    end
   end
 
-  it "returns blank string with empty date" do
-    question = described_class.new
-    expect(question.show_answer).to eq ""
+  context "when a date has a valid day, month or year" do
+    it "displays date in the correct format" do
+      question = described_class.new({ date_day: "31", date_month: "12", date_year: "2021" })
+      expect(question.show_answer).to eq "31/12/2021"
+    end
+
+    it "is valid" do
+      question = described_class.new({ date_day: "31", date_month: "12", date_year: "2021" })
+      expect(question).to be_valid
+    end
+  end
+
+  context "when a date has a valid day, month or year but it's not a real date" do
+    it "isn't valid" do
+      question = described_class.new({ date_day: "31", date_month: "02", date_year: "2021" })
+      question.validate
+      expect(question.errors[:date]).to include(I18n.t("activemodel.errors.models.question/date.attributes.date.invalid_date"))
+    end
+  end
+
+  context "when given non-integers as values for day, month or year" do
+    it "isn't valid" do
+      question = described_class.new
+      day_month_years = [
+        [1, "e", 2022],
+        ["pi", 1, 2022],
+        [1, 1, "zero"],
+      ]
+
+      day_month_years.each do |v|
+        question.date_day = v[0]
+        question.date_month = v[1]
+        question.date_year = v[2]
+        question.validate
+        expect(question.errors[:date]).to include(I18n.t("activemodel.errors.models.question/date.attributes.date.invalid_date"))
+      end
+    end
+  end
+
+  context "when given a date outside a reasonable range" do
+    it "isn't valid" do
+      # !(150.years.ago.year..2999).cover?(date.year)
+      invalid_years = [1871, 0, 3000, 1542]
+      invalid_years.each do |year|
+        question = described_class.new({ date_day: "31", date_month: "02", date_year: year })
+        question.validate
+        expect(question.errors[:date]).to include(I18n.t("activemodel.errors.models.question/date.attributes.date.invalid_date"))
+      end
+    end
   end
 end

--- a/spec/models/question/email_spec.rb
+++ b/spec/models/question/email_spec.rb
@@ -4,15 +4,38 @@ require "shared_examples_for_question_models"
 RSpec.describe Question::Email, type: :model do
   it_behaves_like "a question model"
 
-  it "validates presence" do
-    question = described_class.new
-    question.email = ""
-    question.validate
-    expect(question.errors[:email]).to include("can't be blank")
+  context "when given an empty string or nil" do
+    it "returns invalid with blank message" do
+      question = described_class.new
+      question.validate
+      expect(question.errors[:email]).to include(I18n.t("activemodel.errors.models.question/email.attributes.email.blank"))
+      question.email = ""
+      question.validate
+      expect(question.errors[:email]).to include(I18n.t("activemodel.errors.models.question/email.attributes.email.blank"))
+      expect(question.errors[:email]).not_to include(I18n.t("activemodel.errors.models.question/email.attributes.email.invalid_email"))
+    end
 
-    question.email = "email address"
-    question.validate
-    expect(question.errors[:email]).not_to include("can't be blank")
-    expect(question).to be_valid
+    it "shows as a blank string" do
+      question = described_class.new
+      expect(question.show_answer).to eq ""
+    end
+  end
+
+  context "when given a string with an @ symbol in" do
+    it "validates" do
+      question = described_class.new
+      question.email = " @ "
+      question.validate
+      expect(question).to be_valid
+    end
+  end
+
+  context "when given a string without an @ symbol in" do
+    it "does not validate an address without an @" do
+      question = described_class.new
+      question.email = "not an email address"
+      question.validate
+      expect(question.errors[:email]).to include(I18n.t("activemodel.errors.models.question/email.attributes.email.invalid_email"))
+    end
   end
 end

--- a/spec/models/question/national_insurance_number_spec.rb
+++ b/spec/models/question/national_insurance_number_spec.rb
@@ -4,15 +4,58 @@ require "shared_examples_for_question_models"
 RSpec.describe Question::NationalInsuranceNumber, type: :model do
   it_behaves_like "a question model"
 
-  it "validates presence" do
-    question = described_class.new
-    question.national_insurance_number = ""
-    question.validate
-    expect(question.errors[:national_insurance_number]).to include("can't be blank")
+  context "when empty" do
+    it "returns invalid" do
+      question = described_class.new
+      question.national_insurance_number = ""
+      question.validate
+      expect(question.errors[:national_insurance_number]).to include(I18n.t("activemodel.errors.models.question/national_insurance_number.attributes.national_insurance_number.blank"))
+    end
 
-    question.national_insurance_number = "nino"
-    question.validate
-    expect(question.errors[:national_insurance_number]).not_to include("can't be blank")
-    expect(question).to be_valid
+    it "shows an answer if blank" do
+      question = described_class.new
+      question.national_insurance_number = ""
+      question.validate
+      expect(question.show_answer).to eq ""
+    end
+  end
+
+  context "when given a correct number" do
+    it "removes whitespace before valition presence" do
+      question = described_class.new
+      question.national_insurance_number = " J G 1 2 3 4 5 6 C "
+      question.validate
+      expect(question).to be_valid
+    end
+
+    it "shows answer in correct format" do
+      question = described_class.new
+      question.national_insurance_number = " J G 1 2 3 4 5 6 C "
+      question.validate
+      expect(question.show_answer).to eq "JG 12 34 56 C"
+    end
+
+    it "ignores case" do
+      question = described_class.new
+      question.national_insurance_number = " j g 1 2 3 4 5 6 C "
+      question.validate
+      expect(question).to be_valid
+    end
+
+    it "normlizes to uppercase" do
+      question = described_class.new
+      question.national_insurance_number = " j g 1 2 3 4 5 6 C "
+      question.validate
+      expect(question.show_answer).to eq "JG 12 34 56 C"
+    end
+  end
+
+  context "when given an incorrect number" do
+    it "doesn't validate incorrect NINOs" do
+      question = described_class.new
+      question.national_insurance_number = " Q Q 1 2 3 4 5 6 C "
+      question.validate
+      expect(question).not_to be_valid
+    end
   end
 end

--- a/spec/models/question/phone_number_spec.rb
+++ b/spec/models/question/phone_number_spec.rb
@@ -2,17 +2,74 @@ require "rails_helper"
 require "shared_examples_for_question_models"
 
 RSpec.describe Question::PhoneNumber, type: :model do
+  let(:question) { described_class.new }
+
   it_behaves_like "a question model"
 
-  it "validates presence" do
-    question = described_class.new
-    question.phone_number = ""
-    question.validate
-    expect(question.errors[:phone_number]).to include("can't be blank")
+  context "when a phone number is empty or blank" do
+    it "returns invalid" do
+      question.phone_number = ""
+      question.validate
+      expect(question.errors[:phone_number]).to include(I18n.t("activemodel.errors.models.question/phone_number.attributes.phone_number.blank"))
+      question.phone_number = nil
+      question.validate
+      expect(question.errors[:phone_number]).to include(I18n.t("activemodel.errors.models.question/phone_number.attributes.phone_number.blank"))
+    end
+  end
 
-    question.phone_number = "111"
-    question.validate
-    expect(question.errors[:phone_number]).not_to include("can't be blank")
-    expect(question).to be_valid
+  context "when a phone number is valid" do
+    it "validates correctly" do
+      valid_phone_numbers = [
+        "+447123 123 123",
+        "+407123 123 123",
+        "+1 7123 123 123",
+        "+447123123123",
+        "07123123123",
+        "01234 123 123 --()+ ",
+        "01234 123 123 ext 123",
+        "01234 123 123 x123",
+        "(01234) 123123",
+        "(12345) 123123",
+        "(+44) (0)1234 123456",
+        "+44 (0) 123 4567 123",
+        "123 1234 1234 ext 123",
+        "12345 123456 ext 123",
+        "12345 123456 ext. 123",
+        "12345 123456 ext123",
+        "01234123456 ext 123",
+        "123 1234 1234 x123",
+        "12345 123456 x123",
+        "12345123456 x123",
+        "(1234) 123 1234",
+        "1234 123 1234 x123",
+        "1234 123 1234 ext 1234",
+        "1234 123 1234  ext 123",
+        "+44(0)123 12 12345",
+      ]
+
+      valid_phone_numbers.each do |number|
+        question.phone_number = number
+        question.validate
+        expect(question).to be_valid
+      end
+    end
+  end
+
+  context "when phone number is over 15 numbers" do
+    it "returns an error" do
+      question.phone_number = "123456791123456789"
+      question.validate
+
+      expect(question.errors[:phone_number]).to include(I18n.t("activemodel.errors.models.question/phone_number.attributes.phone_number.phone_too_long"))
+    end
+  end
+
+  context "when phone number is 7 numbers or less" do
+    it "returns an error" do
+      question.phone_number = "1234567"
+      question.validate
+
+      expect(question.errors[:phone_number]).to include(I18n.t("activemodel.errors.models.question/phone_number.attributes.phone_number.phone_too_short"))
+    end
   end
 end

--- a/spec/models/question/single_line_spec.rb
+++ b/spec/models/question/single_line_spec.rb
@@ -4,15 +4,19 @@ require "shared_examples_for_question_models"
 RSpec.describe Question::SingleLine, type: :model do
   it_behaves_like "a question model"
 
-  it "validates presence" do
-    question = described_class.new
-    question.text = ""
-    question.validate
-    expect(question.errors[:text]).to include("can't be blank")
+  context "when given an empty string or nil" do
+    it "returns invalid with blank message" do
+      question = described_class.new
+      question.validate
+      expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/single_line.attributes.text.blank"))
+      question.text = ""
+      question.validate
+      expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/single_line.attributes.text.blank"))
+    end
 
-    question.text = "text"
-    question.validate
-    expect(question.errors[:text]).not_to include("can't be blank")
-    expect(question).to be_valid
+    it "shows as a blank string" do
+      question = described_class.new
+      expect(question.show_answer).to eq ""
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/dsKOQ2fe/305-prevent-form-completers-from-entering-invalid-information

This PR covers the basic validation in the trello card above and leans on the design system pattern pages to implement different types of inputs we use.

Error messages have been moved into the locales file and that, along with the tests is probably the best. overview of whats been implemented.

There are unit tests to cover the validations, but are some properties which would probably benefit from cypress tests.

Everything here is up for discussion -  this is just to get us started with the basics. The design team want to have that conversation too, so once this is merged, I think we can show it to them and then go over what we want to implement and when.

The validation messages themselves are just placeholders.



#### What problem does the pull request solve?

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


