### PR TITLE
WIP: Change form access to by slug rather than id

### DIFF
--- a/app/lib/step_factory.rb
+++ b/app/lib/step_factory.rb
@@ -12,10 +12,11 @@ class StepFactory
 
   def initialize(form:)
     @form = form
+    # require 'pry'; binding.pry
     @pages = form.pages
 
     @submission_email = form.submission_email
-    @form_id = form.id
+    @form_id = form.form_slug
   end
 
   def create_step(page_slug_or_start)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,13 +1,13 @@
 class Page < ActiveResource::Base
   self.site = ENV.fetch("API_BASE").to_s
-  self.prefix = "/api/v1/forms/:form_id/"
+  self.prefix = "/api/v1/forms/:form_slug/"
   self.include_format_in_path = false
   headers["X-API-Token"] = ENV["API_KEY"]
 
   belongs_to :form
 
-  def form_id
-    @prefix_options[:form_id]
+  def form_slug
+    @prefix_options[:form_slug]
   end
 
   def has_next_page?


### PR DESCRIPTION
This is a WIP branch not intended for release. It pairs with changes to the API to support accessing forms solely through form_slug instead of Id.

It's currently not working, throughing an exception: `ActiveResource::MissingPrefixParam (form_slug prefix_option is missing):` when accessing a page.

This is probably because of the changes to the Page model prefix in an attempt to get the runner to call the API correctly.

#### What problem does the pull request solve?

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


