### PR TITLE
Add optional text suffix

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -15,7 +15,7 @@ module Forms
   private
 
     def page_to_row(page)
-      question_name = page.question_short_name.presence || page.question_text
+      question_name = helpers.question_text_with_optional_suffix(page)
       {
         key: { text: question_name },
         value: { text: page.show_answer },

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,4 +13,8 @@ module ApplicationHelper
   def title_with_error_prefix(title, error)
     "#{t('page_titles.error_prefix') if error}#{title}"
   end
+
+  def optional_label(page)
+    "#{page.question_text}#{t('page.optional') if page.question.is_optional?}"
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,7 +14,7 @@ module ApplicationHelper
     "#{t('page_titles.error_prefix') if error}#{title}"
   end
 
-  def optional_label(page)
-    "#{page.question_text}#{t('page.optional') if page.question.is_optional?}"
+  def question_text_with_optional_suffix(page)
+    page.question.is_optional? ? t("page.optional", question_text: page.question_text) : page.question_text
   end
 end

--- a/app/views/question/_address.html.erb
+++ b/app/views/question/_address.html.erb
@@ -1,4 +1,4 @@
-<%= form.govuk_fieldset legend: { text: optional_label(page), tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-address-hint" : nil do %>
+<%= form.govuk_fieldset legend: { text: question_text_with_optional_suffix(page), tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-address-hint" : nil do %>
   <% if page.hint_text.present? %>
     <p id="govuk-address-hint" class="govuk-hint"><%= page.hint_text %></p>
   <% end %>

--- a/app/views/question/_address.html.erb
+++ b/app/views/question/_address.html.erb
@@ -1,4 +1,4 @@
-<%= form.govuk_fieldset legend: { text: page.question_text, tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-address-hint" : nil do %>
+<%= form.govuk_fieldset legend: { text: optional_label(page), tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-address-hint" : nil do %>
   <% if page.hint_text.present? %>
     <p id="govuk-address-hint" class="govuk-hint"><%= page.hint_text %></p>
   <% end %>

--- a/app/views/question/_date.html.erb
+++ b/app/views/question/_date.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_date_field :date, legend: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text } %>
+<%= form.govuk_date_field :date, legend: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text } %>

--- a/app/views/question/_date.html.erb
+++ b/app/views/question/_date.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_date_field :date, legend: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text } %>
+<%= form.govuk_date_field :date, legend: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text } %>

--- a/app/views/question/_email.html.erb
+++ b/app/views/question/_email.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :email, label: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text }, autocomplete: 'email', type: 'email', spellcheck: false   %>
+<%= form.govuk_text_field :email, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }, autocomplete: 'email', type: 'email', spellcheck: false   %>

--- a/app/views/question/_email.html.erb
+++ b/app/views/question/_email.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :email, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, autocomplete: 'email', type: 'email', spellcheck: false   %>
+<%= form.govuk_text_field :email, label: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text }, autocomplete: 'email', type: 'email', spellcheck: false   %>

--- a/app/views/question/_long_text.html.erb
+++ b/app/views/question/_long_text.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_area :text, label: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text }, rows: 5 %>
+<%= form.govuk_text_area :text, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }, rows: 5 %>

--- a/app/views/question/_long_text.html.erb
+++ b/app/views/question/_long_text.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_area :text, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, rows: 5 %>
+<%= form.govuk_text_area :text, label: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text }, rows: 5 %>

--- a/app/views/question/_national_insurance_number.html.erb
+++ b/app/views/question/_national_insurance_number.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, width: 10, spellcheck: false %>
+<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text }, width: 10, spellcheck: false %>

--- a/app/views/question/_national_insurance_number.html.erb
+++ b/app/views/question/_national_insurance_number.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text }, width: 10, spellcheck: false %>
+<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }, width: 10, spellcheck: false %>

--- a/app/views/question/_number.html.erb
+++ b/app/views/question/_number.html.erb
@@ -2,4 +2,4 @@
   form.govuk_number_field uses the 'number' HTML input type, which the Design System reccomends against:
   https://design-system.service.gov.uk/components/text-input/#avoid-using-inputs-with-a-type-of-number
 %>
-<%= form.govuk_text_field :number, label: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text }, spellcheck: false %>
+<%= form.govuk_text_field :number, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }, spellcheck: false %>

--- a/app/views/question/_number.html.erb
+++ b/app/views/question/_number.html.erb
@@ -2,4 +2,4 @@
   form.govuk_number_field uses the 'number' HTML input type, which the Design System reccomends against:
   https://design-system.service.gov.uk/components/text-input/#avoid-using-inputs-with-a-type-of-number
 %>
