### PR TITLE
Escape long answers

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -1,6 +1,7 @@
 module Forms
   class CheckYourAnswersController < BaseController
     def show
+
       return redirect_to form_page_path(current_context.form, current_context.form_slug, current_context.next_page_slug) unless current_context.can_visit?("check_your_answers")
 
       previous_step = current_context.previous_step("check_your_answers")
@@ -10,6 +11,8 @@ module Forms
       unless preview?
         EventLogger.log_form_event(current_context, request, "check_answers")
       end
+
+      answers_need_full_width
     end
 
   private
@@ -25,6 +28,10 @@ module Forms
 
     def check_your_answers_rows
       current_context.steps.map { |page| page_to_row(page) }
+    end
+
+    def answers_need_full_width
+      @full_width = current_context.steps.any?{ |step| step.question.has_long_answer? }
     end
   end
 end

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -1,7 +1,6 @@
 module Forms
   class CheckYourAnswersController < BaseController
     def show
-
       return redirect_to form_page_path(current_context.form, current_context.form_slug, current_context.next_page_slug) unless current_context.can_visit?("check_your_answers")
 
       previous_step = current_context.previous_step("check_your_answers")
@@ -31,7 +30,7 @@ module Forms
     end
 
     def answers_need_full_width
-      @full_width = current_context.steps.any?{ |step| step.question.has_long_answer? }
+      @full_width = current_context.steps.any? { |step| step.question.has_long_answer? }
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,4 +17,8 @@ module ApplicationHelper
   def question_text_with_optional_suffix(page)
     page.question.is_optional? ? t("page.optional", question_text: page.question_text) : page.question_text
   end
+
+  def format_paragraphs(text)
+    simple_format(html_escape(text), class: "govuk-body", sanitize: true)
+  end
 end

--- a/app/models/question/long_text.rb
+++ b/app/models/question/long_text.rb
@@ -3,5 +3,9 @@ module Question
     attribute :text
     validates :text, presence: true, unless: :is_optional?
     validates :text, length: { maximum: 5000 }
+
+    def has_long_answer?
+      true
+    end
   end
 end

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -26,5 +26,9 @@ module Question
     def is_optional?
       @is_optional == true
     end
+
+    def has_long_answer?
+      false
+    end
   end
 end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -46,7 +46,7 @@ class NotifyService
     form.steps.map { |page|
       [prep_question_title(page.question_text),
        prep_answer_text(page.show_answer)].join
-    }.join("\n\n---\n\n")
+    }.join("\n\n---\n\n").concat("\n")
   end
 
   def prep_question_title(question_text)
@@ -54,7 +54,45 @@ class NotifyService
   end
 
   def prep_answer_text(answer)
