### PR TITLE
249 form runner log events for when a user completes skips optional question

### DIFF
--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -13,7 +13,7 @@ module Forms
 
       if current_context.save_step(@step)
         unless preview?
-          log_page_save(@step, request, changing_existing_answer, page_params)
+          LogEventService.new(current_context, @step, request, changing_existing_answer, page_params).log_page_save
         end
         redirect_to next_page
       else
@@ -52,30 +52,6 @@ module Forms
       else
         form_page_path(@step.form_id, @step.form_slug, @step.next_page_slug)
       end
-    end
-
-    def is_starting_form(step)
-      current_context.form_start_page == step.id
-    end
-
-    def log_page_save(step, request, changing_answer, answers)
-      EventLogger.log_page_event(current_context, step, request, log_event(changing_answer, step), skipped_question?(answers))
-    end
-
-    def log_event(changing_answer, step)
-      page_optional = @step.question.is_optional? ? "optional" : "page"
-
-      if changing_answer
-        "change_answer_#{page_optional}_save"
-      elsif is_starting_form(step)
-        "first_#{page_optional}_save"
-      else
-        "#{page_optional}_save"
-      end
-    end
-
-    def skipped_question?(answers)
-      @step.question.is_optional? ? answers.each_value.map.none?(&:present?) : nil
     end
   end
 end

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -13,7 +13,7 @@ module Forms
 
       if current_context.save_step(@step)
         unless preview?
-          log_page_save(@step, request, changing_existing_answer)
+          log_page_save(@step, request, changing_existing_answer, page_params)
         end
         redirect_to next_page
       else
@@ -58,8 +58,8 @@ module Forms
       current_context.form_start_page == step.id
     end
 
-    def log_page_save(step, request, changing_answer)
-      EventLogger.log_page_event(current_context, step, request, log_event(changing_answer, step))
+    def log_page_save(step, request, changing_answer, answers)
+      EventLogger.log_page_event(current_context, step, request, log_event(changing_answer, step), skipped_question?(answers))
     end
 
     def log_event(changing_answer, step)
@@ -72,6 +72,10 @@ module Forms
       else
         "#{page_optional}_save"
       end
+    end
+
+    def skipped_question?(answers)
+      @step.question.is_optional? ? answers.each_value.map.none?(&:present?) : nil
     end
   end
 end

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -58,16 +58,20 @@ module Forms
       current_context.form_start_page == step.id
     end
 
-    def log_page_save(step, request, changing_existing_answer)
-      log_event = if changing_existing_answer
-                    "change_answer_page_save"
-                  elsif is_starting_form(step)
-                    "first_page_save"
-                  else
-                    "page_save"
-                  end
+    def log_page_save(step, request, changing_answer)
+      EventLogger.log_page_event(current_context, step, request, log_event(changing_answer, step))
+    end
 
-      EventLogger.log_page_event(current_context, step, request, log_event)
+    def log_event(changing_answer, step)
+      page_optional = @step.question.is_optional? ? "optional" : "page"
+
+      if changing_answer
+        "change_answer_#{page_optional}_save"
+      elsif is_starting_form(step)
+        "first_#{page_optional}_save"
+      else
+        "#{page_optional}_save"
+      end
     end
   end
 end

--- a/app/lib/event_logger.rb
+++ b/app/lib/event_logger.rb
@@ -13,13 +13,15 @@ class EventLogger
     log("form_#{event}", item_to_log)
   end
 
-  def self.log_page_event(context, page, request, event)
+  def self.log_page_event(context, page, request, event, skipped_question: nil)
     item_to_log = {
       url: request&.url,
       method: request&.method,
       form: context.form_name,
       question_text: page.question.question_text,
     }
+
+    item_to_log.merge!({ skipped_question: skipped_question.to_s }) unless skipped_question.nil?
 
     log(event.to_s, item_to_log)
   end

--- a/app/lib/event_logger.rb
+++ b/app/lib/event_logger.rb
@@ -13,7 +13,7 @@ class EventLogger
     log("form_#{event}", item_to_log)
   end
 
