### PR TITLE
Add form_slug to urls

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -6,7 +6,7 @@ class FormController < Forms::FormController
   def show
     @form = Form.find(params.require(:form_id))
     if @form.start_page
-      redirect_to form_page_path(params.require(:form_id), @form.start_page)
+      redirect_to form_page_path(params.require(:form_id), @form.form_slug, @form.start_page)
       unless preview?
         EventLogger.log_form_event(Context.new(form: @form, store: session), request, "visit")
       end

--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -3,6 +3,11 @@ class FormController < Forms::FormController
     render template: "errors/not_found", status: :not_found
   end
 
+  def redirect_to_user_friendly_url
+    @form = Form.find(params.require(:form_id))
+    redirect_to form_path(@form.id, @form.form_slug)
+  end
+
   def show
     @form = Form.find(params.require(:form_id))
     if @form.start_page

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -1,10 +1,10 @@
 module Forms
   class CheckYourAnswersController < FormController
     def show
-      return redirect_to form_page_path(current_context.form, current_context.next_page_slug) unless current_context.can_visit?("check_your_answers")
+      return redirect_to form_page_path(current_context.form, current_context.form_slug, current_context.next_page_slug) unless current_context.can_visit?("check_your_answers")
 
       previous_step = current_context.previous_step("check_your_answers")
-      @back_link = form_page_path(current_context.form, previous_step)
+      @back_link = form_page_path(current_context.form, current_context.form_slug, previous_step)
       @rows = check_your_answers_rows
       unless preview?
         EventLogger.log_form_event(current_context, request, "check_answers")
@@ -18,7 +18,7 @@ module Forms
       {
         key: { text: question_name },
         value: { text: page.show_answer },
-        actions: [{ href: form_change_answer_path(page.form_id, page.page_id), visually_hidden_text: question_name }],
+        actions: [{ href: form_change_answer_path(page.form_id, page.form_slug, page.page_id), visually_hidden_text: question_name }],
       }
     end
 

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -3,7 +3,7 @@ module Forms
     before_action :prepare_step, :changing_existing_answer
 
     def show
-      redirect_to form_page_path(@step.form_id, current_context.next_page_slug) unless current_context.can_visit?(@step.page_slug)
+      redirect_to form_page_path(@step.form_id, @step.form_slug, current_context.next_page_slug) unless current_context.can_visit?(@step.page_slug)
       back_link(@step.page_slug)
     end
 
@@ -46,9 +46,9 @@ module Forms
 
     def next_page
       if @changing_existing_answer
-        check_your_answers_path(current_context.form)
+        check_your_answers_path(form_id: current_context.form, form_slug: current_context.form_slug)
       else
-        form_page_path(@step.form_id, @step.next_page_slug)
+        form_page_path(@step.form_id, @step.form_slug, @step.next_page_slug)
       end
     end
 

--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -1,4 +1,5 @@
 class Context
+  attr_accessor :form_slug
   attr_reader :form_name, :form_start_page, :privacy_policy_url, :what_happens_next_text
 
   def initialize(form:, store:)
@@ -8,6 +9,7 @@ class Context
 
     @completed_steps = @journey.completed_steps
     @form_id = form.id
+    @form_slug = form.form_slug
     @form_name = form.name
     @form_start_page = form.start_page
     @privacy_policy_url = form.privacy_policy_url

--- a/app/lib/step_factory.rb
+++ b/app/lib/step_factory.rb
@@ -16,6 +16,7 @@ class StepFactory
 
     @submission_email = form.submission_email
     @form_id = form.id
+    @form_slug = form.form_slug
   end
 
   def create_step(page_slug_or_start)
@@ -32,7 +33,7 @@ class StepFactory
     next_page_slug = page.has_next_page? ? page.next_page.to_s : CHECK_YOUR_ANSWERS_PAGE
     question = QuestionRegister.from_page(page)
 
-    Step.new(question:, page_id: page.id, form_id: @form_id, next_page_slug:, page_slug:)
+    Step.new(question:, page_id: page.id, form_id: @form_id, form_slug: @form_slug, next_page_slug:, page_slug:)
   end
 
   def start_step

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,13 +1,13 @@
 class Step
