### PR TITLE
Do not redirect to HTTPS for /ping

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,6 +45,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # Do not redirect for request to /ping because the healthcheck comes direct from the router
+  config.ssl_options = { redirect: { exclude: -> request { request.path =~ /\/ping$/ } } }
+
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
   config.log_level = :info


### PR DESCRIPTION
Our Puma server is not configured for TLS despite the `config.force_ssl = true`. Instead if the request has `X-Forwarded-Proto: https` set then Puma will not redirect to `https` and serve the request. Whenever a request comes via a level 7 router such as an ALB or the PaaS Router it sets the header based on the original client protocol.

On AWS the ALB sends a healthcheck to /ping directly and we cannot set the headers. Stop redirecting /ping to https so we can use it as a healthcheck for now.

with @alice-carr

## Testing
We have built and deployed this to AWS dev account and the ECS task is passing the healthchecks.