-  def self.log_page_event(context, page, request, event, skipped_question: nil)
+  def self.log_page_event(context, page, request, event, skipped_question)
     item_to_log = {
       url: request&.url,
       method: request&.method,

--- a/app/services/log_event_service.rb
+++ b/app/services/log_event_service.rb
@@ -1,0 +1,35 @@
+class LogEventService
+  def initialize(current_context, step, request, changing_answer, answers)
+    @current_context = current_context
+    @step = step
+    @request = request
+    @changing_answer = changing_answer
+    @answers = answers
+  end
+
+  def log_page_save
+    EventLogger.log_page_event(@current_context, @step, @request, log_event, skipped_question?)
+  end
+
+private
+
+  def log_event
+    page_optional = @step.question.is_optional? ? "optional" : "page"
+
+    if @changing_answer
+      "change_answer_#{page_optional}_save"
+    elsif is_starting_form
+      "first_#{page_optional}_save"
+    else
+      "#{page_optional}_save"
+    end
+  end
+
+  def skipped_question?
+    @step.question.is_optional? ? @answers.each_value.map.none?(&:present?) : nil
+  end
+
+  def is_starting_form
+    @current_context.form_start_page == @step.id
+  end
+end

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -71,11 +71,44 @@ RSpec.describe EventLogger do
     expect(described_class).to have_received(:log).with("form_visit", form_log_item)
   end
 
-  it "logs a page event" do
-    allow(described_class).to receive(:log).at_least(:once)
+  context "when completing a question" do
+    it "logs a page event" do
+      allow(described_class).to receive(:log).at_least(:once)
 
-    described_class.log_page_event(context, OpenStruct.new(question: page), request, "page_save")
+      described_class.log_page_event(context, OpenStruct.new(question: page), request, "page_save")
 
-    expect(described_class).to have_received(:log).with("page_save", page_log_item)
+      expect(described_class).to have_received(:log).with("page_save", page_log_item)
+    end
+  end
+
+  context "when skipping an optional question" do
+    let(:page) do
+      Page.new({
+        id: 1,
+        question_text: "Question one",
+        answer_type: "single_line",
+        next_page: 2,
+        question_short_name: nil,
+        is_optional: true,
+      })
+    end
+
+    let(:page_log_item) do
+      {
+        url: "http://example.gov.uk",
+        method: "GET",
+        form: "Form 1",
+        question_text: "Question one",
+        skipped_question: "true",
+      }
+    end
+
+    it "logs a page event with a question_skipped parameter" do
+      allow(described_class).to receive(:log).at_least(:once)
+
+      described_class.log_page_event(context, OpenStruct.new(question: page), request, "optional_save", skipped_question: true)
+
+      expect(described_class).to have_received(:log).with("optional_save", page_log_item)
+    end
   end
 end

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe EventLogger do
       answer_type: "single_line",
       next_page: 2,
       question_short_name: nil,
-      is_optional: nil,
+      is_optional: false,
     })
   end
 

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe EventLogger do
     it "logs a page event" do
       allow(described_class).to receive(:log).at_least(:once)
 
-      described_class.log_page_event(context, OpenStruct.new(question: page), request, "page_save")
+      described_class.log_page_event(context, OpenStruct.new(question: page), request, "page_save", nil)
 
       expect(described_class).to have_received(:log).with("page_save", page_log_item)
     end
@@ -106,7 +106,7 @@ RSpec.describe EventLogger do
     it "logs a page event with a question_skipped parameter" do
       allow(described_class).to receive(:log).at_least(:once)
 
-      described_class.log_page_event(context, OpenStruct.new(question: page), request, "optional_save", skipped_question: true)
+      described_class.log_page_event(context, OpenStruct.new(question: page), request, "optional_save", true)
 
       expect(described_class).to have_received(:log).with("optional_save", page_log_item)
     end

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -356,13 +356,28 @@ RSpec.describe "Page Controller", type: :request do
           ].to_json
         end
 
