### PR TITLE
Handle 404 returns from forms-api

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -1,4 +1,8 @@
 class FormController < ApplicationController
+  rescue_from ActiveResource::ResourceNotFound do
+    redirect_to not_found_page_path
+  end
+
   def show
     @form = Form.find(params.require(:id))
     set_privacy_policy_url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "errors#not_found"
 
+  match "/404", to: "errors#not_found", as: :not_found_page, via: :all
+  match "/500", to: "errors#internal_server_error", as: :server_error_page, via: :all
+
   get "/form/:id" => "form#show", as: :form
   get "/help/accessibility-statement" => "help#accessibility_statement", as: :accessibility_statement
   get "/help/cookies" => "help#cookies", as: :cookies
@@ -17,7 +20,4 @@ Rails.application.routes.draw do
   get "/form/:form_id/:page_slug/change" => "forms/page#show", as: :form_change_answer, defaults: { changing_existing_answer: true }
   get "/form/:form_id/:page_slug" => "forms/page#show", as: :form_page
   post "/form/:form_id/:page_slug" => "forms/page#save", as: :save_form_page
-
-  match "/404", to: "errors#not_found", via: :all
-  match "/500", to: "errors#internal_server_error", via: :all
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
We were getting 404 results from the api as ActiveResources::ResourceNotFound and Rails was raising that as an exception which returned a 500 error

Related to https://trello.com/c/zqDyYX66/106-fix-404-reporting-as-500-errors
#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


