### PR TITLE
Add privacy page

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -5,7 +5,6 @@ class FormController < Forms::FormController
 
   def show
     @form = Form.find(params.require(:form_id))
-    set_privacy_policy_url
     if @form.start_page
       redirect_to form_page_path(params.require(:form_id), @form.start_page)
       unless preview?
@@ -16,12 +15,5 @@ class FormController < Forms::FormController
 
   def submitted
     @form = Form.find(params.require(:form_id))
-    set_privacy_policy_url
-  end
-
-private
-
-  def set_privacy_policy_url
-    @privacy_policy_url = @form.privacy_policy_url
   end
 end

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -1,7 +1,5 @@
 module Forms
   class CheckYourAnswersController < FormController
-    before_action :set_privacy_policy_url
-
     def show
       return redirect_to form_page_path(current_context.form, current_context.next_page_slug) unless current_context.can_visit?("check_your_answers")
 
@@ -26,10 +24,6 @@ module Forms
 
     def check_your_answers_rows
       current_context.steps.map { |page| page_to_row(page) }
-    end
-
-    def set_privacy_policy_url
-      @privacy_policy_url = current_context.privacy_policy_url
     end
   end
 end

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -1,6 +1,6 @@
 module Forms
   class PageController < FormController
-    before_action :prepare_step, :changing_existing_answer, :set_privacy_policy_url
+    before_action :prepare_step, :changing_existing_answer
 
     def show
       redirect_to form_page_path(@step.form_id, current_context.next_page_slug) unless current_context.can_visit?(@step.page_slug)
@@ -66,10 +66,6 @@ module Forms
                   end
 
       EventLogger.log_page_event(current_context, step, request, log_event)
-    end
-
-    def set_privacy_policy_url
-      @privacy_policy_url = current_context.privacy_policy_url
     end
   end
 end

--- a/app/controllers/forms/privacy_page_controller.rb
+++ b/app/controllers/forms/privacy_page_controller.rb
@@ -1,0 +1,7 @@
+module Forms
+  class PrivacyPageController < FormController
+    def show
+      @privacy_policy_url = current_context.privacy_policy_url
+    end
+  end
+end

--- a/app/controllers/forms/submitted_controller.rb
+++ b/app/controllers/forms/submitted_controller.rb
@@ -1,7 +1,7 @@
 module Forms
   class SubmittedController < FormController
     def submitted
-      @privacy_policy_url = current_context.privacy_policy_url
+      @current_context = current_context
     end
   end
 end

--- a/app/views/forms/privacy_page/show.html.erb
+++ b/app/views/forms/privacy_page/show.html.erb
@@ -38,7 +38,7 @@
       for more information.
     </p>
 
-    <h2 class="govuk-heading-l">
+    <h2 class="govuk-heading-m">
       Data we collect from you and what we do with it
     </h2>
 
@@ -115,7 +115,7 @@
       by court order, or to prevent fraud or other crime.
     </p>
 
-    <h2 class="govuk-heading-l">Cookies</h2>
+    <h2 class="govuk-heading-m">Cookies</h2>
 
     <p>
       We use cookies to make this form work.
@@ -123,7 +123,7 @@
 Read about the cookies we use<% end %>.
     </p>
 
-    <h2 class="govuk-heading-l">How long we keep your data</h2>
+    <h2 class="govuk-heading-m">How long we keep your data</h2>
 
     <p>We will only keep your personal data for as long as:</p>
 
@@ -134,7 +134,7 @@ Read about the cookies we use<% end %>.
 
     <p>This means that we will only hold your personal data for one year.</p>
 
-    <h2 class="govuk-heading-l">
+    <h2 class="govuk-heading-m">
       Where your data is processed and stored
     </h2>
 
@@ -147,7 +147,7 @@ Read about the cookies we use<% end %>.
       data in accordance with UK standards.
     </p>
 
-    <h2 class="govuk-heading-l">
+    <h2 class="govuk-heading-m">
       How we protect your data and keep it secure
     </h2>
 
@@ -160,7 +160,7 @@ Read about the cookies we use<% end %>.
       to keep all personal data they process on our behalf secure.
     </p>
 
-    <h2 class="govuk-heading-l">Children’s privacy protection</h2>
+    <h2 class="govuk-heading-m">Children’s privacy protection</h2>
 
     <p>
       We understand the importance of protecting children’s privacy online. Our
@@ -169,7 +169,7 @@ Read about the cookies we use<% end %>.
       maintain data about anyone under the age of 13.
     </p>
 
-    <h2 class="govuk-heading-l">What are your rights</h2>
+    <h2 class="govuk-heading-m">What are your rights</h2>
 
     <p>You have the right to request:</p>
 