-  attr_accessor :page_id, :form_id, :question
+  attr_accessor :page_id, :form_id, :form_slug, :question
   attr_reader :next_page_slug, :page_slug
 
-  def initialize(question:, page_id:, form_id:, next_page_slug:, page_slug:)
+  def initialize(question:, page_id:, form_id:, form_slug:, next_page_slug:, page_slug:)
     @question = question
     @page_id = page_id
     @page_slug = page_slug
     @form_id = form_id
-
+    @form_slug = form_slug
     @next_page_slug = next_page_slug
   end
 

--- a/app/views/forms/page/show.html.erb
+++ b/app/views/forms/page/show.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @step.question, url: save_form_page_path(@step.form_id, @step.id, :changing_existing_answer => @changing_existing_answer), scope: :question, method: :post do |form| %>
+    <%= form_with model: @step.question, url: save_form_page_path(@step.form_id, @step.form_slug, @step.id, :changing_existing_answer => @changing_existing_answer), scope: :question, method: :post do |form| %>
       <% if @step.question&.errors&.any? %>
         <%= form.govuk_error_summary %>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
     <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 
     <% if @current_context.present? %>
-      <%= govuk_header(service_name: @current_context.form_name, homepage_url: "https://www.gov.uk/", service_url: form_path(id: @current_context.form)) %>
+      <%= govuk_header(service_name: @current_context.form_name, homepage_url: "https://www.gov.uk/", service_url: form_path(form_id: @current_context.form, form_slug: @current_context.form_slug)) %>
     <% else %>
       <%= govuk_header(homepage_url: "https://www.gov.uk/") %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get "/help/cookies" => "help#cookies", as: :cookies
 
   scope "/:mode", mode: /preview-form|form/ do
+    get "/:form_id" => "form#redirect_to_user_friendly_url", as: :form_id
     scope "/:form_id/:form_slug" do
       get "/" => "form#show", as: :form
       get "/check_your_answers" => "forms/check_your_answers#show", as: :check_your_answers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,14 +10,17 @@ Rails.application.routes.draw do
   get "/help/cookies" => "help#cookies", as: :cookies
 
   scope "/:mode", mode: /preview-form|form/ do
-    get "/:form_id/:form_slug" => "form#show", as: :form
-    get "/:form_id/:form_slug/check_your_answers" => "forms/check_your_answers#show", as: :check_your_answers
-    post "/:form_id/:form_slug/submit_answers" => "forms/submit_answers#submit_answers", as: :form_submit_answers
-    get "/:form_id/:form_slug/submitted" => "forms/submitted#submitted", as: :form_submitted
-    get "/:form_id/:form_slug/privacy" => "forms/privacy_page#show", as: :form_privacy
-    get "/:form_id/:form_slug/:page_slug/change" => "forms/page#show", as: :form_change_answer, defaults: { changing_existing_answer: true }
-    get "/:form_id/:form_slug/:page_slug" => "forms/page#show", as: :form_page
-    post "/:form_id/:form_slug/:page_slug" => "forms/page#save", as: :save_form_page
+    scope "/:form_id/:form_slug" do
+      get "/" => "form#show", as: :form
+      get "/check_your_answers" => "forms/check_your_answers#show", as: :check_your_answers
+      post "/submit_answers" => "forms/submit_answers#submit_answers", as: :form_submit_answers
+      get "/submitted" => "forms/submitted#submitted", as: :form_submitted
+      get "/privacy" => "forms/privacy_page#show", as: :form_privacy
+      get "/:page_slug/change" => "forms/page#show", as: :form_change_answer, defaults: { changing_existing_answer: true }
+      get "/:page_slug" => "forms/page#show", as: :form_page
+      post "/:page_slug" => "forms/page#save", as: :save_form_page
+    end
+
   end
 
   get "/404", to: "errors#not_found", as: :error_404, via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,14 +10,14 @@ Rails.application.routes.draw do
   get "/help/cookies" => "help#cookies", as: :cookies
 
   scope "/:mode", mode: /preview-form|form/ do
