### PR TITLE
Add page numbers to page save log events

### DIFF
--- a/app/lib/event_logger.rb
+++ b/app/lib/event_logger.rb
@@ -19,6 +19,7 @@ class EventLogger
       method: request&.method,
       form: context.form_name,
       question_text: page.question.question_text,
+      question_number: page.page_number,
     }
 
     item_to_log.merge!({ skipped_question: skipped_question.to_s }) unless skipped_question.nil?

--- a/app/lib/step_factory.rb
+++ b/app/lib/step_factory.rb
@@ -33,7 +33,7 @@ class StepFactory
     next_page_slug = page.has_next_page? ? page.next_page.to_s : CHECK_YOUR_ANSWERS_PAGE
     question = QuestionRegister.from_page(page)
 
-    Step.new(question:, page_id: page.id, form_id: @form_id, form_slug: @form_slug, next_page_slug:, page_slug:)
+    Step.new(question:, page_id: page.id, form_id: @form_id, form_slug: @form_slug, next_page_slug:, page_slug:, page_number: page.number(@form))
   end
 
   def start_step

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -13,4 +13,9 @@ class Page < ActiveResource::Base
   def has_next_page?
     @attributes.include?("next_page") && !@attributes["next_page"].nil?
   end
+
+  def number(form)
+    index = form.pages.index(self)
+    index + 1
+  end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,14 +1,15 @@
 class Step
   attr_accessor :page_id, :form_id, :form_slug, :question
-  attr_reader :next_page_slug, :page_slug
+  attr_reader :next_page_slug, :page_slug, :page_number
 
-  def initialize(question:, page_id:, form_id:, form_slug:, next_page_slug:, page_slug:)
+  def initialize(question:, page_id:, form_id:, form_slug:, next_page_slug:, page_slug:, page_number:)
     @question = question
     @page_id = page_id
     @page_slug = page_slug
     @form_id = form_id
     @form_slug = form_slug
     @next_page_slug = next_page_slug
+    @page_number = page_number
   end
 
   def id

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   config.force_ssl = true
 
   # Do not redirect for request to /ping because the healthcheck comes direct from the router
-  config.ssl_options = { redirect: { exclude: -> request { request.path =~ /\/ping$/ } } }
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path =~ /\/ping$/ } } }
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe EventLogger do
       url: "http://example.gov.uk",
       method: "GET",
       form: "Form 1",
+      question_number: 1,
       question_text: "Question one",
     }
   end
@@ -75,7 +76,7 @@ RSpec.describe EventLogger do
     it "logs a page event" do
       allow(described_class).to receive(:log).at_least(:once)
 
-      described_class.log_page_event(context, OpenStruct.new(question: page), request, "page_save", nil)
+      described_class.log_page_event(context, OpenStruct.new(question: page, page_number: 1), request, "page_save", nil)
 
       expect(described_class).to have_received(:log).with("page_save", page_log_item)
     end
@@ -98,6 +99,7 @@ RSpec.describe EventLogger do
         url: "http://example.gov.uk",
         method: "GET",
         form: "Form 1",
+        question_number: 1,
         question_text: "Question one",
         skipped_question: "true",
       }
@@ -106,7 +108,7 @@ RSpec.describe EventLogger do
     it "logs a page event with a question_skipped parameter" do
       allow(described_class).to receive(:log).at_least(:once)
 
-      described_class.log_page_event(context, OpenStruct.new(question: page), request, "optional_save", true)
+      described_class.log_page_event(context, OpenStruct.new(question: page, page_number: 1), request, "optional_save", true)
 
       expect(described_class).to have_received(:log).with("optional_save", page_log_item)
     end

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -298,6 +298,7 @@ RSpec.describe "Page Controller", type: :request do
           expect(EventLogger).to receive(:log).with("change_answer_page_save",
                                                     { form: "Form 1",
                                                       method: "POST",
+                                                      question_number: 1,
                                                       question_text: "Question one",
                                                       url: "http://www.example.com/form/2/form-1/1?changing_existing_answer=true&question%5Btext%5D=answer+text" })
           post save_form_page_path("form", 2, "form-1", 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
@@ -309,6 +310,7 @@ RSpec.describe "Page Controller", type: :request do
           expect(EventLogger).to receive(:log).with("first_page_save",
                                                     { form: "Form 1",
                                                       method: "POST",
+                                                      question_number: 1,
                                                       question_text: "Question one",
                                                       url: "http://www.example.com/form/2/form-1/1" })
           post save_form_page_path("form", 2, "form-1", 1), params: { question: { text: "answer text" } }
@@ -320,6 +322,7 @@ RSpec.describe "Page Controller", type: :request do
           expect(EventLogger).to receive(:log).with("page_save",
                                                     { form: "Form 1",
                                                       method: "POST",
+                                                      question_number: 2,
                                                       question_text: "Question two",
                                                       url: "http://www.example.com/form/2/form-1/2" })
           post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "answer text" } }
@@ -361,6 +364,7 @@ RSpec.describe "Page Controller", type: :request do
             expect(EventLogger).to receive(:log).with("optional_save",
                                                       { form: "Form 1",
                                                         method: "POST",
+                                                        question_number: 2,
                                                         question_text: "Question two",
                                                         skipped_question: "false",
                                                         url: "http://www.example.com/form/2/form-1/2" })
@@ -373,6 +377,7 @@ RSpec.describe "Page Controller", type: :request do
             expect(EventLogger).to receive(:log).with("optional_save",
                                                       { form: "Form 1",
                                                         method: "POST",
+                                                        question_number: 2,
                                                         question_text: "Question two",
                                                         skipped_question: "true",
                                                         url: "http://www.example.com/form/2/form-1/2" })


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds page numbers to the existing log events. 

Trello card: https://trello.com/c/gdivugjM/322-log-the-question-number

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
