### PR TITLE
Add "TEST FORM" to submission email if in preview

### DIFF
--- a/app/controllers/forms/submit_answers_controller.rb
+++ b/app/controllers/forms/submit_answers_controller.rb
@@ -16,7 +16,7 @@ module Forms
 
     def submit_form(text)
       # in the controller for now but can be moved to service object, maybe use actionmailer fo easier testing?
-      NotifyService.new.send_email(current_context.submission_email, current_context.form_name, text)
+      NotifyService.new.send_email(current_context.submission_email, current_context.form_name, text, preview?)
     end
 
     def answers

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -5,7 +5,8 @@ class NotifyService
     @notify_api_key = ENV["NOTIFY_API_KEY"]
   end
 
-  def send_email(email_address, title, text_input)
+  def send_email(email_address, title, text_input, preview_mode: false)
+    @preview_mode = preview_mode
     unless @notify_api_key
       Rails.logger.warn "Warning: no NOTIFY_API_KEY set."
       return nil
@@ -16,6 +17,7 @@ class NotifyService
   end
 
   def email(email_address, title, text_input)
+    title = "TEST FORM: #{title}" if @preview_mode
     timestamp = submission_timestamp
     {
       email_address:,

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -56,6 +56,29 @@ RSpec.describe NotifyService do
         end
       end
     end
+
+    context "with an email subject identifying that it was submitted from preview-form" do
+      let(:submission_datetime) { Time.utc(2022, 12, 14, 10, 00, 00) }
+      it "sends correct values to notify" do
+        fake_notify_client = instance_double(Notifications::Client)
+        allow(fake_notify_client).to receive(:send_email)
+        allow(Notifications::Client).to receive(:new).and_return(fake_notify_client)
+
+        travel_to submission_datetime do
+          notify_service = NotifyService.new
+          notify_service.send_email('fake-email','title','text', preview_mode: true)
+          expect(fake_notify_client).to have_received(:send_email).with(
+            {:email_address=>'fake-email',
+             :personalisation=>{
+               :submission_date=>"14 December 2022",
+               :submission_time=>"10:00:00",
+               :text_input=>'text',
+               :title=>'TEST FORM: title'
+             },
+             :template_id=>"427eb8bc-ce0d-40a3-bf54-d76e8c3ec916"}).once
+        end
+      end
+    end
   end
 
   context "with no api key set" do


### PR DESCRIPTION
#### What problem does the pull request solve?
We wanted to help organisations identify whether a submitted form came from a preview or from an actual form. This was a quick fix because we didn't have any research on what our users needed from previews but we did know that some people were still accessing the preview form, filling it and submitting it to the form submission email inbox. It was difficult to tell from the email if it was real or not.

refers to https://trello.com/c/0IVH9W4B/179-consider-if-we-should-add-test-form-to-the-subject-line-of-emails-sent-from-the-preview-form
#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