-    get "/:form_id" => "form#show", as: :form
-    get "/:form_id/check_your_answers" => "forms/check_your_answers#show", as: :check_your_answers
-    post "/:form_id/submit_answers" => "forms/submit_answers#submit_answers", as: :form_submit_answers
-    get "/:form_id/submitted" => "forms/submitted#submitted", as: :form_submitted
-    get "/:form_id/privacy" => "forms/privacy_page#show", as: :form_privacy
-    get "/:form_id/:page_slug/change" => "forms/page#show", as: :form_change_answer, defaults: { changing_existing_answer: true }
-    get "/:form_id/:page_slug" => "forms/page#show", as: :form_page
-    post "/:form_id/:page_slug" => "forms/page#save", as: :save_form_page
+    get "/:form_id/:form_slug" => "form#show", as: :form
+    get "/:form_id/:form_slug/check_your_answers" => "forms/check_your_answers#show", as: :check_your_answers
+    post "/:form_id/:form_slug/submit_answers" => "forms/submit_answers#submit_answers", as: :form_submit_answers
+    get "/:form_id/:form_slug/submitted" => "forms/submitted#submitted", as: :form_submitted
+    get "/:form_id/:form_slug/privacy" => "forms/privacy_page#show", as: :form_privacy
+    get "/:form_id/:form_slug/:page_slug/change" => "forms/page#show", as: :form_change_answer, defaults: { changing_existing_answer: true }
+    get "/:form_id/:form_slug/:page_slug" => "forms/page#show", as: :form_page
+    post "/:form_id/:form_slug/:page_slug" => "forms/page#save", as: :save_form_page
   end
 
   get "/404", to: "errors#not_found", as: :error_404, via: :all

--- a/spec/lib/context_spec.rb
+++ b/spec/lib/context_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Context do
   end
 
   let(:form) do
