### PR TITLE
Always precompile assets when building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,7 @@ COPY --chown=ruby:ruby . .
 
 # you can't run rails commands like assets:precompile without a secret key set
 # even though the command doesn't use the value itself
-RUN if [ "${RAILS_ENV}" != "development" ]; then \
-  SECRET_KEY_BASE=dummyvalue rails assets:precompile; fi
+RUN SECRET_KEY_BASE=dummyvalue rails assets:precompile
 
 CMD ["bash"]
 


### PR DESCRIPTION
Even to run the local dev setup the `rails assets:precompile` needs to have been run so remove the condition within the Dockerfile.

#### What problem does the pull request solve?
Make it simpler to run forms locally.

#### Checklist

- [x] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