-    answer = "[This question was skipped]" if answer.blank?
-    "```\n\n#{answer}\n```\n"
+    return "\\[This question was skipped\\]" if answer.blank?
+
+    escape(answer)
+  end
+
+  def escape(text)
+    text
+      .then { normalize_whitespace _1 }
+      .then { replace_setext_headings _1 }
+      .then { escape_markdown_text _1 }
+  end
+
+  def escape_markdown_text(text)
+    url_regex = URI::DEFAULT_PARSER.make_regexp(%w[http https])
+    a = ""
+    rest = text
+    until rest.empty?
+      head, match, rest = rest.partition(url_regex)
+      a << escape_markdown_characters(head)
+      a << match
+    end
+    a
+  end
+
+  def normalize_whitespace(text)
+    text.strip.gsub(/\r\n?/, "\n").split(/\n\n+/).map(&:strip).join("\n\n")
+  end
+
+  def escape_markdown_characters(text)
+    replaced = { "^" => "", "•" => "" }
+    escaped = %w{! " # ' ` ( ) * + - . [ ] _ \{ | \} ~}.index_with { |c| "\\#{c}" }
+
+    changes = replaced.merge(escaped)
+
+    to_change = Regexp.union(changes.keys)
+    text.gsub(to_change, changes)
+  end
+
+  def replace_setext_headings(text)
+    text.gsub(/^=+$/, '\1&nbsp;')
   end
 end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -93,6 +93,7 @@ class NotifyService
   end
 
   def replace_setext_headings(text)
-    text.gsub(/^=+$/, '\1&nbsp;')
+    # replace lengths of ^===$ with --- to stop them making headings
+    text.gsub(/^(=+)$/) { "_" * Regexp.last_match(1).length }
   end
 end

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -7,10 +7,17 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds-from-desktop">
+  <div class="<%= @full_width ? 'govuk-grid-column-full' : 'govuk-grid-column-two-thirds-from-desktop' %>">
     <h1 class="govuk-heading-l">Check your answers before submitting your form</h1>
 
-    <%= govuk_summary_list(rows: @rows) %>
+    <%if @rows %>
+      <%= govuk_summary_list(rows: @rows.map { |row|
+        { key: row[:key],
+          value: { text: format_paragraphs(row[:value][:text]) },
+          actions: row[:actions]
+        } })
+      %>
+    <% end %>
 
     <%if @current_context.declaration_text.present? %>
       <h2 class="govuk-heading-m govuk-!-margin-top-7">Declaration</h2>

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe NotifyService do
               personalisation: {
                 submission_date: "14 September 2022",
                 submission_time: "11:00:00",
-                text_input: "# text\n```\n\nTesting\n```\n",
+                text_input: "# text\nTesting\n",
                 title: "title",
               },
               template_id: "427eb8bc-ce0d-40a3-bf54-d76e8c3ec916" },
@@ -55,7 +55,7 @@ RSpec.describe NotifyService do
               personalisation: {
                 submission_date: "14 December 2022",
                 submission_time: "10:00:00",
-                text_input: "# text\n```\n\nTesting\n```\n",
+                text_input: "# text\nTesting\n",
                 title: "title",
               },
               template_id: "427eb8bc-ce0d-40a3-bf54-d76e8c3ec916" },
@@ -81,7 +81,7 @@ RSpec.describe NotifyService do
               personalisation: {
                 submission_date: "14 December 2022",
                 submission_time: "10:00:00",
-                text_input: "# text\n```\n\nTesting\n```\n",
+                text_input: "# text\nTesting\n",
                 title: "TEST FORM: title",
               },
               template_id: "427eb8bc-ce0d-40a3-bf54-d76e8c3ec916" },
@@ -113,7 +113,7 @@ RSpec.describe NotifyService do
     let(:step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer: "42" }) }
 
     it "returns combined title and answer" do
-      expect(notify_service.build_question_answers_section(form)).to eq "# What is the meaning of life?\n```\n\n42\n```\n"
+      expect(notify_service.build_question_answers_section(form)).to eq "# What is the meaning of life?\n42\n"
     end
 
     context "when there is more than one step" do
@@ -139,10 +139,16 @@ RSpec.describe NotifyService do
 
     it "returns escaped answer" do
       [
-        { input: "Hello", output: "```\n\nHello\n```\n" },
-        { input: "3.4 Question", output: "```\n\n3.4 Question\n```\n" },
-        { input: "-23.4 answer", output: "```\n\n-23.4 answer\n```\n" },
-        { input: "4.5.6", output: "```\n\n4.5.6\n```\n" },
+        { input: "Hello", output: "Hello" },
+        { input: "3.4 Question", output: "3\\.4 Question" },
+        { input: "-23.4 answer", output: "\\-23\\.4 answer" },
+        { input: "4.5.6", output: "4\\.5\\.6" },
+        { input: "\n\n# Test \n\n## Test 2", output:"\\# Test\n\n\\#\\# Test 2"},
+        { input: "\n\n```# Test 3\n\n## Test 4", output:"\\`\\`\\`\\# Test 3\n\n\\#\\# Test 4"}, # escapes ```
+        { input: "\n\n\n\n\n```# Test \n\n\n\n\n\n## Test 3\n\n\n\n", output:"\\`\\`\\`\\# Test\n\n\\#\\# Test 3"},
+        { input: "test https://example.org # more text 19.5\n\nA new paragraph.", output: "test https://example.org \\# more text 19\\.5\n\nA new paragraph\\." },
+        { input: "test https://example.org # more text 19.5\n\nA new paragraph.\n\n# another link http://gov.uk", output: "test https://example.org \\# more text 19\\.5\n\nA new paragraph\\.\n\n\\# another link http://gov.uk" },
+
       ].each do |test_case|
         expect(notify_service.prep_answer_text(test_case[:input])).to eq test_case[:output]
       end