-    f = Form.new({ id: 1, name: "Form", submission_email: "jimbo@example.gov.uk", start_page: "1", privacy_policy_url: "http://www.example.gov.uk", what_happens_next_text: "Good things come to those that wait", pages: })
+    f = Form.new({ id: 1, name: "Form", form_slug: "form", submission_email: "jimbo@example.gov.uk", start_page: "1", privacy_policy_url: "http://www.example.gov.uk", what_happens_next_text: "Good things come to those that wait", pages: })
     f.pages[0].form = f
     f.pages[1].form = f
     f

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe EventLogger do
     Context.new(
       form: Form.new({
         id: 1,
-        name: "Form",
+        name: "Form 1",
+        form_slug: "form-1",
         submission_email: "jimbo@example.gov.uk",
         start_page: "1",
         privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
@@ -35,7 +36,7 @@ RSpec.describe EventLogger do
     {
       url: "http://example.gov.uk",
       method: "GET",
-      form: "Form",
+      form: "Form 1",
     }
   end
 
@@ -43,7 +44,7 @@ RSpec.describe EventLogger do
     {
       url: "http://example.gov.uk",
       method: "GET",
-      form: "Form",
+      form: "Form 1",
       question_text: "Question one",
     }
   end

--- a/spec/requests/check_your_answers_spec.rb
+++ b/spec/requests/check_your_answers_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe "Check Your Answers Controller", type: :request do
   let(:form_data) do
     {
       id: 2,
-      name: "Form",
+      name: "Form 1",
+      form_slug: "form-1",
       submission_email: "submission@email.com",
       start_page: 1,
       privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
@@ -50,18 +51,18 @@ RSpec.describe "Check Your Answers Controller", type: :request do
     context "with preview mode on" do
       context "without any questions answered" do
         it "redirects to first incomplete page of form" do
-          get check_your_answers_path(mode: "preview-form", form_id: 2)
+          get check_your_answers_path(mode: "preview-form", form_id: 2, form_slug: "form-1")
           expect(response.status).to eq(302)
-          expect(response.location).to eq(form_page_url(2, 1))
+          expect(response.location).to eq(form_page_url(2, "form-1", 1))
         end
       end
 
       context "with all questions answered and valid" do
         before do
-          post save_form_page_path("preview-form", 2, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-          post save_form_page_path("preview-form", 2, 2), params: { question: { text: "answer text" }, changing_existing_answer: false }
+          post save_form_page_path("preview-form", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+          post save_form_page_path("preview-form", 2, "form-1", 2), params: { question: { text: "answer text" }, changing_existing_answer: false }
           allow(EventLogger).to receive(:log).at_least(:once)
-          get check_your_answers_path(mode: "preview-form", form_id: 2)
+          get check_your_answers_path(mode: "preview-form", form_id: 2, form_slug: "form-1")
         end
 
         it "returns 200" do
@@ -69,7 +70,7 @@ RSpec.describe "Check Your Answers Controller", type: :request do
         end
 
         it "Displays a back link to the last page of the form" do
-          expect(response.body).to include(form_page_path("preview-form", 2, 2))
+          expect(response.body).to include(form_page_path("preview-form", 2, "form-1", 2))
         end
 
         it "Returns the correct X-Robots-Tag header" do
@@ -77,8 +78,8 @@ RSpec.describe "Check Your Answers Controller", type: :request do
         end
 
         it "Contains a change link for each page" do
-          expect(response.body).to include(form_change_answer_path(2, 1))
-          expect(response.body).to include(form_change_answer_path(2, 2))
+          expect(response.body).to include(form_change_answer_path(2, "form-1", 1))
+          expect(response.body).to include(form_change_answer_path(2, "form-1", 2))
         end
 
         it "does not log the form_check_answers event" do
@@ -90,18 +91,18 @@ RSpec.describe "Check Your Answers Controller", type: :request do
     context "with preview mode off" do
       context "without any questions answered" do
         it "redirects to first incomplete page of form" do
-          get check_your_answers_path(mode: "form", form_id: 2)
+          get check_your_answers_path(mode: "form", form_id: 2, form_slug: "form-1")
           expect(response.status).to eq(302)
-          expect(response.location).to eq(form_page_url(2, 1))
+          expect(response.location).to eq(form_page_url(2, "form-1", 1))
         end
       end
 
       context "with all questions answered and valid" do
         before do
-          post save_form_page_path("form", 2, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-          post save_form_page_path("form", 2, 2), params: { question: { text: "answer text" }, changing_existing_answer: false }
+          post save_form_page_path("form", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+          post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "answer text" }, changing_existing_answer: false }
           allow(EventLogger).to receive(:log).at_least(:once)
-          get check_your_answers_path(mode: "form", form_id: 2)
+          get check_your_answers_path(mode: "form", form_id: 2, form_slug: "form-1")
         end
 
         it "returns 200" do
@@ -109,7 +110,7 @@ RSpec.describe "Check Your Answers Controller", type: :request do
         end
 
         it "Displays a back link to the last page of the form" do
-          expect(response.body).to include(form_page_path("form", 2, 2))
+          expect(response.body).to include(form_page_path("form", 2, "form-1", 2))
         end
 
         it "Returns the correct X-Robots-Tag header" do
@@ -117,12 +118,12 @@ RSpec.describe "Check Your Answers Controller", type: :request do
         end
 
         it "Contains a change link for each page" do
-          expect(response.body).to include(form_change_answer_path(2, 1))
-          expect(response.body).to include(form_change_answer_path(2, 2))
+          expect(response.body).to include(form_change_answer_path(2, "form-1", 1))
+          expect(response.body).to include(form_change_answer_path(2, "form-1", 2))
         end
 
         it "Logs the form_check_answers event" do
-          expect(EventLogger).to have_received(:log).with("form_check_answers", { form: "Form", method: "GET", url: "http://www.example.com/form/2/check_your_answers" })
+          expect(EventLogger).to have_received(:log).with("form_check_answers", { form: "Form 1", method: "GET", url: "http://www.example.com/form/2/form-1/check_your_answers" })
         end
       end
     end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe "Errors", type: :request do
       {
         id: 2,
         name: "Form name",
+        form_slug: "form-name",
         submission_email: "submission@email.com",
         start_page: 1,
       }.to_json
@@ -71,7 +72,7 @@ RSpec.describe "Errors", type: :request do
     end
 
     it "returns http code 500" do
-      post form_submit_answers_path(mode: "form", form_id: 2)
+      post form_submit_answers_path(mode: "form", form_id: 2, form_slug: "form-name")
       expect(response).to have_http_status(:internal_server_error)
     end
   end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -62,6 +62,18 @@ RSpec.describe "Form controller", type: :request do
     end
   end
 
+  describe "#redirect_to_user_friendly_url" do
+    context "when the form exists and has no start page" do
+      before do
+        get form_id_path(mode:"form", form_id: 2)
+      end
+
+      it "Redirects to the form page that includes the form slug" do
+        expect(response).to redirect_to(form_path("form", 2, "form-name"))
+      end
+    end
+  end
+
   describe "#show" do
     context "with preview mode on" do
       context "when a form exists" do

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Form controller", type: :request do
     {
       id: 2,
       name: "Form name",
+      form_slug: "form-name",
       submission_email: "submission@email.com",
       start_page: "1",
       privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
@@ -65,12 +66,12 @@ RSpec.describe "Form controller", type: :request do
     context "with preview mode on" do
       context "when a form exists" do
         before do
-          get form_path(mode: "preview-form", form_id: 2)
+          get form_path(mode: "preview-form", form_id: 2, form_slug: "form-name")
         end
 
         context "when the form has a start page" do
           it "Redirects to the first page" do
-            expect(response).to redirect_to(form_page_path("preview-form", 2, 1))
+            expect(response).to redirect_to(form_page_path("preview-form", 2, "form-name", 1))
           end
 
           it "does not log the form_visit event" do
@@ -83,6 +84,7 @@ RSpec.describe "Form controller", type: :request do
             {
               id: 2,
               name: "Form name",
+              form_slug: "form-name",
               submission_email: "submission@email.com",
               start_page: nil,
               privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
@@ -101,12 +103,12 @@ RSpec.describe "Form controller", type: :request do
 
         describe "Privacy page" do
           it "returns http code 200" do
-            get form_privacy_path(mode: "form", form_id: 2)
+            get form_privacy_path(mode: "form", form_id: 2, form_slug: "form-name")
             expect(response).to have_http_status(:ok)
           end
 
           it "contains link to data controller's privacy policy" do
-            get form_privacy_path(mode: "form", form_id: 2)
+            get form_privacy_path(mode: "form", form_id: 2, form_slug: "form-name")
             expect(response.body).to include("http://www.example.gov.uk/privacy_policy")
           end
         end
@@ -114,7 +116,7 @@ RSpec.describe "Form controller", type: :request do
 
       context "when a form doesn't exists" do
         before do
-          get form_path(mode: "preview-form", form_id: 9999)
+          get form_path(mode: "preview-form", form_id: 9999, form_slug: "form-name-1")
         end
 
         it "Render the not found page" do
@@ -131,6 +133,7 @@ RSpec.describe "Form controller", type: :request do
           {
             id: 2,
             name: "Form name",
+            form_slug: "form-name",
             submission_email: "submission@email.com",
             start_page: nil,
             privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
@@ -139,7 +142,7 @@ RSpec.describe "Form controller", type: :request do
         end
 
         before do
-          get form_path(mode: "preview-form", form_id: 9999)
+          get form_path(mode: "preview-form", form_id: 9999, form_slug: "form-name")
         end
 
         it "Render the not found page" do
@@ -155,16 +158,16 @@ RSpec.describe "Form controller", type: :request do
     context "with preview mode off" do
       context "when a form exists" do
         before do
-          get form_path(mode: "form", form_id: 2)
+          get form_path(mode: "form", form_id: 2, form_slug: "form-name")
         end
 
         context "when the form has a start page" do
           it "Redirects to the first page" do
-            expect(response).to redirect_to(form_page_path("form", 2, 1))
+            expect(response).to redirect_to(form_page_path("form", 2, "form-name", 1))
           end
 
           it "Logs the form_visit event" do
-            expect(EventLogger).to have_received(:log).with("form_visit", { form: "Form name", method: "GET", url: "http://www.example.com/form/2" })
+            expect(EventLogger).to have_received(:log).with("form_visit", { form: "Form name", method: "GET", url: "http://www.example.com/form/2/form-name" })
           end
         end
 
@@ -173,6 +176,7 @@ RSpec.describe "Form controller", type: :request do
             {
               id: 2,
               name: "Form name",
+              form_slug: "form-name",
               submission_email: "submission@email.com",
               start_page: nil,
               privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
@@ -192,7 +196,7 @@ RSpec.describe "Form controller", type: :request do
 
       context "when a form doesn't exists" do
         before do
-          get form_path(mode: "form", form_id: 9999)
+          get form_path(mode: "form", form_id: 9999, form_slug: "form-name")
         end
 
         it "Render the not found page" do
@@ -209,7 +213,7 @@ RSpec.describe "Form controller", type: :request do
   describe "#submit_answers" do
     context "with preview mode on" do
       before do
-        post form_submit_answers_path("preview-form", 2, 1)
+        post form_submit_answers_path("preview-form", 2, "form-name", 1)
       end
 
       it "does not log the form_submission event" do
@@ -219,11 +223,11 @@ RSpec.describe "Form controller", type: :request do
 
     context "with preview mode off" do
       before do
-        post form_submit_answers_path("form", 2, 1)
+        post form_submit_answers_path("form", 2, "form-name", 1)
       end
 
       it "Logs the form_submission event" do
-        expect(EventLogger).to have_received(:log).with("form_submission", { form: "Form name", method: "POST", url: "http://www.example.com/form/2/submit_answers.1" })
+        expect(EventLogger).to have_received(:log).with("form_submission", { form: "Form name", method: "POST", url: "http://www.example.com/form/2/form-name/submit_answers.1" })
       end
     end
   end

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe "Page Controller", type: :request do
   let(:form_data) do
     {
       id: 2,
-      name: "Form",
+      name: "Form 1",
+      form_slug: "form-1",
       submission_email: "submission@email.com",
       start_page: 1,
       privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
@@ -49,128 +50,128 @@ RSpec.describe "Page Controller", type: :request do
   describe "#show" do
     context "with preview mode on" do
       it "Returns a 200" do
-        get form_page_path("preview-form", 2, 1)
+        get form_page_path("preview-form", 2, "form-1", 1)
         expect(response.status).to eq(200)
       end
 
       it "redirects to first page if second request before first complete" do
-        get form_page_path("preview-form", 2, 2)
-        expect(response).to redirect_to(form_page_path(2, 1))
+        get form_page_path("preview-form", 2, "form-1", 2)
+        expect(response).to redirect_to(form_page_path(2, "form-1", 1))
       end
 
       it "Displays the question text on the page" do
-        get form_page_path("preview-form", 2, 1)
+        get form_page_path("preview-form", 2, "form-1", 1)
         expect(response.body).to include("Question one")
       end
 
       it "Displays the privacy policy link on the page" do
-        get form_page_path("preview-form", 2, 1)
+        get form_page_path("preview-form", 2, "form-1", 1)
         expect(response.body).to include("Privacy")
       end
 
       it "Displays the accessibility statement link on the page" do
-        get form_page_path("preview-form", 2, 1)
+        get form_page_path("preview-form", 2, "form-1", 1)
         expect(response.body).to include("Accessibility statement")
       end
 
       it "Displays the Cookies link on the page" do
-        get form_page_path("preview-form", 2, 1)
+        get form_page_path("preview-form", 2, "form-1", 1)
         expect(response.body).to include("Cookies")
       end
 
       context "with a page that has a previous page" do
         it "Displays a link to the previous page" do
-          get form_page_path("preview-form", 2, 2)
-          expect(response.body).to include(form_page_path(2, 1))
+          get form_page_path("preview-form", 2, "form-1", 2)
+          expect(response.body).to include(form_page_path(2, "form-1", 1))
         end
       end
 
       context "with a change answers page" do
         it "Displays a back link to the check your answers page" do
-          get form_change_answer_path("preview-form", 2, 1)
-          expect(response.body).to include(check_your_answers_path("preview-form", 2))
+          get form_change_answer_path("preview-form", 2, "form-1", 1)
+          expect(response.body).to include(check_your_answers_path("preview-form", 2, "form-1"))
         end
 
         it "Passes the changing answers parameter in its submit request" do
-          get form_change_answer_path("preview-form", 2, 1)
-          expect(response.body).to include(save_form_page_path("preview-form", 2, 1, changing_existing_answer: true))
+          get form_change_answer_path("preview-form", 2, "form-1", 1)
+          expect(response.body).to include(save_form_page_path("preview-form", 2, "form-1", 1, changing_existing_answer: true))
         end
       end
 
       it "Returns the correct X-Robots-Tag header" do
-        get form_page_path("preview-form", 2, 1)
+        get form_page_path("preview-form", 2, "form-1", 1)
         expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
       end
 
       context "with no questions answered" do
         it "redirects if a later page is requested" do
-          get check_your_answers_path("preview-form", 2)
+          get check_your_answers_path("preview-form", 2, "form-1")
           expect(response.status).to eq(302)
-          expect(response.location).to eq(form_page_url("preview-form", 2, 1))
+          expect(response.location).to eq(form_page_url("preview-form", 2, "form-1", 1))
         end
       end
     end
 
     context "with preview mode off" do
       it "Returns a 200" do
-        get form_page_path("form", 2, 1)
+        get form_page_path("form", 2, "form-1", 1)
         expect(response.status).to eq(200)
       end
 
       it "redirects to first page if second request before first complete" do
-        get form_page_path("form", 2, 2)
-        expect(response).to redirect_to(form_page_path(2, 1))
+        get form_page_path("form", 2, "form-1", 2)
+        expect(response).to redirect_to(form_page_path(2, "form-1", 1))
       end
 
       it "Displays the question text on the page" do
-        get form_page_path("form", 2, 1)
+        get form_page_path("form", 2, "form-1", 1)
         expect(response.body).to include("Question one")
       end
 
       it "Displays the privacy policy link on the page" do
-        get form_page_path("form", 2, 1)
+        get form_page_path("form", 2, "form-1", 1)
         expect(response.body).to include("Privacy")
       end
 
       it "Displays the accessibility statement link on the page" do
-        get form_page_path("form", 2, 1)
+        get form_page_path("form", 2, "form-1", 1)
         expect(response.body).to include("Accessibility statement")
       end
 
       it "Displays the Cookies link on the page" do
-        get form_page_path("form", 2, 1)
+        get form_page_path("form", 2, "form-1", 1)
         expect(response.body).to include("Cookies")
       end
 
       context "with a page that has a previous page" do
         it "Displays a link to the previous page" do
-          get form_page_path("form", 2, 2)
-          expect(response.body).to include(form_page_path(2, 1))
+          get form_page_path("form", 2, "form-1", 2)
+          expect(response.body).to include(form_page_path(2, "form-1", 1))
         end
       end
 
       context "with a change answers page" do
         it "Displays a back link to the check your answers page" do
-          get form_change_answer_path("form", 2, 1)
-          expect(response.body).to include(check_your_answers_path("form", 2))
+          get form_change_answer_path("form", 2, "form-1", 1)
+          expect(response.body).to include(check_your_answers_path("form", 2, "form-1"))
         end
 
         it "Passes the changing answers parameter in its submit request" do
-          get form_change_answer_path("form", 2, 1)
-          expect(response.body).to include(save_form_page_path("form", 2, 1, changing_existing_answer: true))
+          get form_change_answer_path("form", 2, "form-1", 1)
+          expect(response.body).to include(save_form_page_path("form", 2, "form-1", 1, changing_existing_answer: true))
         end
       end
 
       it "Returns the correct X-Robots-Tag header" do
-        get form_page_path("form", 2, 1)
+        get form_page_path("form", 2, "form-1", 1)
         expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
       end
 
       context "with no questions answered" do
         it "redirects if a later page is requested" do
-          get check_your_answers_path("form", 2)
+          get check_your_answers_path("form", 2, "form-1")
           expect(response.status).to eq(302)
-          expect(response.location).to eq(form_page_url("form", 2, 1))
+          expect(response.location).to eq(form_page_url("form", 2, "form-1", 1))
         end
       end
     end
@@ -179,92 +180,92 @@ RSpec.describe "Page Controller", type: :request do
   describe "#save" do
     context "with preview mode on" do
       it "Redirects to the next page" do
-        post save_form_page_path("preview-form", 2, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path("preview-form", 2, 2))
+        post save_form_page_path("preview-form", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path("preview-form", 2, "form-1", 2))
       end
 
       context "when changing an existing answer" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("preview-form", 2, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
-          expect(response).to redirect_to(check_your_answers_path("preview-form", 2))
+          post save_form_page_path("preview-form", 2, "form-1", 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          expect(response).to redirect_to(check_your_answers_path("preview-form", 2, "form-1"))
         end
 
         it "does not log the change_answer_page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-form", 2, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          post save_form_page_path("preview-form", 2, "form-1", 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
         end
       end
 
       context "with the first page" do
         it "Logs the first_page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-form", 2, 1), params: { question: { text: "answer text" } }
+          post save_form_page_path("preview-form", 2, "form-1", 1), params: { question: { text: "answer text" } }
         end
       end
 
       context "with a subsequent page" do
         it "Logs the page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-form", 2, 2), params: { question: { text: "answer text" } }
+          post save_form_page_path("preview-form", 2, "form-1", 2), params: { question: { text: "answer text" } }
         end
       end
 
       context "with the final page" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("preview-form", 2, 2), params: { question: { text: "answer text" } }
-          expect(response).to redirect_to(check_your_answers_path("preview-form", 2))
+          post save_form_page_path("preview-form", 2, "form-1", 2), params: { question: { text: "answer text" } }
+          expect(response).to redirect_to(check_your_answers_path("preview-form", 2, "form-1"))
         end
       end
     end
 
     context "with preview mode off" do
       it "Redirects to the next page" do
-        post save_form_page_path("form", 2, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path("form", 2, 2))
+        post save_form_page_path("form", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path("form", 2, "form-1", 2))
       end
 
       context "when changing an existing answer" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("form", 2, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
-          expect(response).to redirect_to(check_your_answers_path("form", 2))
+          post save_form_page_path("form", 2, "form-1", 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          expect(response).to redirect_to(check_your_answers_path("form", 2, "form-1"))
         end
 
         it "Logs the change_answer_page_save event" do
           expect(EventLogger).to receive(:log).with("change_answer_page_save",
-                                                    { form: "Form",
+                                                    { form: "Form 1",
                                                       method: "POST",
                                                       question_text: "Question one",
-                                                      url: "http://www.example.com/form/2/1?changing_existing_answer=true&question%5Btext%5D=answer+text" })
-          post save_form_page_path("form", 2, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+                                                      url: "http://www.example.com/form/2/form-1/1?changing_existing_answer=true&question%5Btext%5D=answer+text" })
+          post save_form_page_path("form", 2, "form-1", 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
         end
       end
 
       context "with the first page" do
         it "Logs the first_page_save event" do
           expect(EventLogger).to receive(:log).with("first_page_save",
-                                                    { form: "Form",
+                                                    { form: "Form 1",
                                                       method: "POST",
                                                       question_text: "Question one",
-                                                      url: "http://www.example.com/form/2/1" })
-          post save_form_page_path("form", 2, 1), params: { question: { text: "answer text" } }
+                                                      url: "http://www.example.com/form/2/form-1/1" })
+          post save_form_page_path("form", 2, "form-1", 1), params: { question: { text: "answer text" } }
         end
       end
 
       context "with a subsequent page" do
         it "Logs the page_save event" do
           expect(EventLogger).to receive(:log).with("page_save",
-                                                    { form: "Form",
+                                                    { form: "Form 1",
                                                       method: "POST",
                                                       question_text: "Question two",
-                                                      url: "http://www.example.com/form/2/2" })
-          post save_form_page_path("form", 2, 2), params: { question: { text: "answer text" } }
+                                                      url: "http://www.example.com/form/2/form-1/2" })
+          post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "answer text" } }
         end
       end
 
       context "with the final page" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("form", 2, 2), params: { question: { text: "answer text" } }
-          expect(response).to redirect_to(check_your_answers_path("form", 2))
+          post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "answer text" } }
+          expect(response).to redirect_to(check_your_answers_path("form", 2, "form-1"))
         end
       end
     end


### PR DESCRIPTION
#### What problem does the pull request solve?
We decided to add the form slug to the run
Relates to https://trello.com/c/J5E6JuuY/92-use-human-readable-url-paths-for-forms-instead-of-id-based-paths

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


