### PR TITLE
Validate optional address fields if any fields have been filled in 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,6 +357,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/app/models/question/address.rb
+++ b/app/models/question/address.rb
@@ -7,9 +7,9 @@ module Question
     attribute :county
     attribute :postcode
 
-    validates :address1, presence: true, unless: :is_optional?
-    validates :town_or_city, presence: true, unless: :is_optional?
-    validates :postcode, presence: true, unless: :is_optional?
+    validates :address1, presence: true, unless: :skipping_question?
+    validates :town_or_city, presence: true, unless: :skipping_question?
+    validates :postcode, presence: true, unless: :skipping_question?
     validate :postcode, :invalid_postcode?
 
     def postcode=(str)
@@ -25,6 +25,11 @@ module Question
           errors.add(:postcode, :invalid_postcode)
         end
       end
+    end
+
+    def skipping_question?
+      fields = [address1, address2, town_or_city, county, postcode]
+      is_optional? && fields.none?(&:present?)
     end
   end
 end

--- a/spec/models/question/address_spec.rb
+++ b/spec/models/question/address_spec.rb
@@ -56,12 +56,12 @@ RSpec.describe Question::Address, type: :model do
     let(:question) { described_class.new({}, { is_optional: true }) }
 
     context "when an address is blank" do
-      it "returns invalid with blank address fields" do
+      it "returns valid with blank address fields" do
         expect(question).to be_valid
         expect(question.errors[:address1]).not_to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.blank"))
       end
 
-      it "returns invalid with empty string address fields" do
+      it "returns valid with empty string address fields" do
         question.address1 = ""
         question.address2 = ""
         question.town_or_city = ""
@@ -69,6 +69,18 @@ RSpec.describe Question::Address, type: :model do
         question.postcode = ""
         expect(question).to be_valid
         expect(question.errors[:address1]).not_to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.blank"))
+      end
+
+      it "validates required fields when any fields are filled in" do
+        question.address1 = ""
+        question.address2 = ""
+        question.town_or_city = ""
+        question.county = "Lancashire"
+        question.postcode = ""
+        expect(question).not_to be_valid
+        expect(question.errors[:address1]).to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.blank"))
+        expect(question.errors[:town_or_city]).to include(I18n.t("activemodel.errors.models.question/address.attributes.town_or_city.blank"))
+        expect(question.errors[:postcode]).to include(I18n.t("activemodel.errors.models.question/address.attributes.postcode.blank"))
       end
 
       it "returns \"\" for show_answer" do

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -143,9 +143,9 @@ RSpec.describe NotifyService do
         { input: "3.4 Question", output: "3\\.4 Question" },
         { input: "-23.4 answer", output: "\\-23\\.4 answer" },
         { input: "4.5.6", output: "4\\.5\\.6" },
-        { input: "\n\n# Test \n\n## Test 2", output:"\\# Test\n\n\\#\\# Test 2"},
-        { input: "\n\n```# Test 3\n\n## Test 4", output:"\\`\\`\\`\\# Test 3\n\n\\#\\# Test 4"}, # escapes ```
-        { input: "\n\n\n\n\n```# Test \n\n\n\n\n\n## Test 3\n\n\n\n", output:"\\`\\`\\`\\# Test\n\n\\#\\# Test 3"},
+        { input: "\n\n# Test \n\n## Test 2", output: "\\# Test\n\n\\#\\# Test 2" },
+        { input: "\n\n```# Test 3\n\n## Test 4", output: "\\`\\`\\`\\# Test 3\n\n\\#\\# Test 4" }, # escapes ```
+        { input: "\n\n\n\n\n```# Test \n\n\n\n\n\n## Test 3\n\n\n\n", output: "\\`\\`\\`\\# Test\n\n\\#\\# Test 3" },
         { input: "test https://example.org # more text 19.5\n\nA new paragraph.", output: "test https://example.org \\# more text 19\\.5\n\nA new paragraph\\." },
         { input: "test https://example.org # more text 19.5\n\nA new paragraph.\n\n# another link http://gov.uk", output: "test https://example.org \\# more text 19\\.5\n\nA new paragraph\\.\n\n\\# another link http://gov.uk" },
         { input: "not a title\n====", output: "not a title\n\\_\\_\\_\\_" },

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -29,14 +29,14 @@ describe "forms/check_your_answers/show.html.erb" do
     end
   end
 
-  it 'displays two-thirds ' do
+  it "displays two-thirds" do
     expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop")
   end
 
   context "when full_width not set" do
     let(:full_width) { true }
 
-    it 'displays full width when set' do
+    it "displays full width when set" do
       expect(rendered).to have_css(".govuk-grid-column-full")
     end
   end


### PR DESCRIPTION
#### What problem does the pull request solve?
Fixes a bug with address validation where if an address question was optional the user could enter invalid input.

Also includes a couple of minor linting fixes from elsewhere that rubocop picked up.

Trello card: https://trello.com/c/TZsyB7DK/284-addresses-arent-validated-when-theyre-optional

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


