### PR TITLE
Copy Assets Into Correct Directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,7 @@ COPY --chown=ruby:ruby bin/ ./bin
 RUN chmod 0755 bin/*
 
 COPY --chown=ruby:ruby --from=build /usr/local/bundle /usr/local/bundle
-COPY --chown=ruby:ruby --from=build /app/public /public
-COPY --chown=ruby:ruby . .
+COPY --chown=ruby:ruby --from=build /app /app
 
 EXPOSE 3000
 


### PR DESCRIPTION
Do not copy the public assets into /public but instead copy them into /app/public which is where Rails expects them to be. We should revisit to make sure we only copy what we actually need between the build and final stages.

#### What problem does the pull request solve?
Forms-Runner running from the docker image was unable to find the precompiled public assets because they were being copied into the wrong directory. This copies the public assets and puts them under the `/app` working directory. We should revisit before going live to make sure we only copy the necessary files between build and final stages.

I have deployed this to dev environment and it works as expected to return the 404 page:
https://submit.dev.forms.service.gov.uk/

I have also run this with `docker-compose` and it works as expected.

I'll look at forms-admin and forms-api as I get to them as part of the replatforming work.


