### PR TITLE
Fix annoying deprecation warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,4 +385,4 @@ RUBY VERSION
    ruby 3.1.1p18
 
 BUNDLED WITH
-   2.2.33
+   2.3.20


### PR DESCRIPTION
#### What problem does the pull request solve?
This deprecation warning was flagged in this github issue
https://github.com/rubygems/rubygems/issues/5234

I fixed this by running `bundle update --bundler`

 `Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.`

 When running any ruby commands you should no longer see these warnings.
 
 Relates to https://github.com/alphagov/forms-admin/pull/95
#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