@@ -203,7 +203,7 @@ Read about the cookies we use<% end %>.
       Officer - you can find their contact details below.
     </p>
 
-    <h2 class="govuk-heading-l">Changes to this notice</h2>
+    <h2 class="govuk-heading-m">Changes to this notice</h2>
 
     <p>
       We may modify or amend this privacy notice at our discretion at any time.
@@ -214,7 +214,7 @@ Read about the cookies we use<% end %>.
       about how we are protecting your data.
     </p>
 
-    <h2 class="govuk-heading-l">Questions and complaints</h2>
+    <h2 class="govuk-heading-m">Questions and complaints</h2>
 
     <p>
       Contact <%= govuk_link_to "gds-privacy-office@digital.cabinet-office.gov.uk", "mailto:gds-privacy-office@digital.cabinet-office.gov.uk" %> if you either:
@@ -225,17 +225,19 @@ Read about the cookies we use<% end %>.
       <li>think that your personal data has been misused or mishandled</li>
     </ul>
 
-    <p>You can also contact the Cabinet Office Data Protection Officer.</p>
-
-    <p><%= govuk_link_to "DPO@cabinetoffice.gov.uk", "mailto:DPO@cabinetoffice.gov.uk" %></p>
-
-    <p>Data Protection Officer</p>
-
-    <p>Cabinet Office</p>
-
-    <p>70 Whitehall</p>
-
-    <p>London SW1A 2AS</p>
+    <p>
+      You can also contact the Cabinet Office Data Protection Officer.
+      <br>
+      <%= govuk_link_to "DPO@cabinetoffice.gov.uk", "mailto:DPO@cabinetoffice.gov.uk" %>
+      <br>
+      Data Protection Officer
+      <br>
+      Cabinet Office
+      <br>
+      70 Whitehall
+      <br>
+      London SW1A 2AS
+    </p>
 
     <p>
       If you have a complaint, you can also contact the
@@ -246,18 +248,20 @@ Read about the cookies we use<% end %>.
       rights.
     </p>
 
-    <p>Information Commissioner’s Office</p>
-
-    <p><%= govuk_link_to "icocasework@ico.org.uk", "mailto:icocasework@ico.org.uk" %></p>
-
-    <p>0303 123 1113</p>
-
-    <p>Wycliffe House</p>
-
-    <p>Water Lane</p>
-
-    <p>Wilmslow</p>
-
-    <p>Cheshire SK9 5AF</p>
+    <p>
+      Information Commissioner’s Office
+      <br>
+      <%= govuk_link_to "icocasework@ico.org.uk", "mailto:icocasework@ico.org.uk" %>
+      <br />
+      0303 123 1113
+      <br />
+      Wycliffe House
+      <br />
+      Water Lane
+      <br />
+      Wilmslow
+      <br />
+      Cheshire SK9 5AF
+    </p>
   </div>
 </div>

