### PR TITLE
Revert "api_key"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,5 +39,4 @@ jobs:
           cf push --strategy rolling \
             --var PAAS_ENVIRONMENT=dev \
             --var API_BASE=${{ secrets.API_BASE }} \
-            --var NOTIFY_API_KEY=${{ secrets.NOTIFY_API_KEY }} \
-            --var API_KEY=${{ secrets.API_KEY }}
+            --var NOTIFY_API_KEY=${{ secrets.NOTIFY_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ use the 'api intergration' tab on notify dashboard to check emails sent.
 | `REDIS_URL`           | The URL for Redis (optional)                                 |
 | `SENTRY_DSN`          | The DSN provided by Sentry                                   |
 | `API_BASE`            | The base url for the API - E.g. `http://localhost:9090`      |
-| `API_KEY`             | The API key for authentication                               |
 | `SERVICE_UNAVAILABLE` | All pages will render 'Service unavailable' if set to `true` |
 
 ### Running the app

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -2,7 +2,6 @@ class Form < ActiveResource::Base
   self.site = ENV.fetch("API_BASE").to_s
   self.prefix = "/api/v1/"
   self.include_format_in_path = false
-  headers["X-API-Token"] = ENV["API_KEY"]
 
   has_many :pages
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,7 +2,6 @@ class Page < ActiveResource::Base
   self.site = ENV.fetch("API_BASE").to_s
   self.prefix = "/api/v1/forms/:form_id/"
   self.include_format_in_path = false
-  headers["X-API-Token"] = ENV["API_KEY"]
 
   belongs_to :form
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,4 +11,3 @@ applications:
     RACK_ENV: production
     API_BASE: ((API_BASE))
     NOTIFY_API_KEY: ((NOTIFY_API_KEY))
-    API_KEY: ((API_KEY))

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -10,17 +10,10 @@ RSpec.describe Form, type: :model do
     ].to_json
   end
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => ENV["API_KEY"],
-      "Accept" => "application/json",
-    }
-  end
-
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1", req_headers, response_data, 200
-      mock.get "/api/v1/forms/1/pages", req_headers, pages_data, 200
+      mock.get "/api/v1/forms/1", {}, response_data, 200
+      mock.get "/api/v1/forms/1/pages", {}, pages_data, 200
     end
   end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -9,16 +9,9 @@ RSpec.describe Page, type: :model do
     }.to_json
   end
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => ENV["API_KEY"],
-      "Accept" => "application/json",
-    }
-  end
-
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2/pages/1", req_headers, response_data, 200
+      mock.get "/api/v1/forms/2/pages/1", {}, response_data, 200
     end
   end
 

--- a/spec/requests/check_your_answers_spec.rb
+++ b/spec/requests/check_your_answers_spec.rb
@@ -30,17 +30,10 @@ RSpec.describe "Check Your Answers Controller", type: :request do
     ].to_json
   end
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => ENV["API_KEY"],
-      "Accept" => "application/json",
-    }
-  end
-
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2", req_headers, form_data, 200
-      mock.get "/api/v1/forms/2/pages", req_headers, pages_data, 200
+      mock.get "/api/v1/forms/2", {}, form_data, 200
+      mock.get "/api/v1/forms/2/pages", {}, pages_data, 200
     end
   end
 

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -35,16 +35,9 @@ RSpec.describe "Errors", type: :request do
 
     let(:notify_service) { instance_double(NotifyService) }
 
-    let(:req_headers) do
-      {
-        "X-API-Token" => ENV["API_KEY"],
-        "Accept" => "application/json",
-      }
-    end
-
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/2", req_headers, form_response_data, 200
+        mock.get "/api/v1/forms/2", {}, form_response_data, 200
       end
 
       allow(notify_service).to receive(:send_email).and_throw("Oh no!").with(any_args)

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -37,18 +37,11 @@ RSpec.describe "Form controller", type: :request do
     }
   end
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => ENV["API_KEY"],
-      "Accept" => "application/json",
-    }
-  end
-
   before do
     ActiveResource::HttpMock.respond_to do |mock|
       allow(EventLogger).to receive(:log).at_least(:once)
-      mock.get "/api/v1/forms/2", req_headers, form_response_data, 200
-      mock.get "/api/v1/forms/2/pages", req_headers, pages_data, 200
+      mock.get "/api/v1/forms/2", {}, form_response_data, 200
+      mock.get "/api/v1/forms/2/pages", {}, pages_data, 200
     end
   end
 

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -30,17 +30,10 @@ RSpec.describe "Page Controller", type: :request do
     ].to_json
   end
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => ENV["API_KEY"],
-      "Accept" => "application/json",
-    }
-  end
-
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2", req_headers, form_data, 200
-      mock.get "/api/v1/forms/2/pages", req_headers, pages_data, 200
+      mock.get "/api/v1/forms/2", {}, form_data, 200
+      mock.get "/api/v1/forms/2/pages", {}, pages_data, 200
     end
   end
 


### PR DESCRIPTION
Reverts alphagov/forms-runner#83 - the deploy was failing with an error saying an env var wasn't supplied. Will revert to debug. 