### PR TITLE
change type of next_page from string to int in tests

### DIFF
--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Form controller", type: :request do
         question_text: "Question one",
         question_short_name: nil,
         answer_type: "date",
-        next_page: "2",
+        next_page: 2,
       },
       {
         id: 2,


### PR DESCRIPTION
#### What problem does the pull request solve?

In this PR: https://github.com/alphagov/forms-api/pull/69 we're changing the type of next_page from string to int - this PR reflects those changes in the test data in this repo.

#### Checklist

- [x] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