-<%= form.govuk_text_field :number, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, spellcheck: false %>
+<%= form.govuk_text_field :number, label: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text }, spellcheck: false %>

--- a/app/views/question/_phone_number.html.erb
+++ b/app/views/question/_phone_number.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :phone_number, label: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text }, width: 'one-half', autocomplete: 'tel' %>
+<%= form.govuk_text_field :phone_number, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }, width: 'one-half', autocomplete: 'tel' %>

--- a/app/views/question/_phone_number.html.erb
+++ b/app/views/question/_phone_number.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :phone_number, label: { tag: 'h1', size: 'l', text: page.question_text }, width: 'one-half', autocomplete: 'tel' %>
+<%= form.govuk_text_field :phone_number, label: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text }, width: 'one-half', autocomplete: 'tel' %>

--- a/app/views/question/_single_line.html.erb
+++ b/app/views/question/_single_line.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :text, label: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }, width: 'one-half' %>
+<%= form.govuk_text_field :text, label: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text }, width: 'one-half' %>

--- a/app/views/question/_single_line.html.erb
+++ b/app/views/question/_single_line.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :text, label: { tag: 'h1', size: 'l', text: optional_label(page) }, hint: { text: page.hint_text }, width: 'one-half' %>
+<%= form.govuk_text_field :text, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }, width: 'one-half' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,8 @@ en:
   form:
     submitted:
       title: Your form has been submitted
+  page:
+    optional: " (optional)"
   page_titles:
     error_prefix: 'Error: '
   phase_banner:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,7 +60,7 @@ en:
     submitted:
       title: Your form has been submitted
   page:
-    optional: " (optional)"
+    optional: "%{question_text} (optional)"
   page_titles:
     error_prefix: 'Error: '
   phase_banner:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -22,4 +22,20 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "optional_label" do
+    context "with an optional question" do
+      it "returns the title with the optional suffix" do
+        page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(is_optional?: true))
+        expect(helper.optional_label(page)).to eq("What is your name? (optional)")
+      end
+    end
+
+    context "with a required question" do
+      it "returns the title with the optional suffix" do
+        page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(is_optional?: false))
+        expect(helper.optional_label(page)).to eq("What is your name?")
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -23,18 +23,18 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "optional_label" do
+  describe "question_text_with_optional_suffix" do
     context "with an optional question" do
       it "returns the title with the optional suffix" do
         page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(is_optional?: true))
-        expect(helper.optional_label(page)).to eq("What is your name? (optional)")
+        expect(helper.question_text_with_optional_suffix(page)).to eq(I18n.t("page.optional", question_text: "What is your name?"))
       end
     end
 
     context "with a required question" do
       it "returns the title with the optional suffix" do
         page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(is_optional?: false))
-        expect(helper.optional_label(page)).to eq("What is your name?")
+        expect(helper.question_text_with_optional_suffix(page)).to eq("What is your name?")
       end
     end
   end

--- a/spec/lib/question_register_spec.rb
+++ b/spec/lib/question_register_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe QuestionRegister do
   it "accepts is_optional for each answer_type" do
     [false, true].each do |is_optional|
       %i[date single_line address email national_insurance_number phone_number].each do |type|
-        page = OpenStruct.new(answer_type: type, is_optional: is_optional)
+        page = OpenStruct.new(answer_type: type, is_optional:)
         expect(described_class.from_page(page).is_optional?).to eq(is_optional)
       end
     end

--- a/spec/models/question/date_spec.rb
+++ b/spec/models/question/date_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Question::Date, type: :model do
-  let(:options) { {} }
   subject(:question) { described_class.new({}, options) }
+
+  let(:options) { {} }
 
   it_behaves_like "a question model"
 
@@ -85,7 +86,7 @@ RSpec.describe Question::Date, type: :model do
 
     it "returns valid with blank date" do
       expect(question).to be_valid
-      expect(question.errors[:date]).to_not include(I18n.t("activemodel.errors.models.question/date.attributes.date.blank"))
+      expect(question.errors[:date]).not_to include(I18n.t("activemodel.errors.models.question/date.attributes.date.blank"))
     end
 
     it "returns valid with empty string" do

--- a/spec/models/question/email_spec.rb
+++ b/spec/models/question/email_spec.rb
@@ -71,6 +71,5 @@ RSpec.describe Question::Email, type: :model do
         expect(question.errors[:email]).to include(I18n.t("activemodel.errors.models.question/email.attributes.email.invalid_email"))
       end
     end
-
   end
 end

