### PR TITLE
Fix sessions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ group :test do
   gem "selenium-webdriver"
   gem "simplecov"
   gem "webdrivers"
+  gem "climate_control"
 end
 
 gem "bundler-audit", "~> 0.9.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
@@ -357,6 +358,7 @@ DEPENDENCIES
   brakeman (~> 5.2)
   bundler-audit (~> 0.9.0)
   capybara
+  climate_control
   cssbundling-rails
   debug
   dotenv-rails

--- a/app/lib/redis_config.rb
+++ b/app/lib/redis_config.rb
@@ -1,0 +1,16 @@
+class RedisConfig
+  # this is the key the redis details are stored in PAAS VCAP_SERVICES
+  REDIS_ATTRS = [:redis].freeze
+  REDIS_URL = REDIS_ATTRS + [0, :credentials, :uri]
+
+  def self.redis_url
+    return vcap_services.dig(*REDIS_URL) if vcap_services
+
+    ENV.fetch("REDIS_URL", nil)
+  end
+
+  def self.vcap_services
+    env_var = ENV.fetch("VCAP_SERVICES", nil)
+    JSON.parse(env_var, symbolize_names: true) if env_var
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,35 +33,6 @@ module FormsRunner
     config.generators do |g|
       g.test_framework :rspec
     end
-    #
-    # Get redis url based on VCAP_SERVICES or REDIS_URL depending on environment
-    # GovPaaS provides the URI in VCAP_SERVICES
-
-    if ENV["VCAP_SERVICES"]
-      vcap_services = JSON.parse(ENV["VCAP_SERVICES"])
-      if vcap_services["redis"]
-        host = vcap_services["redis"][0]["credentials"]["host"]
-        password = vcap_services["redis"][0]["credentials"]["password"]
-        port = vcap_services["redis"][0]["credentials"]["port"]
-
-        config.session_store :redis_session_store,
-                             key: "_app_session_key",
-                             redis: {
-                               host:,
-                               password:,
-                               port:,
-                               ssl: true,
-                             },
-                             on_redis_down: ->(_e, _env, _sid) { Rails.logger.debug "Redis down" }
-      end
-    elsif ENV["REDIS_URL"]
-      config.session_store :redis_session_store,
-                           key: "_app_session_key",
-                           redis: {
-                             url: ENV["REDIS_URL"],
-                           },
-                           on_redis_down: ->(_e, _env, _sid) { Rails.logger.debug "Redis down" }
-    end
 
     # Use custom error pages
     config.exceptions_app = routes

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,4 +58,8 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Allow storing session in cookies. This should only be allowed in local
+  # development and testing. In production redis should be used
+  config.unsafe_session_storage = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,4 +54,8 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Allow storing session in cookies. This should only be allowed in local
+  # development and testing. In production redis should be used
+  config.unsafe_session_storage = true
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,20 @@
+require_relative "../../app/lib/redis_config"
+
+redis_url = RedisConfig.redis_url
+
+if redis_url.blank?
+  throw StandardError.new "You must configure a session store using REDIS_URL or VCAP_SERVICES" unless Rails.configuration.try(:unsafe_session_storage)
+  STDERR.write "WARNING: Using cookies as session store, insecure\n"
+else
+  Rails.application.config.session_store :redis_session_store,
+    key: "_forms",
+    redis: {
+      url: redis_url,
+      ttl: 20.hours, # set the redis ttl to 20 hours, but the cookie expiry will still be session
+      key_prefix: "session:"
+    },
+    on_redis_down: ->(_e, _env, _sid) { Rails.logger.warn "Unable to connect to Redis session store." },
+    serializer: :json
+
+    STDERR.write "Using redis as session store\n"
+end

--- a/spec/fixtures/vcap_example.json
+++ b/spec/fixtures/vcap_example.json
@@ -1,0 +1,28 @@
+{
+  "redis": [
+    {
+      "binding_guid": "d003755a-352d-4bc9-b427-f931570f8cab",
+      "binding_name": null,
+      "credentials": {
+        "host": "redis.example.org",
+        "name": "cf-name",
+        "password": "password",
+        "port": 6379,
+        "tls_enabled": true,
+        "uri": "rediss://:password@redis.example.org:6379"
+      },
+      "instance_guid": "24989eb3-0b52-48f5-9538-13017082e26c",
+      "instance_name": "forms-runner-redis",
+      "label": "redis",
+      "name": "forms-runner-redis",
+      "plan": "micro-6.x",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "elasticache",
+        "redis"
+      ],
+      "volume_mounts": []
+    }
+  ]
+}

--- a/spec/lib/redis_config_spec.rb
+++ b/spec/lib/redis_config_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+require_relative "../../app/lib/redis_config.rb"
+
+RSpec.describe RedisConfig do
+  let(:vcap_env) { nil }
+  let(:redis_url_env) { nil }
+
+  around do |example|
+    ClimateControl.modify VCAP_SERVICES: vcap_env, REDIS_URL: redis_url_env do
+      example.run
+    end
+  end
+
+  context "when VCAP_SERVICES is set" do
+    let(:vcap_env) { File.read(File.join('spec', 'fixtures', "vcap_example.json")) }
+
+    it "extracts the uri from JSON" do
+      expect(RedisConfig.redis_url).to eq("rediss://:password@redis.example.org:6379")
+    end
+
+  end
+
+  context "when REDIS_URL is set" do
+    let(:redis_url_env) { "redis_url_value" }
+
+    it "equals REDIS_URL" do
+      expect(RedisConfig.redis_url).to eq("redis_url_value")
+    end
+  end
+
+  context "when VCAP_SERVICES and REDIS_URL are set" do
+    let(:vcap_env) { File.read(File.join('spec', 'fixtures', "vcap_example.json")) }
+    let(:redis_url_env) { "redis_url_value" }
+
+    it "uses the VCAP_SERVICES url" do
+      expect(RedisConfig.redis_url).to eq("rediss://:password@redis.example.org:6379")
+    end
+  end
+
+  context "when no redis url is set" do
+    it "is nil" do
+      expect(RedisConfig.redis_url).to be_nil
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "pry"
 require "simplecov"
+require "climate_control"
 
 SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,


### PR DESCRIPTION
#### What problem does the pull request solve?
Add a few security measures to protect users sessions in the runner:
- set `force_ssl=true` in production, this sets secure=true on cookies, so they are only ever transported over ssl, also HSTS
- set TTL on Redis session keys to 20hours. This means sessions will expire after 20hours of no requests to the server from the users browser. Cookies are still session based, so are not kept around after the browser closes.
- cleans up the config of redis and tries to prevent accidental misconfiguration of the session store

There are a few other session based things which we might consider doing - I'm also documenting current behaviour in a sample session and I'll bring a few of them up for review.

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


