### PR TITLE
Add accessibility statement page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,6 @@
 $govuk-images-path: "./images/";
 $govuk-fonts-path: "./fonts/";
+$govuk-new-link-styles: true;
+$govuk-global-styles: true;
 
 @import "govuk/all";

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,0 +1,2 @@
+class HelpController < ApplicationController
+end

--- a/app/views/help/accessibility_statement.html.erb
+++ b/app/views/help/accessibility_statement.html.erb
@@ -1,0 +1,172 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Accessibility statement for this form</h1>
+    <p>
+      This accessibility statement contains information about this online form
+      available at
+      <a href="https://submit.forms.service.gov.uk"
+        >https://submit.forms.service.gov.uk</a
+      >.
+    </p>
+
+    <p class="govuk-inset-text">
+      This form is part of the wider GOV.UK website. There’s a separate
+      <a href="https://www.gov.uk/help/accessibility-statement"
+        >accessibility statement for the main GOV.UK website</a
+      >.
+    </p>
+
+    <p>This accessibility statement explains:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>how accessible the form is</li>
+      <li>what work we’re planning to do</li>
+      <li>what to do if you have difficulty using it</li>
+      <li>how to report any accessibility problems</li>
+    </ul>
+
+    <h2 class="govuk-heading-m">Using this form</h2>
+
+    <p>
+      This form was created using a platform called
+      <a href="http://www.gov.uk/forms">GOV.UK Forms</a>. GOV.UK Forms is built
+      by the Government Digital Service (GDS). It is designed to create forms
+      that can be used by as many people as possible.
+    </p>
+
+    <p>The text in the form should be clear and simple to understand.</p>
+
+    <p>You should be able to:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>change colours, contrast levels and fonts</li>
+      <li>zoom in up to 300% without the text spilling off the screen</li>
+      <li>get from the start of the form to the end using just a keyboard</li>
+      <li>
+        get from the start of the form to the end using speech recognition
+        software
+      </li>
+      <li>
+        listen to the form using a screen reader (including the most recent
+        versions of JAWS, NVDA and VoiceOver)
+      </li>
+    </ul>
+
+    <p>
+      <a href="https://mcmw.abilitynet.org.uk/">AbilityNet</a>
+      has advice on making your device easier to use if you have a disability.
+    </p>
+
+    <h2 class="govuk-heading-m">How accessible this form is</h2>
+
+    <p>Some parts of this form may not be fully accessible.</p>
+
+    <p>
+      The questions in the form are written by people in government departments
+      and agencies. Each department and agency which publishes content on GOV.UK
+      is responsible for making sure it meets the accessibility regulations.
+      However, the text used in the form might not be plain language and the
+      structure may not be fully accessible.
+    </p>
+
+    <p>
+      To encourage accessible content we provide guidance within the GOV.UK
+      Forms platform. We also use feedback and analytics to identify
+      accessibility issues.
+    </p>
+
+    <h2 class="govuk-heading-m">
+      What to do if you have difficulty using this form
+    </h2>
+
+    <p>
+      If you have difficulty using this form or need the form in a different
+      format, send an email to
+      <a href="mailto:govuk-forms@digital.cabinet-office.gov.uk"
+        >govuk-forms@digital.cabinet-office.gov.uk</a
+      >
+      - include the name of the form in your email.
+    </p>
+
+    <h2 class="govuk-heading-m">Reporting accessibility problems</h2>
+
+    <p>
+      We’re always looking to improve the accessibility of forms made with
+      GOV.UK Forms.
+    </p>
+
+    <p>
+      If you find any problems, or think we’re not meeting accessibility
+      requirements, email us at
+      <a href="mailto:govuk-forms@digital.cabinet-office.gov.uk"
+        >govuk-forms@digital.cabinet-office.gov.uk</a
+      >.
+    </p>
+
+    <h2 class="govuk-heading-m">If you’re not happy with our response</h2>
+
+    <p>
+      The Equality and Human Rights Commission (EHRC) is responsible for
+      enforcing the Public Sector Bodies (Websites and Mobile Applications) (No.
+      2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
+    </p>
+
+    <p>
+      If you are not happy with how we respond to your complaint, contact the
+      <a href="https://www.equalityadvisoryservice.com/"
+        >Equality Advisory and Support Service</a
+      >, which is run on behalf of EHRC.
+    </p>
+
+    <h2 class="govuk-heading-m">
+      Technical information about this form’s accessibility
+    </h2>
+
+    <p>
+      GDS is committed to making this form accessible, in accordance with the
+      Public Sector Bodies (Websites and Mobile Applications) (No. 2)
+      Accessibility Regulations 2018.
+    </p>
+
+    <h3 class="govuk-heading-s">Compliance status</h3>
+
+    <p>
+      This form is partially compliant with the
+      <a href="https://www.w3.org/TR/WCAG21/"
+        >Web Content Accessibility Guidelines version 2.1 AA standard</a
+      >, due to the non-compliances listed below.
+    </p>
+
+    <h2 class="govuk-heading-m">Non accessible content</h2>
+
+    <h3 class="govuk-heading-s">
+      Non compliance with the accessibility regulations
+    </h3>
+
+    <p>
+      Some form inputs ask for information without the appropriate autocomplete
+      attributes. This means that they won’t be automatically filled by the
+      browser. This does not meet WCAG 2.1 success criterion 1.3.5 (identify
+      input purpose).
+    </p>
+
+    <p>
+      We plan to add autocomplete for the most common answer types by April
+      2023.
+    </p>
+
+    <h2 class="govuk-heading-m">Preparation of this accessibility statement</h2>
+
+    <p>This statement was prepared on 6 September 2022.</p>
+
+    <p>
+      Forms created using the GOV.UK Forms platform were last tested on 6
+      September 2022. The test was carried out by GDS.
+    </p>
+
+    <p>
+      GDS assessed the forms against the Web Content Accessibility Guidelines
+      WCAG 2.1.
+    </p>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,12 +49,12 @@
       </main>
     </div>
 
+    <% meta_links = {t("footer.accessibility_statement") => accessibility_statement_path} %>
     <% if @privacy_policy_url.present? %>
-      <%= govuk_footer meta_items_title: "Helpful links", meta_items: {t("footer.privacy_policy") => @privacy_policy_url} %>
-    <% else %>
-      <%= govuk_footer %>
-    <% end %>
+      <% meta_links[t("footer.privacy_policy")] = @privacy_policy_url %>
+    <% end -%>
 
+    <%= govuk_footer meta_items_title: t("footer.helpful_links"), meta_items: meta_links %>
 
     <%= javascript_include_tag "application" %>
   </body>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,8 @@ en:
               blank: Enter an answer
               too_long: The answer must be shorter than 500 characters
   footer:
+    accessibility_statement: Accessibility statement
+    helpful_links: Helpful links
     privacy_policy: Privacy
   form:
     no_pages: This form has no pages

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   root "errors#not_found"
 
   get "/form/:id" => "form#show", as: :form
+  get "/help/accessibility-statement" => "help#accessibility_statement", as: :accessibility_statement
 
   get "/form/:form_id/check_your_answers" => "forms/check_your_answers#show", as: :check_your_answers
   post "/form/:form_id/submit_answers" => "forms/submit_answers#submit_answers", as: :form_submit_answers

--- a/spec/requests/help_spec.rb
+++ b/spec/requests/help_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "Help pages", type: :request do
+  describe "Accessibility statement" do
+    it "returns http code 200" do
+      get accessibility_statement_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -66,6 +66,11 @@ RSpec.describe "Page Controller", type: :request do
       expect(response.body).to include("Privacy")
     end
 
+    it "Displays the accessibility statement link on the page" do
+      get form_page_path(2, 1)
+      expect(response.body).to include("Accessibility statement")
+    end
+
     context "with a page that has a previous page" do
       it "Displays a link to the previous page" do
         get form_page_path(2, 2)


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds a static accessibility page to the runner and links to it in the footer. 

Note that the content isn't quite final yet, but functionally this should be complete and can be merged if approved.

Trello card: https://trello.com/c/v2RiiRfw/353-add-a-static-accessibility-statement-to-forms-runner-and-a-link-to-it-in-footer-of-every-form-page-content-to-change-after-inter

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


