### PR TITLE
Fix HTML parsing error in address input

### DIFF
--- a/app/views/question/_address.html.erb
+++ b/app/views/question/_address.html.erb
@@ -1,4 +1,7 @@
-<%= form.govuk_fieldset legend: { text: page.question_text, tag: 'h1', size: 'l' }, hint: { text: page.hint_text } do %>
+<%= form.govuk_fieldset legend: { text: page.question_text, tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-address-hint" : nil do %>
+  <% if page.hint_text.present? %>
+    <p id="govuk-address-hint" class="govuk-hint"><%= page.hint_text %></p>
+  <% end %>
   <%= form.govuk_text_field :address1, label: { text: "Address line 1" }, autocomplete: "address-line1" %>
   <%= form.govuk_text_field :address2, label: {  text: "Address line 2 (optional)"  }, autocomplete: "address-line2" %>
   <%= form.govuk_text_field :town_or_city, label: {  text: "Town or City" }, width: 'two-thirds', autocomplete: "address-level2" %>


### PR DESCRIPTION
#### What problem does the pull request solve?
The govuk-form-builder gem doesn't support adding a hint to the address component, so Rails turns this into an invalid 'hint' attribute.

I've removed that attribute and added the hint text to the markup.

Trello card: https://trello.com/c/YcZBtTWC/103-fix-html-parsing-error-on-address-input

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