--- a/spec/models/question/long_text_spec.rb
+++ b/spec/models/question/long_text_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Question::LongText, type: :model do
       expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/long_text.attributes.text.blank"))
     end
 
-
     it "returns invalid with empty string" do
       question.text = ""
       expect(question).not_to be_valid
@@ -47,7 +46,6 @@ RSpec.describe Question::LongText, type: :model do
         expect(question.errors[:text]).not_to include(I18n.t("activemodel.errors.models.question/long_text.attributes.text.blank"))
       end
 
-
       it "returns invalid with empty string" do
         question.text = ""
         expect(question).to be_valid
@@ -73,7 +71,5 @@ RSpec.describe Question::LongText, type: :model do
         expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/long_text.attributes.text.too_long"))
       end
     end
-
   end
-
 end

--- a/spec/models/question/national_insurance_number_spec.rb
+++ b/spec/models/question/national_insurance_number_spec.rb
@@ -103,9 +103,5 @@ RSpec.describe Question::NationalInsuranceNumber, type: :model do
         expect(question).not_to be_valid
       end
     end
-
-
   end
-
-
 end

--- a/spec/models/question/phone_number_spec.rb
+++ b/spec/models/question/phone_number_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe Question::PhoneNumber, type: :model do
     end
   end
 
-
   context "when question is optional" do
     let(:question) { described_class.new({}, { is_optional: true }) }
 
@@ -118,6 +117,5 @@ RSpec.describe Question::PhoneNumber, type: :model do
         expect(question.errors[:phone_number]).to include(I18n.t("activemodel.errors.models.question/phone_number.attributes.phone_number.phone_too_short"))
       end
     end
-
   end
 end

--- a/spec/models/question/single_line_spec.rb
+++ b/spec/models/question/single_line_spec.rb
@@ -71,6 +71,5 @@ RSpec.describe Question::SingleLine, type: :model do
         expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/single_line.attributes.text.too_long"))
       end
     end
-
   end
 end

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -110,14 +110,14 @@ RSpec.describe NotifyService do
 
     let(:form) { OpenStruct.new(steps: [step]) }
 
-    let(:step) { OpenStruct.new({question_text: "What is the meaning of life?", show_answer: "42" }) }
+    let(:step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer: "42" }) }
 
     it "returns combined title and answer" do
       expect(notify_service.build_question_answers_section(form)).to eq "# What is the meaning of life?\n```\n\n42\n```\n"
     end
 
     context "when there is more than one step" do
-      let(:form) { OpenStruct.new(steps: [step, step])}
+      let(:form) { OpenStruct.new(steps: [step, step]) }
 
       it "contains a horizontal rule between each step" do
         expect(notify_service.build_question_answers_section(form)).to include "\n\n---\n\n"
@@ -141,7 +141,7 @@ RSpec.describe NotifyService do
       [
         { input: "Hello", output: "```\n\nHello\n```\n" },
         { input: "3.4 Question", output: "```\n\n3.4 Question\n```\n" },
-        { input:"-23.4 answer", output: "```\n\n-23.4 answer\n```\n" },
+        { input: "-23.4 answer", output: "```\n\n-23.4 answer\n```\n" },
         { input: "4.5.6", output: "```\n\n4.5.6\n```\n" },
       ].each do |test_case|
         expect(notify_service.prep_answer_text(test_case[:input])).to eq test_case[:output]

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -1,17 +1,17 @@
 require "rails_helper"
 
 describe "forms/check_your_answers/show.html.erb" do
-  let(:context) { OpenStruct.new(form_id: 1, form_slug: 'slug', mode: '', name: "Form 1") }
+  let(:context) { OpenStruct.new(form_id: 1, form_slug: "slug", mode: "", name: "Form 1") }
 
   before do
     assign(:current_context, context)
-    assign(:form_submit_path, '/')
+    assign(:form_submit_path, "/")
     render template: "forms/check_your_answers/show"
   end
 
   context "when the form does not have a declaration" do
     it "does not display the declaration heading" do
-      expect(rendered).to_not have_css("h2", text: "Declaration")
+      expect(rendered).not_to have_css("h2", text: "Declaration")
     end
   end
 
@@ -27,4 +27,3 @@ describe "forms/check_your_answers/show.html.erb" do
     end
   end
 end
-


### PR DESCRIPTION
#### What problem does the pull request solve?
Lets the form filler know that the question they're looking at is optional, without needing the form creator to explicitly add this to the label.

Trello card: https://trello.com/c/0Fp3VrLT/90-epic-build-optional-questions

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


