### PR TITLE
WIP: Add notify template render to CYO in dev

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -11,6 +11,25 @@ module Forms
       end
     end
 
+    def preview_email
+      @back_link = check_your_answers_path(current_context.form, current_context.form_slug)
+      @email_preview = NotifyService.new.preview_email(current_context, preview_mode: preview?)
+      @rows = [
+        {
+          key: { text: 'Template'},
+          value: { text: @email_preview[:template_id] },
+        },
+        {
+          key: { text: 'To'},
+          value: { text: @email_preview[:email_address] },
+        },
+        {
+          key: { text: 'Subject'},
+          value: { text: @email_preview[:subject] },
+        },
+      ]
+    end
+
   private
 
     def page_to_row(page)

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -19,6 +19,29 @@ class NotifyService
     client.send_email(**email(email_address, title, text_input))
   end
 
+  def preview_email(form, preview_mode: false)
+    title = form.form_name
+    text_input = build_question_answers_section(form)
+    email_address = form.submission_email || ''
+    @preview_mode = preview_mode
+    unless @notify_api_key
+      Rails.logger.warn "Warning: no NOTIFY_API_KEY set."
+      return nil
+    end
+
+    client = Notifications::Client.new(@notify_api_key)
+    full_email = email(email_address, title, text_input)
+    response = client.generate_template_preview(full_email[:template_id], personalisation: full_email[:personalisation])
+    {
+      email_address: full_email[:email_address],
+      template_id: full_email[:template_id],
+      personalisation: full_email[:personalisation],
+      body: response.body,
+      html: response.html,
+      subject: response.subject,
+    }
+  end
+
   def email(email_address, title, text_input)
     title = "TEST FORM: #{title}" if @preview_mode
     timestamp = submission_timestamp

--- a/app/views/forms/check_your_answers/preview_email.html.erb
+++ b/app/views/forms/check_your_answers/preview_email.html.erb
@@ -1,0 +1,20 @@
+<% set_page_title("Preview email - #{@current_context.form_name}") %>
+
+<% content_for :before_content do %>
+  <% if @back_link %>
+    <%= link_to "Back", @back_link, class: "govuk-back-link" %>
+  <% end %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">Preview email as rendered by Notify</h1>
+
+    <%= govuk_summary_list(rows: @rows) %>
+
+    <h2 class="govuk-heading-s">Body:</h2>
+    <%= @email_preview[:html].html_safe %>
+
+  </div>
+</div>
+

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -15,5 +15,9 @@
     <%= form_with url: form_submit_answers_path do |form| %>
       <%= form.govuk_submit 'Submit' %>
     <% end %>
+
+    <% if Rails.env.development? %>
+      <%= link_to "Preview email", preview_email_path(@current_context.form, @current_context.form_slug), class: "govuk-link" %>
+    <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     scope "/:form_id/:form_slug" do
       get "/" => "forms/base#redirect_to_friendly_url_start", as: :form
       get "/check_your_answers" => "forms/check_your_answers#show", as: :check_your_answers
+      get "/check_your_answers/preview_email" => "forms/check_your_answers#preview_email", as: :preview_email
       post "/submit_answers" => "forms/submit_answers#submit_answers", as: :form_submit_answers
       get "/submitted" => "forms/submitted#submitted", as: :form_submitted
       get "/privacy" => "forms/privacy_page#show", as: :form_privacy


### PR DESCRIPTION
This commit adds a new page, /check_your_answers/preview_email, which shows a preview of how a submitted form will appear in notify.

To decide:
- choose when the preview is available - only RAILS_ENV=dev?
- it currently doesn't apply notify styles to the email - should it?
- is this useful? Are there any features which would make this better for testing?

Need to:
- add better guards to make sure it doesn't show in production
- add errors and message for when NOTIFY_API is not set
- add tests

<img width="776" alt="image" src="https://user-images.githubusercontent.com/11035856/196433022-3ec7e7d5-6d96-4258-b043-15550cb8d38f.png">

<img width="758" alt="image" src="https://user-images.githubusercontent.com/11035856/196433109-238438d3-fe67-4f17-8958-24e1d23531e9.png">



#### What problem does the pull request solve?

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


