### PR TITLE
Remove redundant calls to validate

### DIFF
--- a/spec/models/question/number_spec.rb
+++ b/spec/models/question/number_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe Question::Number, type: :model do
   context "when given an empty string or nil" do
     it "returns invalid with blank message" do
       question = described_class.new
-      question.validate
+      expect(question).not_to be_valid
       expect(question.errors[:number]).to include(I18n.t("activemodel.errors.models.question/number.attributes.number.blank"))
       question.number = ""
-      question.validate
+      expect(question).not_to be_valid
       expect(question.errors[:number]).to include(I18n.t("activemodel.errors.models.question/number.attributes.number.blank"))
     end
 
@@ -23,7 +23,6 @@ RSpec.describe Question::Number, type: :model do
   context "when given a whole number" do
     it "validates without errors" do
       question = described_class.new(number: "299792458")
-      question.validate
       expect(question).to be_valid
     end
   end
@@ -31,7 +30,6 @@ RSpec.describe Question::Number, type: :model do
   context "when given a decimal number" do
     it "validates without errors" do
       question = described_class.new(number: "8.5")
-      question.validate
       expect(question).to be_valid
     end
   end
@@ -39,7 +37,6 @@ RSpec.describe Question::Number, type: :model do
   context "when given a negative number" do
     it "returns a validation error" do
       question = described_class.new(number: "-1")
-      question.validate
       expect(question).not_to be_valid
       expect(question.errors[:number]).to include(I18n.t("activemodel.errors.models.question/number.attributes.number.greater_than_or_equal_to"))
     end
@@ -48,7 +45,6 @@ RSpec.describe Question::Number, type: :model do
   context "when given a string which is not numeric" do
     it "returns a validation error" do
       question = described_class.new(number: "two")
-      question.validate
       expect(question).not_to be_valid
       expect(question.errors[:number]).to include(I18n.t("activemodel.errors.models.question/number.attributes.number.not_a_number"))
     end

--- a/spec/models/question/number_spec.rb
+++ b/spec/models/question/number_spec.rb
@@ -2,41 +2,44 @@ require "rails_helper"
 require "shared_examples_for_question_models"
 
 RSpec.describe Question::Number, type: :model do
+  let(:question) { described_class.new }
+
   it_behaves_like "a question model"
 
   context "when given an empty string or nil" do
     it "returns invalid with blank message" do
-      question = described_class.new
       expect(question).not_to be_valid
       expect(question.errors[:number]).to include(I18n.t("activemodel.errors.models.question/number.attributes.number.blank"))
+    end
+
+    it "returns invalid with empty string" do
       question.number = ""
       expect(question).not_to be_valid
       expect(question.errors[:number]).to include(I18n.t("activemodel.errors.models.question/number.attributes.number.blank"))
     end
 
     it "shows as a blank string" do
-      question = described_class.new
       expect(question.show_answer).to eq ""
     end
   end
 
   context "when given a whole number" do
     it "validates without errors" do
-      question = described_class.new(number: "299792458")
+      question.number = "299792458"
       expect(question).to be_valid
     end
   end
 
   context "when given a decimal number" do
     it "validates without errors" do
-      question = described_class.new(number: "8.5")
+      question.number = "8.5"
       expect(question).to be_valid
     end
   end
 
   context "when given a negative number" do
     it "returns a validation error" do
-      question = described_class.new(number: "-1")
+      question.number = "-1"
       expect(question).not_to be_valid
       expect(question.errors[:number]).to include(I18n.t("activemodel.errors.models.question/number.attributes.number.greater_than_or_equal_to"))
     end
@@ -44,7 +47,7 @@ RSpec.describe Question::Number, type: :model do
 
   context "when given a string which is not numeric" do
     it "returns a validation error" do
-      question = described_class.new(number: "two")
+      question.number = "two"
       expect(question).not_to be_valid
       expect(question.errors[:number]).to include(I18n.t("activemodel.errors.models.question/number.attributes.number.not_a_number"))
     end


### PR DESCRIPTION
#### What problem does the pull request solve?
Addresses some post-merge feedback on #158 - removes some redundant calls to `validate`, which is already included in rspec's `be_valid` check.
#### Checklist

- [x] I've used the pull request template
- [n/a] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


