### PR TITLE
Configure number of instances

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,4 +41,5 @@ jobs:
             --var API_BASE=${{ secrets.API_BASE }} \
             --var API_KEY=${{ secrets.API_KEY }} \
             --var SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
+            --var INSTANCES=2 \
             --var NOTIFY_API_KEY=${{ secrets.NOTIFY_API_KEY }}

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@
 applications:
   - name: forms-runner-((PAAS_ENVIRONMENT))
     memory: 256M
+    instances: ((INSTANCES))
     command: bin/rails server
     services:
       - forms-runner-((PAAS_ENVIRONMENT))-redis


### PR DESCRIPTION
Allow the number of app instances to be configurable when deploying to PaaS. Set the number of instances to 2 in development.

### What problem does the pull request solve?
We should run at least two instances to avoid down time to PaaS maintenance and if an application instance crashes. The number of instances can be configured per environment should more than two be necessary for capacity planning reasons.

Dev has been set to 2 because often issues arise when going from a single to multiple instances and this will allow us to see such problems in dev environments.

Linked with forms-deploy change: https://github.com/alphagov/forms-deploy/pull/11