@@ -150,7 +156,7 @@ RSpec.describe NotifyService do
 
     context "when answer is blank i.e skipped" do
       it "returns the blank answer text" do
-        expect(notify_service.prep_answer_text("")).to eq "```\n\n[This question was skipped]\n```\n"
+        expect(notify_service.prep_answer_text("")).to eq "\\[This question was skipped\\]"
       end
     end
   end

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -148,6 +148,9 @@ RSpec.describe NotifyService do
         { input: "\n\n\n\n\n```# Test \n\n\n\n\n\n## Test 3\n\n\n\n", output:"\\`\\`\\`\\# Test\n\n\\#\\# Test 3"},
         { input: "test https://example.org # more text 19.5\n\nA new paragraph.", output: "test https://example.org \\# more text 19\\.5\n\nA new paragraph\\." },
         { input: "test https://example.org # more text 19.5\n\nA new paragraph.\n\n# another link http://gov.uk", output: "test https://example.org \\# more text 19\\.5\n\nA new paragraph\\.\n\n\\# another link http://gov.uk" },
+        { input: "not a title\n====", output: "not a title\n\\_\\_\\_\\_" },
+        { input: "a normal sentence: 10 = 5 + 5", output: "a normal sentence: 10 = 5 \\+ 5" },
+        { input: "    paragraph 1\n\n\n\n\n\n\n\n\n\n\n\n\n Another Paragraph with trailing space     \n\n\n\n\n", output: "paragraph 1\n\nAnother Paragraph with trailing space" },
 
       ].each do |test_case|
         expect(notify_service.prep_answer_text(test_case[:input])).to eq test_case[:output]

--- a/spec/support/shared_examples/question_models.rb
+++ b/spec/support/shared_examples/question_models.rb
@@ -13,7 +13,11 @@ RSpec.shared_examples "a question model" do |_parameter|
     expect(question.valid?).to be(true).or be(false)
   end
 
-  it "response to is_optional?" do
+  it "responds to is_optional?" do
     expect(question.is_optional?).to be(true).or be(false)
+  end
+
+  it "responds to has_long_answer?" do
+    expect(question.has_long_answer?).to be(true).or be(false)
   end
 end

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -2,10 +2,12 @@ require "rails_helper"
 
 describe "forms/check_your_answers/show.html.erb" do
   let(:context) { OpenStruct.new(form_id: 1, form_slug: "slug", mode: "", name: "Form 1") }
+  let(:full_width) { false }
 
   before do
     assign(:current_context, context)
     assign(:form_submit_path, "/")
+    assign(:full_width, full_width)
     render template: "forms/check_your_answers/show"
   end
 
@@ -24,6 +26,18 @@ describe "forms/check_your_answers/show.html.erb" do
 
     it "displays declaration text" do
       expect(rendered).to have_css("p.govuk-body", text: "You should agree to all terms before submitting")
+    end
+  end
+
+  it 'displays two-thirds ' do
+    expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop")
+  end
+
+  context "when full_width not set" do
+    let(:full_width) { true }
+
+    it 'displays full width when set' do
+      expect(rendered).to have_css(".govuk-grid-column-full")
     end
   end
 end


### PR DESCRIPTION
# Fix escaping and display of long text answer-type

Long text is a new answer type which adds a couple of complications:
  - playing back long text answers in the CYA screen
  - submitting text with line breaks via notify

Answers with line breaks need to show paragraphs on the check your answer
screen. This commit breaks text into paragraphs and removes leading/trailing
space. It condenses multiple newlines into single newlines.

Notify interprets submissions as markdown and doesn't offer a way to safely
escape markdown formatting.

This commit fixes both of these issues.

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


