### PR TITLE
Add number answer type

### DIFF
--- a/app/lib/question_register.rb
+++ b/app/lib/question_register.rb
@@ -15,6 +15,8 @@ class QuestionRegister
               Question::PhoneNumber
             when :long_text
               Question::LongText
+            when :number
+              Question::Number
             else
               raise ArgumentError, "Unexpected answer_type for page #{page.id}: #{page.answer_type}"
             end

--- a/app/models/question/number.rb
+++ b/app/models/question/number.rb
@@ -1,0 +1,7 @@
+module Question
+  class Number < QuestionBase
+    attribute :number
+    validates :number, presence: true
+    validates :number, numericality: { greater_than_or_equal_to: 0 }
+  end
+end

--- a/app/views/question/_number.html.erb
+++ b/app/views/question/_number.html.erb
@@ -1,0 +1,5 @@
+<%#
+  form.govuk_number_field uses the 'number' HTML input type, which the Design System reccomends against:
+  https://design-system.service.gov.uk/components/text-input/#avoid-using-inputs-with-a-type-of-number
+%>
+<%= form.govuk_text_field :number, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, spellcheck: false %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,8 +36,8 @@ en:
         question/number:
           attributes:
             number:
-              blank: Enter an answer
-              greater_than_or_equal_to: The answer must be at least 0
+              blank: Enter a number
+              greater_than_or_equal_to: The answer must be greater than or equal to 0
               not_a_number: The answer must be a number
         question/phone_number:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,7 +60,7 @@ en:
     submitted:
       title: Your form has been submitted
   page_titles:
-    error_prefix: "Error: "
+    error_prefix: 'Error: '
   phase_banner:
     after_link: will help us improve it.
     before_link: This is a new service, your

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,12 @@ en:
             national_insurance_number:
               blank: Enter a National Insurance number
               invalid_national_insurance_number: Enter a National Insurance number that is 2 letters, 6 numbers, then A, B, C or D, like QQ 12 34 56 C
+        question/number:
+          attributes:
+            number:
+              blank: Enter an answer
+              greater_than_or_equal_to: The answer must be at least 0
+              not_a_number: The answer must be a number
         question/phone_number:
           attributes:
             phone_number:
@@ -54,7 +60,7 @@ en:
     submitted:
       title: Your form has been submitted
   page_titles:
-    error_prefix: 'Error: '
+    error_prefix: "Error: "
   phase_banner:
     after_link: will help us improve it.
     before_link: This is a new service, your

--- a/spec/lib/question_register_spec.rb
+++ b/spec/lib/question_register_spec.rb
@@ -3,7 +3,7 @@ require "ostruct"
 
 RSpec.describe QuestionRegister do
   it "returns a class given a valid answer_type" do
-    %i[date single_line address email national_insurance_number phone_number long_text].each do |type|
+    %i[date single_line address email national_insurance_number phone_number long_text number].each do |type|
       page = OpenStruct.new(answer_type: type)
       expect { described_class.from_page(page) }.not_to raise_error
     end

--- a/spec/models/question/long_text_spec.rb
+++ b/spec/models/question/long_text_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Question::LongText, type: :model do
     it "validates without errors" do
       question = described_class.new(text: "a" * 5001)
       question.validate
-			expect(question).not_to be_valid
+      expect(question).not_to be_valid
       expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/long_text.attributes.text.too_long"))
     end
   end

--- a/spec/models/question/number_spec.rb
+++ b/spec/models/question/number_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+require "shared_examples_for_question_models"
+
+RSpec.describe Question::Number, type: :model do
+  it_behaves_like "a question model"
+
+  context "when given an empty string or nil" do
+    it "returns invalid with blank message" do
+      question = described_class.new
+      question.validate
+      expect(question.errors[:number]).to include(I18n.t("activemodel.errors.models.question/number.attributes.number.blank"))
+      question.number = ""
+      question.validate
+      expect(question.errors[:number]).to include(I18n.t("activemodel.errors.models.question/number.attributes.number.blank"))
+    end
+
+    it "shows as a blank string" do
+      question = described_class.new
+      expect(question.show_answer).to eq ""
+    end
+  end
+
+  context "when given a whole number" do
+    it "validates without errors" do
+      question = described_class.new(number: "299792458")
+      question.validate
+      expect(question).to be_valid
+    end
+  end
+
+  context "when given a decimal number" do
+    it "validates without errors" do
+      question = described_class.new(number: "8.5")
+      question.validate
+      expect(question).to be_valid
+    end
+  end
+
+  context "when given a negative number" do
+    it "returns a validation error" do
+      question = described_class.new(number: "-1")
+      question.validate
+      expect(question).not_to be_valid
+      expect(question.errors[:number]).to include(I18n.t("activemodel.errors.models.question/number.attributes.number.greater_than_or_equal_to"))
+    end
+  end
+
+  context "when given a string which is not numeric" do
+    it "returns a validation error" do
+      question = described_class.new(number: "two")
+      question.validate
+      expect(question).not_to be_valid
+      expect(question.errors[:number]).to include(I18n.t("activemodel.errors.models.question/number.attributes.number.not_a_number"))
+    end
+  end
+end

