### PR TITLE
Link header to GOV.UK homepage

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,9 +30,9 @@
     <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 
     <% if @current_context.present? %>
-      <%= govuk_header(service_name: @current_context.form_name) %>
+      <%= govuk_header(service_name: @current_context.form_name, homepage_url: "https://www.gov.uk/") %>
     <% else %>
-      <%= govuk_header %>
+      <%= govuk_header(homepage_url: "https://www.gov.uk/") %>
     <% end %>
 
 


### PR DESCRIPTION
#### What problem does the pull request solve?
Makes the logo link point to the GOV.UK homepage, so that users aren't sent to a 404 page when they click it.

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


