### PR TITLE
Add privacy policy link

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -1,6 +1,7 @@
 class FormController < ApplicationController
   def show
     @form = Form.find(params.require(:id))
+    set_privacy_policy_url
     if @form.start_page
       redirect_to form_page_path(params.require(:id), @form.start_page)
       EventLogger.log_form_event(Context.new(form: @form, store: session), request, "visit")
@@ -9,5 +10,12 @@ class FormController < ApplicationController
 
   def submitted
     @form = Form.find(params.require(:form_id))
+    set_privacy_policy_url
+  end
+
+private
+
+  def set_privacy_policy_url
+    @privacy_policy_url = @form.privacy_policy_url
   end
 end

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -1,5 +1,7 @@
 module Forms
   class CheckYourAnswersController < FormController
+    before_action :set_privacy_policy_url
+
     def show
       return redirect_to form_page_path(current_context.form, current_context.next_page_slug) unless current_context.can_visit?("check_your_answers")
 
@@ -22,6 +24,10 @@ module Forms
 
     def check_your_answers_rows
       current_context.steps.map { |page| page_to_row(page) }
+    end
+
+    def set_privacy_policy_url
+      @privacy_policy_url = current_context.privacy_policy_url
     end
   end
 end

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -1,6 +1,6 @@
 module Forms
   class PageController < FormController
-    before_action :prepare_step, :changing_existing_answer
+    before_action :prepare_step, :changing_existing_answer, :set_privacy_policy_url
 
     def show
       redirect_to form_page_path(@step.form_id, current_context.next_page_slug) unless current_context.can_visit?(@step.page_slug)
@@ -64,6 +64,10 @@ module Forms
                   end
 
       EventLogger.log_page_event(current_context, step, request, log_event)
+    end
+
+    def set_privacy_policy_url
+      @privacy_policy_url = current_context.privacy_policy_url
     end
   end
 end

--- a/app/controllers/forms/submitted_controller.rb
+++ b/app/controllers/forms/submitted_controller.rb
@@ -1,5 +1,7 @@
 module Forms
   class SubmittedController < FormController
-    def submitted; end
+    def submitted
+      @privacy_policy_url = current_context.privacy_policy_url
+    end
   end
 end

--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -1,5 +1,5 @@
 class Context
-  attr_reader :form_name, :form_start_page
+  attr_reader :form_name, :form_start_page, :privacy_policy_url
 
   def initialize(form:, store:)
     @form_context = FormContext.new(store)
@@ -10,6 +10,7 @@ class Context
     @form_id = form.id
     @form_name = form.name
     @form_start_page = form.start_page
+    @privacy_policy_url = form.privacy_policy_url
   end
 
   def find_or_create(page_slug)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,25 +59,11 @@
       </main>
     </div>
 
-    <footer class="govuk-footer " role="contentinfo">
-      <div class="govuk-width-container ">
-        <div class="govuk-footer__meta">
-          <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-
-            <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
-              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
-            </svg>
-            <span class="govuk-footer__licence-description">
-              All content is available under the
-              <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-            </span>
-          </div>
-          <div class="govuk-footer__meta-item">
-            <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
-          </div>
-        </div>
-      </div>
-    </footer>
+    <% if @privacy_policy_url.present? %>
+      <%= govuk_footer meta_items_title: "Helpful links", meta_items: {t("footer.privacy_policy") => @privacy_policy_url} %>
+    <% else %>
+      <%= govuk_footer %>
+    <% end %>
 
 
     <%= javascript_include_tag "application" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,8 @@ en:
             text:
               blank: Enter an answer
               too_long: The answer must be shorter than 500 characters
+  footer:
+    privacy_policy: Privacy policy
   form:
     no_pages: This form has no pages
   phase_banner:

--- a/spec/lib/context_spec.rb
+++ b/spec/lib/context_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Context do
   end
 
   let(:form) do
-    f = Form.new({ id: 1, name: "Form", submission_email: "jimbo@example.gov.uk", start_page: "1", pages: })
+    f = Form.new({ id: 1, name: "Form", submission_email: "jimbo@example.gov.uk", start_page: "1", privacy_policy_url: "http://www.example.gov.uk", pages: })
     f.pages[0].form = f
     f.pages[1].form = f
     f

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe EventLogger do
     })
   end
 
-  let(:context) { Context.new(form: Form.new({ id: 1, name: "Form", submission_email: "jimbo@example.gov.uk", start_page: "1", pages: [page] }), store: {}) }
+  let(:context) { Context.new(form: Form.new({ id: 1, name: "Form", submission_email: "jimbo@example.gov.uk", start_page: "1", privacy_policy_url: "http://www.example.gov.uk/privacy_policy", pages: [page] }), store: {}) }
 
   let(:request) do
     OpenStruct.new({ url: "http://example.gov.uk", method: "GET", user_agent: "agent" })

--- a/spec/requests/check_your_answers_spec.rb
+++ b/spec/requests/check_your_answers_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Check Your Answers Controller", type: :request do
       name: "Form",
       submission_email: "submission@email.com",
       start_page: 1,
+      privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
     }.to_json
   end
 

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Form controller", type: :request do
       name: "Form name",
       submission_email: "submission@email.com",
       start_page: "1",
+      privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
     }.to_json
   end
 
@@ -74,6 +75,7 @@ RSpec.describe "Form controller", type: :request do
           name: "Form name",
           submission_email: "submission@email.com",
           start_page: nil,
+          privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
         }.to_json
       end
 

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Page Controller", type: :request do
       name: "Form",
       submission_email: "submission@email.com",
       start_page: 1,
+      privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
     }.to_json
   end
 
@@ -58,6 +59,11 @@ RSpec.describe "Page Controller", type: :request do
     it "Displays the question text on the page" do
       get form_page_path(2, 1)
       expect(response.body).to include("Question one")
+    end
+
+    it "Displays the privacy policy link on the page" do
+      get form_page_path(2, 1)
+      expect(response.body).to include("Privacy policy")
     end
 
     context "with a page that has a previous page" do


### PR DESCRIPTION
#### What problem does the pull request solve?
Reads a form's privacy policy URL and displays it in the footer if it's present.

Trello card: https://trello.com/c/aZtUyjei/16-add-link-to-privacy-information-to-forms-runner-in-footer-of-every-form-pageneeds-dev-review

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