--- a/spec/requests/base_spec.rb
+++ b/spec/requests/base_spec.rb
@@ -280,10 +280,6 @@ RSpec.describe "Base controller", type: :request do
           it "Render the not found page" do
             expect(response.body).to include(I18n.t("not_found.title"))
           end
-
-          it "returns 404" do
-            expect(response.status).to eq(404)
-          end
         end
       end
 

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe NotifyService do
 
         travel_to submission_datetime do
           notify_service = described_class.new
-          form = OpenStruct.new(submission_email:"fake-email", form_name: "title", steps: [OpenStruct.new(question_text: "text", show_answer: "Testing")])
+          form = OpenStruct.new(submission_email: "fake-email", form_name: "title", steps: [OpenStruct.new(question_text: "text", show_answer: "Testing")])
           notify_service.send_email(form)
           expect(fake_notify_client).to have_received(:send_email).with(
             { email_address: "fake-email",
@@ -48,7 +48,7 @@ RSpec.describe NotifyService do
 
         travel_to submission_datetime do
           notify_service = described_class.new
-          form = OpenStruct.new(submission_email:"fake-email", form_name: "title", steps: [OpenStruct.new(question_text: "text", show_answer: "Testing")])
+          form = OpenStruct.new(submission_email: "fake-email", form_name: "title", steps: [OpenStruct.new(question_text: "text", show_answer: "Testing")])
           notify_service.send_email(form)
           expect(fake_notify_client).to have_received(:send_email).with(
             { email_address: "fake-email",
@@ -65,25 +65,27 @@ RSpec.describe NotifyService do
     end
 
     context "with an email subject identifying that it was submitted from preview-form" do
-      let(:submission_datetime) { Time.utc(2022, 12, 14, 10, 00, 00) }
+      let(:submission_datetime) { Time.utc(2022, 12, 14, 10, 0o0, 0o0) }
+
       it "sends correct values to notify" do
         fake_notify_client = instance_double(Notifications::Client)
         allow(fake_notify_client).to receive(:send_email)
         allow(Notifications::Client).to receive(:new).and_return(fake_notify_client)
 
         travel_to submission_datetime do
-          notify_service = NotifyService.new
-          form = OpenStruct.new(submission_email:"fake-email", form_name: "title", steps: [OpenStruct.new(question_text: "text", show_answer: "Testing")])
-          notify_service.send_email(form,preview_mode: true)
+          notify_service = described_class.new
+          form = OpenStruct.new(submission_email: "fake-email", form_name: "title", steps: [OpenStruct.new(question_text: "text", show_answer: "Testing")])
+          notify_service.send_email(form, preview_mode: true)
           expect(fake_notify_client).to have_received(:send_email).with(
-            {:email_address=>'fake-email',
-             :personalisation=>{
-               :submission_date=>"14 December 2022",
-               :submission_time=>"10:00:00",
-               :text_input=>"# text\nTesting",
-               :title=>'TEST FORM: title'
-             },
-             :template_id=>"427eb8bc-ce0d-40a3-bf54-d76e8c3ec916"}).once
+            { email_address: "fake-email",
+              personalisation: {
+                submission_date: "14 December 2022",
+                submission_time: "10:00:00",
+                text_input: "# text\nTesting",
+                title: "TEST FORM: title",
+              },
+              template_id: "427eb8bc-ce0d-40a3-bf54-d76e8c3ec916" },
+          ).once
         end
       end
     end
@@ -97,7 +99,7 @@ RSpec.describe NotifyService do
       expect(Rails.logger).to receive(:warn).with(/NOTIFY_API_KEY/)
 
       notify_service = described_class.new
-      form = OpenStruct.new(submission_email:"fake-email", form_name: "title", steps: [OpenStruct.new(question_text: "text", show_answer: "Testing")])
+      form = OpenStruct.new(submission_email: "fake-email", form_name: "title", steps: [OpenStruct.new(question_text: "text", show_answer: "Testing")])
       notify_service.send_email(form)
       expect(fake_notify_client).not_to have_received(:send_email)
     end


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds a new number input type. This can be any whole or decimal number greater than or equal to 0.

Trello card: https://trello.com/c/tyDQQZ6A/222-add-number-answer-to-a-question-in-the-runner-and-api

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


