### PR TITLE
Make submission time in emails use local timezone

### DIFF
--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -11,20 +11,29 @@ class NotifyService
       return nil
     end
 
-    timestamp = Time.zone.now
-    submission_time = timestamp.strftime("%H:%M:%S")
-    submission_date = timestamp.strftime("%-d %B %Y")
-
     client = Notifications::Client.new(@notify_api_key)
-    client.send_email(
+    client.send_email(**email(email_address, title, text_input))
+  end
+
+  def email(email_address, title, text_input)
+    timestamp = submission_timestamp
+    {
       email_address:,
       template_id: "427eb8bc-ce0d-40a3-bf54-d76e8c3ec916",
       personalisation: {
         title:,
         text_input:,
-        submission_time:,
-        submission_date:,
+        submission_time: timestamp.strftime("%H:%M:%S"),
+        submission_date: timestamp.strftime("%-d %B %Y"),
       },
-    )
+    }
+  end
+
+  def submission_timezone
+    Rails.configuration.x.submission.time_zone || "UTC"
+  end
+
+  def submission_timestamp
+    Time.use_zone(submission_timezone) { Time.zone.now }
   end
 end

--- a/config/initializers/submission.rb
+++ b/config/initializers/submission.rb
@@ -1,0 +1,3 @@
+# The email sent to processors includes the time the submission was made. This
+# value controls where the submission time is recorded
+Rails.configuration.x.submission.time_zone = 'London'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,4 +52,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Add rails own time testing helpers
+  config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe NotifyService do
+  let(:notify_api_key) { nil }
+  around do |example|
+    ClimateControl.modify NOTIFY_API_KEY: notify_api_key do
+        example.run
+    end
+  end
+
+  context "with api key set" do
+    let(:notify_api_key) { 'test-key' }
+    let(:submission_datetime) { Time.utc(2022, 9, 14, 10, 00, 00) }
+
+    it "sends correct values to notify" do
+      fake_notify_client = instance_double(Notifications::Client)
+      allow(fake_notify_client).to receive(:send_email)
+      allow(Notifications::Client).to receive(:new).and_return(fake_notify_client)
+
+      travel_to submission_datetime do
+        notify_service = NotifyService.new
+        notify_service.send_email('fake-email','title','text')
+        expect(fake_notify_client).to have_received(:send_email).with(
+          {:email_address=>'fake-email',
+           :personalisation=>{
+             :submission_date=>"14 September 2022",
+             :submission_time=>"11:00:00",
+             :text_input=>'text',
+             :title=>'title'
+           },
+           :template_id=>"427eb8bc-ce0d-40a3-bf54-d76e8c3ec916"}).once
+      end
+    end
+  end
+
+  context "with no api key set" do
+    it "does not send an email through notify" do
+      fake_notify_client = instance_double(Notifications::Client)
+      allow(fake_notify_client).to receive(:send_email)
+      allow(Notifications::Client).to receive(:new).and_return(fake_notify_client)
+      expect(Rails.logger).to receive(:warn).with(/NOTIFY_API_KEY/)
+
+      notify_service = NotifyService.new
+      notify_service.send_email('fake-email','title','text')
+      expect(fake_notify_client).to_not have_received(:send_email)
+    end
+  end
+end

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -10,25 +10,50 @@ RSpec.describe NotifyService do
 
   context "with api key set" do
     let(:notify_api_key) { 'test-key' }
-    let(:submission_datetime) { Time.utc(2022, 9, 14, 10, 00, 00) }
 
-    it "sends correct values to notify" do
-      fake_notify_client = instance_double(Notifications::Client)
-      allow(fake_notify_client).to receive(:send_email)
-      allow(Notifications::Client).to receive(:new).and_return(fake_notify_client)
+    context "with a time in BST" do
+      let(:submission_datetime) { Time.utc(2022, 9, 14, 10, 00, 00) }
+      it "sends correct values to notify" do
+        fake_notify_client = instance_double(Notifications::Client)
+        allow(fake_notify_client).to receive(:send_email)
+        allow(Notifications::Client).to receive(:new).and_return(fake_notify_client)
 
-      travel_to submission_datetime do
-        notify_service = NotifyService.new
-        notify_service.send_email('fake-email','title','text')
-        expect(fake_notify_client).to have_received(:send_email).with(
-          {:email_address=>'fake-email',
-           :personalisation=>{
-             :submission_date=>"14 September 2022",
-             :submission_time=>"11:00:00",
-             :text_input=>'text',
-             :title=>'title'
-           },
-           :template_id=>"427eb8bc-ce0d-40a3-bf54-d76e8c3ec916"}).once
+        travel_to submission_datetime do
+          notify_service = NotifyService.new
+          notify_service.send_email('fake-email','title','text')
+          expect(fake_notify_client).to have_received(:send_email).with(
+            {:email_address=>'fake-email',
+             :personalisation=>{
+               :submission_date=>"14 September 2022",
+               :submission_time=>"11:00:00",
+               :text_input=>'text',
+               :title=>'title'
+             },
+             :template_id=>"427eb8bc-ce0d-40a3-bf54-d76e8c3ec916"}).once
+        end
+      end
+    end
+
+    context "with a time in GMT" do
+      let(:submission_datetime) { Time.utc(2022, 12, 14, 10, 00, 00) }
+      it "sends correct values to notify" do
+        fake_notify_client = instance_double(Notifications::Client)
+        allow(fake_notify_client).to receive(:send_email)
+        allow(Notifications::Client).to receive(:new).and_return(fake_notify_client)
+
+        travel_to submission_datetime do
+          notify_service = NotifyService.new
+          notify_service.send_email('fake-email','title','text')
+          expect(fake_notify_client).to have_received(:send_email).with(
+            {:email_address=>'fake-email',
+             :personalisation=>{
+               :submission_date=>"14 December 2022",
+               :submission_time=>"10:00:00",
+               :text_input=>'text',
+               :title=>'title'
+             },
+             :template_id=>"427eb8bc-ce0d-40a3-bf54-d76e8c3ec916"}).once
+        end
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/XNOhXuOY/128-bug-submission-time-in-the-processing-email-is-off-by-an-hour

Submission emails show the time of submission in UTC zone - which the server uses. This commit changes the timezone to use a zone specified in the config and defaults to London. It also adds tests to the submission code.

#### What problem does the pull request solve?

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