--- a/app/views/forms/privacy_page/show.html.erb
+++ b/app/views/forms/privacy_page/show.html.erb
@@ -1,0 +1,263 @@
+<% set_page_title("Title") %>
+<% content_for :before_content do %>
+  <% if @back_link.present? %>
+    <%= link_to "Back", @back_link, class: "govuk-back-link" %>
+  <% end %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Privacy notice: how we use your data</h1>
+    <p>Last updated: 20 September 2022</p>
+    <p>
+      This form was created using GOV.UK Forms. GOV.UK Forms is a product
+      provided by the Government Digital Service (GDS) which is part of the
+      Cabinet Office. It lets UK government teams create online forms to collect
+      information from people and organisations.
+    </p>
+
+    <p>
+      The organisation that created this online form using GOV.UK Forms is the
+      data controller of personal data they collect using the form, whilst the
+      Cabinet Office, through GDS, is the data processor. The data controller
+      must tell you about what they are doing with your personal data -
+      <%= govuk_link_to @privacy_policy_url do %>read the data controller’s privacy information for this form<% end %>.
+    </p>
+
+    <p>
+      The Cabinet Office also collects some data as a data controller. This
+      privacy notice explains what personal data the Cabinet Office collects and
+      processes as a data controller through forms made with GOV.UK Forms.
+    </p>
+
+    <p>
+      Read
+      <a href="https://ico.org.uk/ESDWebPages/Entry/Z7414053"
+        >the Cabinet Office’s entry in the Data Protection Public Register</a
+      >
+      for more information.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Data we collect from you and what we do with it
+    </h2>
+
+    <p>When you use this form your device sends information such as your:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>IP address</li>
+      <li>
+        <a
+          href="https://draft-origin.publishing.service.gov.uk/support/browsers"
+          >web browser</a
+        >
+        and version number
+      </li>
+      <li>time zone and language settings</li>
+    </ul>
+
+    <p>We use this information to:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>give you the information and web pages you request</li>
+      <li>monitor the use of the site for security threats</li>
+      <li>
+        monitor the performance of the site to identify inefficiencies and
+        JavaScript errors
+      </li>
+    </ul>
+
+    <p>
+      We collect this information in system logs. These logs are stored in
+      Amazon Web Services in Ireland.
+    </p>
+
+    <p>
+      We move some of this information to our security and network monitoring
+      tools in Ireland and the USA which are provided by companies acting as our
+      data processors.
+    </p>
+
+    <p>
+      We may also use this information to produce anonymised reports about the
+      GOV.UK Forms service. This helps us understand where we can make
+      improvements. We may share this information with the data controller of
+      the form.
+    </p>
+
+    <p>
+      If you email us feedback about this form, we’ll collect your email address
+      and any other personal information you choose to include in your email.
+    </p>
+
+    <p>
+      We may share your data with data controllers where it is appropriate. For
+      example, if you provide feedback that relates to their function or if you
+      make a data protection request.
+    </p>
+
+    <p>The legal basis for processing this data is that it’s necessary:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>to perform a task in the public interest</li>
+      <li>in the exercise of our functions as a government department</li>
+    </ul>
+
+    <p>We will not:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>sell or rent your data to third parties</li>
+      <li>share your data with third parties for marketing purposes</li>
+    </ul>
+
+    <p>
+      We will share your data if we are required to do so by law – for example,
+      by court order, or to prevent fraud or other crime.
+    </p>
+
+    <h2 class="govuk-heading-l">Cookies</h2>
+
+    <p>
+      We use cookies to make this form work.
+      <%= govuk_link_to cookies_path do %>
+Read about the cookies we use<% end %>.
+    </p>
+
+    <h2 class="govuk-heading-l">How long we keep your data</h2>
+
+    <p>We will only keep your personal data for as long as:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the law requires us to</li>
+      <li>we need it for the purposes listed above</li>
+    </ul>
+
+    <p>This means that we will only hold your personal data for one year.</p>
+
+    <h2 class="govuk-heading-l">
+      Where your data is processed and stored
+    </h2>
+
+    <p>
+      Your personal data may be transferred outside the United Kingdom while
+      being processed by GDS. If this happens, we’ll make sure you’re given the
+      same level of technical and legal protection as you are within the United
+      Kingdom by relying on the UK Government’s data adequacy decisions or by
+      including clauses in contracts that require the recipient to protect the
+      data in accordance with UK standards.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      How we protect your data and keep it secure
+    </h2>
+
+    <p>
+      We are committed to doing all that we can to keep your data secure. To
+      prevent unauthorised access or disclosure we have put in place technical
+      and organisational procedures to secure the data we collect about you –
+      for example, we protect your data using varying levels of encryption. We
+      also make sure that any third parties that we deal with have an obligation
+      to keep all personal data they process on our behalf secure.
+    </p>
+
+    <h2 class="govuk-heading-l">Children’s privacy protection</h2>
+
+    <p>
+      We understand the importance of protecting children’s privacy online. Our
+      services are not designed for, or intentionally targeted at, children 13
+      years of age or younger. It is not our policy to intentionally collect or
+      maintain data about anyone under the age of 13.
+    </p>
+
+    <h2 class="govuk-heading-l">What are your rights</h2>
+
+    <p>You have the right to request:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>information about how your personal data is processed</li>
+      <li>
+        a copy of that personal data - this copy will be provided in a
+        structured, commonly used and machine-readable format
+      </li>
+      <li>
+        that anything inaccurate in your personal data is corrected immediately
+      </li>
+    </ul>
+
+    <p>You can also:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>raise an objection about how your personal data is processed</li>
+      <li>
+        request that your personal data is erased if there is no longer a
+        justification for it
+      </li>
+      <li>
+        ask that the processing of your personal data is restricted in certain
+        circumstances
+      </li>
+    </ul>
+
+    <p>
+      If you have any of these requests, get in contact with our Data Protection
+      Officer - you can find their contact details below.
+    </p>
+
+    <h2 class="govuk-heading-l">Changes to this notice</h2>
+
+    <p>
+      We may modify or amend this privacy notice at our discretion at any time.
+      When we make changes to this notice, we will amend the last modified date
+      at the top of this page. Any modification or amendment to this privacy
+      notice will be applied to you and your data as of that revision date. We
+      encourage you to periodically review this privacy notice to be informed
+      about how we are protecting your data.
+    </p>
+
+    <h2 class="govuk-heading-l">Questions and complaints</h2>
+
+    <p>
+      Contact <%= govuk_link_to "gds-privacy-office@digital.cabinet-office.gov.uk", "mailto:gds-privacy-office@digital.cabinet-office.gov.uk" %> if you either:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>have questions about anything in this document</li>
+      <li>think that your personal data has been misused or mishandled</li>
+    </ul>
+
+    <p>You can also contact the Cabinet Office Data Protection Officer.</p>
+
+    <p><%= govuk_link_to "DPO@cabinetoffice.gov.uk", "mailto:DPO@cabinetoffice.gov.uk" %></p>
+
+    <p>Data Protection Officer</p>
+
+    <p>Cabinet Office</p>
+
+    <p>70 Whitehall</p>
+
+    <p>London SW1A 2AS</p>
+
+    <p>
+      If you have a complaint, you can also contact the
+      <a href="https://ico.org.uk/"
+        >Information Commissioner’s Office</a
+      >
+      (ICO). The ICO is an independent regulator set up to uphold information
+      rights.
+    </p>
+
+    <p>Information Commissioner’s Office</p>
+
+    <p><%= govuk_link_to "icocasework@ico.org.uk", "mailto:icocasework@ico.org.uk" %></p>
+
+    <p>0303 123 1113</p>
+
+    <p>Wycliffe House</p>
+
+    <p>Water Lane</p>
+
+    <p>Wilmslow</p>
+
+    <p>Cheshire SK9 5AF</p>
+  </div>
+</div>

