### PR TITLE
Check that the Dockerfile can be built

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,15 @@
+name: "Docker build"
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  build_the_image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run docker build
+        run: docker build .
+


### PR DESCRIPTION
Build the Dockerfile on PRs and merges to main branch. We're not deploying with the docker images at present but this will help keep them working in the interim.

#### What problem does the pull request solve?
Makes sure that the Dockerfile can be built.

### Testing
The docker-build workflow has passed for this PR. 

### Review Notes
I've added a separate action because for now I think it's ok for people to merge their PRs if the docker build action fails and they need to urgently merge or the fix is beyond the scope of the work, because we're not currently reliant on the docker images other than for local dev. For now we could also only run this action when we merge to main just to make sure we have a regular attempt to build the image with each change made. I'd welcome any thoughts on this.

When we get closer to using docker images for deployment we'll want to be stricter on ensuring this passes before merging. We might also want to bring this docker build check into the main lint and test action nearer the time.