-        it "Logs the optional_save event" do
-          expect(EventLogger).to receive(:log).with("optional_save",
-                                                    { form: "Form 1",
-                                                      method: "POST",
-                                                      question_text: "Question two",
-                                                      url: "http://www.example.com/form/2/form-1/2" })
-          post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "answer text" } }
+        context "when an optional question is completed" do
+          it "Logs the optional_save event with skipped_question as true" do
+            expect(EventLogger).to receive(:log).with("optional_save",
+                                                      { form: "Form 1",
+                                                        method: "POST",
+                                                        question_text: "Question two",
+                                                        skipped_question: "false",
+                                                        url: "http://www.example.com/form/2/form-1/2" })
+            post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "answer text" } }
+          end
+        end
+
+        context "when an optional question is skipped" do
+          it "Logs the optional_save event with skipped_question as false" do
+            expect(EventLogger).to receive(:log).with("optional_save",
+                                                      { form: "Form 1",
+                                                        method: "POST",
+                                                        question_text: "Question two",
+                                                        skipped_question: "true",
+                                                        url: "http://www.example.com/form/2/form-1/2" })
+            post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "" } }
+          end
         end
       end
     end

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -332,6 +332,39 @@ RSpec.describe "Page Controller", type: :request do
           expect(response).to redirect_to(check_your_answers_path("form", 2, "form-1"))
         end
       end
+
+      context "with an subsequent optional page" do
+        let(:pages_data) do
+          [
+            {
+              id: 1,
+              question_text: "Question one",
+              answer_type: "single_line",
+              hint_text: "",
+              next_page: 2,
+              question_short_name: nil,
+              is_optional: nil,
+            },
+            {
+              id: 2,
+              question_text: "Question two",
+              hint_text: "Q2 hint text",
+              answer_type: "single_line",
+              question_short_name: nil,
+              is_optional: true,
+            },
+          ].to_json
+        end
+
+        it "Logs the optional_save event" do
+          expect(EventLogger).to receive(:log).with("optional_save",
+                                                    { form: "Form 1",
+                                                      method: "POST",
+                                                      question_text: "Question two",
+                                                      url: "http://www.example.com/form/2/form-1/2" })
+          post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "answer text" } }
+        end
+      end
     end
   end
 end

--- a/spec/services/log_event_service_spec.rb
+++ b/spec/services/log_event_service_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe LogEventService do
+  describe "#log_page_save" do
+    let(:changing_answers) { true }
+    let(:step) { OpenStruct.new(question:) }
+    let(:question) { OpenStruct.new(is_optional?: true) }
+    let(:request) { "request" }
+    let(:current_context) { "current_context" }
+    let(:answers) { { "name": "John" } }
+
+    it "calls the event logger with log_page_event" do
+      allow(EventLogger).to receive(:log_page_event).and_return(true)
+
+      log_event_service = described_class.new(current_context, step, request, changing_answers, answers)
+
+      log_event_service.log_page_save
+      expect(EventLogger).to have_received(:log_page_event).with(
+        current_context,
+        step,
+        request,
+        "change_answer_optional_save",
+        false,
+      )
+    end
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?
https://trello.com/c/DmZWSCEK/249-form-runner-log-events-for-when-a-user-completes-skips-optional-question

Adding a log for when users skip or complete an optional question. This has been broken into two parts, one that adds a log key for a question being optional or not, and another for when a question is skipped, currently only possible if it's optional. 

The log used to show up like this - `[page_save] {"url":"http://localhost:3001/preview-form/1/test/7","method":"POST","form":"test","question_text":"phone num"}`

And now will show up like this if it's an optional question that isn't skipped - `[optional_save] {"url":"http://localhost:3001/preview-form/1/test/7","method":"POST","form":"test","question_text":"phone num","optional_question":"true","skipped_question":"false"}`

And like this when it is skipped - `[optional_save] {"url":"http://localhost:3001/preview-form/1/test/7","method":"POST","form":"test","question_text":"phone num","optional_question":"true","skipped_question":"true"}`

There are other page event names that have also been conditioned to match whether it's an optional question `"change_answer_optional_save" and `"first_optional_save"`

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