--- a/app/views/forms/privacy_page/show.html.erb
+++ b/app/views/forms/privacy_page/show.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title("Title") %>
+<% set_page_title("Privacy") %>
 <% content_for :before_content do %>
   <% if @back_link.present? %>
     <%= link_to "Back", @back_link, class: "govuk-back-link" %>

--- a/app/views/help/cookies.html.erb
+++ b/app/views/help/cookies.html.erb
@@ -11,11 +11,11 @@
 
     <h2 class="govuk-heading-l">Essential cookies</h2>
 
-    <p>This essential cookie remembers your progress through the form. We do not need to ask permission to use it.</p>
+    <p>We use essential cookies to make this form work. UK law does not require us to ask for consent for these cookies because they are essential for the service to function.</p>
 
     <%= govuk_table(rows: [
       ["Name", "Purpose", "Expires"],
       ["_forms", "Used to remember your progress through the form", "When the browser is closed or after 20 hours"],
-    ], caption: "Essential cookies") %>
+    ]) %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,8 +50,8 @@
     </div>
 
     <% meta_links = {t("footer.accessibility_statement") => accessibility_statement_path, t("footer.cookies") => cookies_path} %>
-    <% if @privacy_policy_url.present? %>
-      <% meta_links[t("footer.privacy_policy")] = @privacy_policy_url %>
+    <% if @current_context.present? %>
+      <% meta_links[t("footer.privacy_policy")] = form_privacy_path(@current_context.form) %>
     <% end -%>
 
     <%= govuk_footer meta_items_title: t("footer.helpful_links"), meta_items: meta_links %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     get "/:form_id/check_your_answers" => "forms/check_your_answers#show", as: :check_your_answers
     post "/:form_id/submit_answers" => "forms/submit_answers#submit_answers", as: :form_submit_answers
     get "/:form_id/submitted" => "forms/submitted#submitted", as: :form_submitted
+    get "/:form_id/privacy" => "forms/privacy_page#show", as: :form_privacy
     get "/:form_id/:page_slug/change" => "forms/page#show", as: :form_change_answer, defaults: { changing_existing_answer: true }
     get "/:form_id/:page_slug" => "forms/page#show", as: :form_page
     post "/:form_id/:page_slug" => "forms/page#save", as: :save_form_page

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe EventLogger do
         start_page: "1",
         privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
         what_happens_next_text: "Good things come to those that wait",
-        pages: [page]
+        pages: [page],
       }),
       store: {},
     )

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -98,6 +98,18 @@ RSpec.describe "Form controller", type: :request do
         it "Returns the correct X-Robots-Tag header" do
           expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
         end
+
+        describe "Privacy page" do
+          it "returns http code 200" do
+            get form_privacy_path(mode: "form", form_id: 2)
+            expect(response).to have_http_status(:ok)
+          end
+
+          it "contains link to data controller's privacy policy" do
+            get form_privacy_path(mode: "form", form_id: 2)
+            expect(response.body).to include("http://www.example.gov.uk/privacy_policy")
+          end
+        end
       end
 
       context "when a form doesn't exists" do


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds a new privacy page, containing both a link to the existing user-generated privacy policy, and our own privacy information.

Trello card: https://trello.com/c/wFxazV7I/144-add-privacy-page-to-the-runner

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


