### PR TITLE
Fix: Submission timestamp issue

### DIFF
--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -11,7 +11,7 @@ class NotifyService
       return nil
     end
 
-    timestamp = Time.now.zone
+    timestamp = Time.zone.now
     submission_time = timestamp.strftime("%H:%M:%S")
     submission_date = timestamp.strftime("%-d %B %Y")
 


### PR DESCRIPTION
# Submission error

Forms can't be submitted without raising an error:
https://sentry.io/organizations/govuk-forms/issues/3548258202/?project=6576261&query=is%3Aunresolved

This happens because `Time.now.zone` was called instead of
`Time.zone.now`. The first returns a string - e.g 'UTC', which then
throws method unknown when the `strftime` call is made.

This seems a sharp corner of ruby `Time` and rubocop bullied us into
making the error in the first place.

#### What problem does the pull request solve?

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


