### PR TITLE
Add "What happens next" to the submitted confirmation page

### DIFF
--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -1,5 +1,5 @@
 class Context
-  attr_reader :form_name, :form_start_page, :privacy_policy_url
+  attr_reader :form_name, :form_start_page, :privacy_policy_url, :what_happens_next_text
 
   def initialize(form:, store:)
     @form_context = FormContext.new(store)
@@ -11,6 +11,7 @@ class Context
     @form_name = form.name
     @form_start_page = form.start_page
     @privacy_policy_url = form.privacy_policy_url
+    @what_happens_next_text = form.what_happens_next_text
   end
 
   def find_or_create(page_slug)

--- a/app/views/forms/submitted/submitted.html.erb
+++ b/app/views/forms/submitted/submitted.html.erb
@@ -3,5 +3,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel(title_text: t('form.submitted.title')) %>
+
+    <%if @current_context.what_happens_next_text.present? %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-7">What happens next</h2>
+      <p class="govuk-body"><%= @current_context.what_happens_next_text %></p>
+  <% end %>
   </div>
 </div>

--- a/spec/lib/context_spec.rb
+++ b/spec/lib/context_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Context do
   end
 
   let(:form) do
-    f = Form.new({ id: 1, name: "Form", submission_email: "jimbo@example.gov.uk", start_page: "1", privacy_policy_url: "http://www.example.gov.uk", pages: })
+    f = Form.new({ id: 1, name: "Form", submission_email: "jimbo@example.gov.uk", start_page: "1", privacy_policy_url: "http://www.example.gov.uk", what_happens_next_text: "Good things come to those that wait", pages: })
     f.pages[0].form = f
     f.pages[1].form = f
     f

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -12,7 +12,20 @@ RSpec.describe EventLogger do
     })
   end
 
-  let(:context) { Context.new(form: Form.new({ id: 1, name: "Form", submission_email: "jimbo@example.gov.uk", start_page: "1", privacy_policy_url: "http://www.example.gov.uk/privacy_policy", pages: [page] }), store: {}) }
+  let(:context) do
+    Context.new(
+      form: Form.new({
+        id: 1,
+        name: "Form",
+        submission_email: "jimbo@example.gov.uk",
+        start_page: "1",
+        privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+        what_happens_next_text: "Good things come to those that wait",
+        pages: [page]
+      }),
+      store: {},
+    )
+  end
 
   let(:request) do
     OpenStruct.new({ url: "http://example.gov.uk", method: "GET" })

--- a/spec/requests/check_your_answers_spec.rb
+++ b/spec/requests/check_your_answers_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Check Your Answers Controller", type: :request do
       submission_email: "submission@email.com",
       start_page: 1,
       privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+      what_happens_next_text: "Good things come to those that wait",
     }.to_json
   end
 

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Form controller", type: :request do
       submission_email: "submission@email.com",
       start_page: "1",
       privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+      what_happens_next_text: "Good things come to those that wait",
     }.to_json
   end
 
@@ -100,6 +101,31 @@ RSpec.describe "Form controller", type: :request do
       end
 
       context "when a form doesn't exists" do
+        before do
+          get form_path(mode: "preview-form", form_id: 9999)
+        end
+
+        it "Render the not found page" do
+          expect(response.body).to include(I18n.t("not_found.title"))
+        end
+
+        it "returns 404" do
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context "when the form has no start page" do
+        let(:form_response_data) do
+          {
+            id: 2,
+            name: "Form name",
+            submission_email: "submission@email.com",
+            start_page: nil,
+            privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+            what_happens_next_text: "Good things come to those that wait",
+          }.to_json
+        end
+
         before do
           get form_path(mode: "preview-form", form_id: 9999)
         end

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Page Controller", type: :request do
       submission_email: "submission@email.com",
       start_page: 1,
       privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+      what_happens_next_text: "Good things come to those that wait",
     }.to_json
   end
 

--- a/spec/views/forms/submitted/submitted.html.erb_spec.rb
+++ b/spec/views/forms/submitted/submitted.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "forms/submitted/submitted.html.erb" do
+  before do
+    assign(:current_context, OpenStruct.new(id: 1, name: "Form 1"))
+    render template: "forms/submitted/submitted"
+  end
+
+  it "contains a green govuk panel with success message " do
+    expect(rendered).to have_css("h1.govuk-panel__title", text: "Your form has been submitted")
+  end
+
+  context "when the form has extra information about what happens next" do
+    before do
+      assign(:current_context, OpenStruct.new(id: 1, name: "Form 1", what_happens_next_text: "See what the day brings"))
+      render template: "forms/submitted/submitted"
+    end
+
+    it "displays what happens next heading" do
+      expect(rendered).to have_css("h2", text: "What happens next")
+    end
+
+    it "displays tells the user what happens next" do
+      expect(rendered).to have_css("p.govuk-body", text: "See what the day brings")
+    end
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?
Form users need to know what happens after they submit the form. If a form admin has added copy to the forms "What happens next" step then that copy will now be show to the form user once they have submitted their form

related to https://trello.com/c/4mCMqpda/356-add-what-happens-next-to-the-confirmation-page-should-have

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


