### PR TITLE
Add selection list answer type

### DIFF
--- a/app/lib/question_register.rb
+++ b/app/lib/question_register.rb
@@ -17,10 +17,12 @@ class QuestionRegister
               Question::LongText
             when :number
               Question::Number
+            when :selection
+              Question::Selection
             else
               raise ArgumentError, "Unexpected answer_type for page #{page.id}: #{page.answer_type}"
             end
     hint_text = page.respond_to?(:hint_text) ? page.hint_text : nil
-    klass.new({}, { question_text: page.question_text, question_short_name: page.question_short_name, hint_text:, is_optional: page.is_optional })
+    klass.new({}, { question_text: page.question_text, question_short_name: page.question_short_name, hint_text:, is_optional: page.is_optional, answer_settings: page.answer_settings })
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -18,4 +18,8 @@ class Page < ActiveResource::Base
     index = form.pages.index(self)
     index + 1
   end
+
+  def answer_settings
+    @attributes["answer_settings"] || {}
+  end
 end

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -5,7 +5,7 @@ module Question
     include ActiveModel::Serialization
     include ActiveModel::Attributes
 
-    attr_accessor :question_text, :question_short_name, :hint_text
+    attr_accessor :question_text, :question_short_name, :hint_text, :answer_settings
 
     def initialize(attributes = {}, options = {})
       super(attributes)
@@ -13,6 +13,7 @@ module Question
       @question_short_name = options[:question_short_name]
       @hint_text = options[:hint_text]
       @is_optional = options[:is_optional]
+      @answer_settings = options[:answer_settings]
     end
 
     def attributes

--- a/app/models/question/selection.rb
+++ b/app/models/question/selection.rb
@@ -45,7 +45,7 @@ module Question
     end
 
     def validate_checkbox
-      return errors.add(:selection, :blank) if selection_without_blanks.empty?
+      return errors.add(:selection, is_optional? ? :both_none_and_value_selected : :checkbox_blank) if selection_without_blanks.empty?
       return errors.add(:selection, :both_none_and_value_selected) if selection_without_blanks.count > 1 && :none_of_the_above.to_s.in?(selection_without_blanks)
       return errors.add(:selection, :inclusion) if selection_without_blanks.any? { |item| allowed_options.exclude?(item.to_sym) }
     end

--- a/app/models/question/selection.rb
+++ b/app/models/question/selection.rb
@@ -3,6 +3,7 @@ module Question
     attribute :selection
     validates :selection, presence: true
     validate :selection, :validate_checkbox, if: :allow_multiple_answers?
+    validate :selection, :validate_radio, unless: :allow_multiple_answers?
 
     def allow_multiple_answers?
       answer_settings.allow_multiple_answers == "true"
@@ -18,13 +19,26 @@ module Question
 
   private
 
+    def allowed_options
+      options = answer_settings.selection_options.map(&:name)
+      if is_optional?
+        options.concat(["None of the above"])
+      end
+      options
+    end
+
     def selection_without_blanks
       selection.reject(&:blank?)
+    end
+
+    def validate_radio
+      return errors.add(:selection, :inclusion) if allowed_options.exclude?(selection)
     end
 
     def validate_checkbox
       return errors.add(:selection, :blank) if selection_without_blanks.empty?
       return errors.add(:selection, :both_none_and_value_selected) if selection_without_blanks.count > 1 && "None of the above".in?(selection_without_blanks)
+      return errors.add(:selection, :inclusion) if selection_without_blanks.any? { |item| allowed_options.exclude?(item) }
     end
   end
 end

--- a/app/models/question/selection.rb
+++ b/app/models/question/selection.rb
@@ -1,6 +1,8 @@
 module Question
   class Selection < QuestionBase
     attribute :selection
+    validates :selection, presence: true
+    validate :selection, :validate_checkbox, if: :allow_multiple_answers
 
     def allow_multiple_answers
       answer_settings.allow_multiple_answers == "true"
@@ -8,10 +10,21 @@ module Question
 
     def show_answer
       if allow_multiple_answers
-        attribute_names.map { |attribute| send(attribute) }.first.reject(&:blank?)&.join(", ")
+        selection_without_blanks&.join(", ")
       else
-        attribute_names.map { |attribute| send(attribute) }.reject(&:blank?)&.join(", ")
+        selection
       end
+    end
+
+  private
+
+    def selection_without_blanks
+      selection.reject(&:blank?)
+    end
+
+    def validate_checkbox
+      return errors.add(:selection, :blank) if selection_without_blanks.empty?
+      return errors.add(:selection, :none_and_value) if selection_without_blanks.count > 1 && "None of the above".in?(selection_without_blanks)
     end
   end
 end

--- a/app/models/question/selection.rb
+++ b/app/models/question/selection.rb
@@ -10,19 +10,28 @@ module Question
     end
 
     def show_answer
-      if allow_multiple_answers?
-        selection_without_blanks&.join(", ")
-      else
-        selection
-      end
+      answer = if allow_multiple_answers?
+                 selection_without_blanks.join(", ")
+               else
+                 selection
+               end
+      replace_none_of_the_above(answer)
     end
 
   private
 
+    def replace_none_of_the_above(answer)
+      if answer == :none_of_the_above.to_s
+        I18n.t("page.none_of_the_above")
+      else
+        answer
+      end
+    end
+
     def allowed_options
-      options = answer_settings.selection_options.map(&:name)
+      options = answer_settings.selection_options.map(&:name).map(&:to_sym)
       if is_optional?
-        options.concat(["None of the above"])
+        options.concat([:none_of_the_above])
       end
       options
     end
@@ -32,13 +41,13 @@ module Question
     end
 
     def validate_radio
-      return errors.add(:selection, :inclusion) if allowed_options.exclude?(selection)
+      return errors.add(:selection, :inclusion) if allowed_options.exclude?(selection.to_sym)
     end
 
     def validate_checkbox
       return errors.add(:selection, :blank) if selection_without_blanks.empty?
-      return errors.add(:selection, :both_none_and_value_selected) if selection_without_blanks.count > 1 && "None of the above".in?(selection_without_blanks)
-      return errors.add(:selection, :inclusion) if selection_without_blanks.any? { |item| allowed_options.exclude?(item) }
+      return errors.add(:selection, :both_none_and_value_selected) if selection_without_blanks.count > 1 && :none_of_the_above.to_s.in?(selection_without_blanks)
+      return errors.add(:selection, :inclusion) if selection_without_blanks.any? { |item| allowed_options.exclude?(item.to_sym) }
     end
   end
 end

--- a/app/models/question/selection.rb
+++ b/app/models/question/selection.rb
@@ -1,0 +1,17 @@
+module Question
+  class Selection < QuestionBase
+    attribute :selection
+
+    def allow_multiple_answers
+      answer_settings.allow_multiple_answers == "true"
+    end
+
+    def show_answer
+      if allow_multiple_answers
+        attribute_names.map { |attribute| send(attribute) }.first.reject(&:blank?)&.join(", ")
+      else
+        attribute_names.map { |attribute| send(attribute) }.reject(&:blank?)&.join(", ")
+      end
+    end
+  end
+end

--- a/app/models/question/selection.rb
+++ b/app/models/question/selection.rb
@@ -24,7 +24,7 @@ module Question
 
     def validate_checkbox
       return errors.add(:selection, :blank) if selection_without_blanks.empty?
-      return errors.add(:selection, :none_and_value) if selection_without_blanks.count > 1 && "None of the above".in?(selection_without_blanks)
+      return errors.add(:selection, :both_none_and_value_selected) if selection_without_blanks.count > 1 && "None of the above".in?(selection_without_blanks)
     end
   end
 end

--- a/app/models/question/selection.rb
+++ b/app/models/question/selection.rb
@@ -2,14 +2,14 @@ module Question
   class Selection < QuestionBase
     attribute :selection
     validates :selection, presence: true
-    validate :selection, :validate_checkbox, if: :allow_multiple_answers
+    validate :selection, :validate_checkbox, if: :allow_multiple_answers?
 
-    def allow_multiple_answers
+    def allow_multiple_answers?
       answer_settings.allow_multiple_answers == "true"
     end
 
     def show_answer
-      if allow_multiple_answers
+      if allow_multiple_answers?
         selection_without_blanks&.join(", ")
       else
         selection

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -41,7 +41,7 @@ class Step
   end
 
   def params
-    @question.attribute_names
+    @question.attribute_names.concat([selection: []])
   end
 
   def valid?
@@ -66,6 +66,10 @@ class Step
 
   def question_short_name
     @question.question_short_name
+  end
+
+  def answer_settings
+    @question.answer_settings
   end
 
   def end_page?

--- a/app/views/question/_selection.html.erb
+++ b/app/views/question/_selection.html.erb
@@ -1,11 +1,11 @@
-<% if page.answer_settings.allow_multiple_answers == "true" %>
+<% if page.question.allow_multiple_answers? %>
   <%= form.govuk_check_boxes_fieldset(:selection, legend: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }) do %>
     <% page.answer_settings.selection_options.each_with_index do |option, index| %>
       <%= form.govuk_check_box :selection, option.name, label: { text: option.name }, link_errors: index == 0  %>
     <% end %>
     <% if page.question.is_optional? %>
       <%= form.govuk_check_box_divider %>
-      <%= form.govuk_check_box :selection, 'None of the above', exclusive: true, label: { text: 'None of the above' } %>
+      <%= form.govuk_check_box :selection, 'None of the above', exclusive: true, label: { text: t('page.none_of_the_above') } %>
     <% end %>
   <% end %>
 <% else %>
@@ -16,7 +16,7 @@
     <% end %>
     <% if page.question.is_optional? %>
       <%= form.govuk_radio_divider %>
-      <%= form.govuk_radio_button :selection, 'None of the above', label: { text: 'None of the above' } %>
+      <%= form.govuk_radio_button :selection, 'None of the above', label: { text: t('page.none_of_the_above') } %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/question/_selection.html.erb
+++ b/app/views/question/_selection.html.erb
@@ -5,7 +5,7 @@
     <% end %>
     <% if page.question.is_optional? %>
       <%= form.govuk_check_box_divider %>
-      <%= form.govuk_check_box :selection, 'None of the above', exclusive: true, label: { text: t('page.none_of_the_above') } %>
+      <%= form.govuk_check_box :selection, :none_of_the_above.to_s, exclusive: true, label: { text: t('page.none_of_the_above') } %>
     <% end %>
   <% end %>
 <% else %>
@@ -16,7 +16,7 @@
     <% end %>
     <% if page.question.is_optional? %>
       <%= form.govuk_radio_divider %>
-      <%= form.govuk_radio_button :selection, 'None of the above', label: { text: t('page.none_of_the_above') } %>
+      <%= form.govuk_radio_button :selection, :none_of_the_above.to_s, label: { text: t('page.none_of_the_above') } %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/question/_selection.html.erb
+++ b/app/views/question/_selection.html.erb
@@ -1,0 +1,17 @@
+<% if page.answer_settings.allow_multiple_answers == "true" %>
+  <%= form.govuk_collection_check_boxes(
+        :selection,
+        page.answer_settings.selection_options,
+        ->(option) { option.name },
+        ->(option) { option.name },
+        legend: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }
+  )  %>
+<% else %>
+  <%= form.govuk_collection_radio_buttons(
+        :selection,
+        page.answer_settings.selection_options,
+        :name,
+        :name,
+        legend: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }
+  )  %>
+<% end %>

--- a/app/views/question/_selection.html.erb
+++ b/app/views/question/_selection.html.erb
@@ -1,17 +1,22 @@
 <% if page.answer_settings.allow_multiple_answers == "true" %>
-  <%= form.govuk_collection_check_boxes(
-        :selection,
-        page.answer_settings.selection_options,
-        ->(option) { option.name },
-        ->(option) { option.name },
-        legend: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }
-  )  %>
+  <%= form.govuk_check_boxes_fieldset(:selection, legend: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }) do %>
+    <% page.answer_settings.selection_options.each_with_index do |option, index| %>
+      <%= form.govuk_check_box :selection, option.name, label: { text: option.name }, link_errors: index == 0  %>
+    <% end %>
+    <% if page.question.is_optional? %>
+      <%= form.govuk_check_box_divider %>
+      <%= form.govuk_check_box :selection, 'None of the above', exclusive: true, label: { text: 'None of the above' } %>
+    <% end %>
+  <% end %>
 <% else %>
-  <%= form.govuk_collection_radio_buttons(
-        :selection,
-        page.answer_settings.selection_options,
-        :name,
-        :name,
-        legend: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }
-  )  %>
+  <%= form.govuk_radio_buttons_fieldset(:selection, legend: { tag: 'h1', size: 'l', text: page.question_text }, hint: { text: page.hint_text }) do %>
+    <%= form.hidden_field :selection %>
+    <% page.answer_settings.selection_options.each_with_index do |option, index| %>
+      <%= form.govuk_radio_button :selection, option.name, label: { text: option.name }, link_errors: index == 0  %>
+    <% end %>
+    <% if page.question.is_optional? %>
+      <%= form.govuk_radio_divider %>
+      <%= form.govuk_radio_button :selection, 'None of the above', label: { text: 'None of the above' } %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
     submitted:
       title: Your form has been submitted
   page:
+    none_of_the_above: None of the above
     optional: "%{question_text} (optional)"
   page_titles:
     error_prefix: 'Error: '

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,11 @@ en:
               invalid_phone_number: Enter a phone number using only numbers, spaces,’ext’, ‘-’ or ‘+’
               phone_too_long: The phone number should have 15 digits or less
               phone_too_short: The phone number should have 8 digits or more
+        question/selection:
+          attributes:
+            selection:
+              blank: Select an answer
+              both_none_and_value_selected: Select one or more options, or select ‘None of the above’
         question/single_line:
           attributes:
             text:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
             selection:
               blank: Select an answer
               both_none_and_value_selected: Select one or more options, or select ‘None of the above’
+              inclusion: Select an answer from the list
         question/single_line:
           attributes:
             text:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,8 +49,9 @@ en:
         question/selection:
           attributes:
             selection:
-              blank: Select an answer
+              blank: Select one option
               both_none_and_value_selected: Select one or more options, or select ‘None of the above’
+              checkbox_blank: Select one or more options
               inclusion: Select an answer from the list
         question/single_line:
           attributes:

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -25,4 +25,25 @@ RSpec.describe Page, type: :model do
   it "returns the page for a form" do
     expect(described_class.find(1, params: { form_id: 2 })).to have_attributes(id: 1, question_text: "Question text", answer_type: "date")
   end
+
+  context "when answer_settings is not present" do
+    it "returns an empty object for answer_settings" do
+      expect(described_class.find(1, params: { form_id: 2 })).to have_attributes(answer_settings: {})
+    end
+  end
+
+  context "when answer_settings is present" do
+    let(:response_data) do
+      {
+        id: 1,
+        question_text: "Question text",
+        answer_type: "selection",
+        answer_settings: { allow_multiple_answers: "true" },
+      }.to_json
+    end
+
+    it "returns an answer settings object for answer_settings" do
+      expect(described_class.find(1, params: { form_id: 2 }).answer_settings.attributes).to eq({ "allow_multiple_answers" => "true" })
+    end
+  end
 end

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe Question::Selection, type: :model do
+  subject(:question) { described_class.new({}, options) }
+
+  let(:options) { { is_optional:, answer_settings: OpenStruct.new({ allow_multiple_answers:, selection_options: [OpenStruct.new({ name: "option 1" }), OpenStruct.new({ name: "option 2" })] }) } }
+
+  context "when the selection question is a checkbox" do
+    let(:allow_multiple_answers) { "true" }
+    let(:is_optional) { false }
+
+    before do
+      question.selection = []
+    end
+
+    it_behaves_like "a question model"
+
+    it "returns invalid with blank selection" do
+      question.selection = [""]
+      expect(question).not_to be_valid
+      expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.blank"))
+      expect(question.show_answer).to eq ""
+    end
+
+    it "returns valid with one item selected" do
+      question.selection = ["option 1"]
+      expect(question).to be_valid
+      expect(question.errors[:selection]).to be_empty
+    end
+
+    it "returns valid with two items selected" do
+      question.selection = ["option 1", "option 2"]
+      expect(question).to be_valid
+      expect(question.errors[:selection]).to be_empty
+    end
+
+    it "calculates allow_multiple_answers correctly" do
+      expect(question.allow_multiple_answers).to be true
+    end
+
+    context "when question is optional" do
+      let(:is_optional) { true }
+
+      it "returns valid with none of the above selected" do
+        question.selection = ["None of the above"]
+        expect(question).to be_valid
+        expect(question.errors[:selection]).to be_empty
+      end
+
+      it "returns invalid with both an item and none selected" do
+        question.selection = ["option 1", "None of the above"]
+        expect(question).not_to be_valid
+        expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.both_none_and_value_selected"))
+      end
+    end
+  end
+
+  context "when the selection question is a radio button" do
+    let(:allow_multiple_answers) { "false" }
+    let(:is_optional) { false }
+
+    before do
+      question.selection = ""
+    end
+
+    it_behaves_like "a question model"
+
+    it "returns invalid with blank selection" do
+      question.selection = ""
+      expect(question).not_to be_valid
+      expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.blank"))
+      expect(question.show_answer).to eq ""
+    end
+
+    it "returns valid with one item selected" do
+      question.selection = "option 1"
+      expect(question).to be_valid
+      expect(question.errors[:selection]).to be_empty
+    end
+
+    it "calculates allow_multiple_answers correctly" do
+      expect(question.allow_multiple_answers).to be false
+    end
+
+    context "when question is optional" do
+      let(:is_optional) { true }
+
+      it "returns valid with none of the above selected" do
+        question.selection = "None of the above"
+        expect(question).to be_valid
+        expect(question.errors[:selection]).to be_empty
+      end
+    end
+  end
+end

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -19,7 +19,12 @@ RSpec.describe Question::Selection, type: :model do
       question.selection = [""]
       expect(question).not_to be_valid
       expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.blank"))
-      expect(question.show_answer).to eq ""
+    end
+
+    it "returns invalid when selection is not one of the options" do
+      question.selection = ["option 1000"]
+      expect(question).not_to be_valid
+      expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.inclusion"))
     end
 
     it "returns valid with one item selected" do
@@ -69,7 +74,12 @@ RSpec.describe Question::Selection, type: :model do
       question.selection = ""
       expect(question).not_to be_valid
       expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.blank"))
-      expect(question.show_answer).to eq ""
+    end
+
+    it "returns invalid when selection is not one of the options" do
+      question.selection = "option 1000"
+      expect(question).not_to be_valid
+      expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.inclusion"))
     end
 
     it "returns valid with one item selected" do

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -47,13 +47,13 @@ RSpec.describe Question::Selection, type: :model do
       let(:is_optional) { true }
 
       it "returns valid with none of the above selected" do
-        question.selection = ["None of the above"]
+        question.selection = [:none_of_the_above.to_s]
         expect(question).to be_valid
         expect(question.errors[:selection]).to be_empty
       end
 
       it "returns invalid with both an item and none selected" do
-        question.selection = ["option 1", "None of the above"]
+        question.selection = ["option 1", :none_of_the_above.to_s]
         expect(question).not_to be_valid
         expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.both_none_and_value_selected"))
       end
@@ -96,7 +96,7 @@ RSpec.describe Question::Selection, type: :model do
       let(:is_optional) { true }
 
       it "returns valid with none of the above selected" do
-        question.selection = "None of the above"
+        question.selection = :none_of_the_above.to_s
         expect(question).to be_valid
         expect(question.errors[:selection]).to be_empty
       end

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Question::Selection, type: :model do
     end
 
     it "calculates allow_multiple_answers correctly" do
-      expect(question.allow_multiple_answers).to be true
+      expect(question.allow_multiple_answers?).to be true
     end
 
     context "when question is optional" do
@@ -79,7 +79,7 @@ RSpec.describe Question::Selection, type: :model do
     end
 
     it "calculates allow_multiple_answers correctly" do
-      expect(question.allow_multiple_answers).to be false
+      expect(question.allow_multiple_answers?).to be false
     end
 
     context "when question is optional" do

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Question::Selection, type: :model do
     it "returns invalid with blank selection" do
       question.selection = [""]
       expect(question).not_to be_valid
-      expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.blank"))
+      expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.checkbox_blank"))
     end
 
     it "returns invalid when selection is not one of the options" do

--- a/spec/support/shared_examples/question_models.rb
+++ b/spec/support/shared_examples/question_models.rb
@@ -1,6 +1,4 @@
 RSpec.shared_examples "a question model" do |_parameter|
-  let(:question) { described_class.new }
-
   it "responds with text to .show_answer" do
     expect(question.show_answer).to be_kind_of(String)
   end

--- a/spec/views/question/_selection.html.erb_spec.rb
+++ b/spec/views/question/_selection.html.erb_spec.rb
@@ -1,0 +1,110 @@
+require "rails_helper"
+
+describe "question/_selection.html.erb" do
+  let(:page) do
+    Page.new({
+      id: 1,
+      question_text: "Which city do you live in?",
+      question_short_name: nil,
+      hint_text: nil,
+      answer_type: "selection",
+      is_optional:,
+      answer_settings: OpenStruct.new({ allow_multiple_answers:, selection_options: [OpenStruct.new({ name: "Bristol" }), OpenStruct.new({ name: "London" }), OpenStruct.new({ name: "Manchester" })] }),
+    })
+  end
+
+  let(:question) do
+    QuestionRegister.from_page(page)
+  end
+
+  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1) }
+
+  let(:form) do
+    GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+  end
+
+  before do
+    render partial: "question/selection", locals: { page: step, form: }
+  end
+
+  context "when the question allows multiple answers" do
+    let(:allow_multiple_answers) { "true" }
+
+    context "when the question is not optional" do
+      let(:is_optional) { false }
+
+      it "contains the question" do
+        expect(rendered).to have_css("h1", text: "Which city do you live in?")
+      end
+
+      it "contains the options" do
+        expect(rendered).to have_css("input[type='checkbox'] + label", text: "Bristol")
+        expect(rendered).to have_css("input[type='checkbox'] + label", text: "London")
+        expect(rendered).to have_css("input[type='checkbox'] + label", text: "Manchester")
+      end
+
+      it "does not contain the 'None of the above' option" do
+        expect(rendered).not_to have_css("input[type='checkbox'] + label", text: "None of the above")
+      end
+    end
+
+    context "when the question is optional" do
+      let(:is_optional) { true }
+
+      it "contains the question" do
+        expect(rendered).to have_css("h1", text: "Which city do you live in?")
+      end
+
+      it "contains the options" do
+        expect(rendered).to have_css("input[type='checkbox'] + label", text: "Bristol")
+        expect(rendered).to have_css("input[type='checkbox'] + label", text: "London")
+        expect(rendered).to have_css("input[type='checkbox'] + label", text: "Manchester")
+      end
+
+      it "contains the 'None of the above' option" do
+        expect(rendered).to have_css("input[type='checkbox'] + label", text: "None of the above")
+      end
+    end
+  end
+
+  context "when the question does not allow multiple answers" do
+    let(:allow_multiple_answers) { "false" }
+
+    context "when the question is not optional" do
+      let(:is_optional) { false }
+
+      it "contains the question" do
+        expect(rendered).to have_css("h1", text: "Which city do you live in?")
+      end
+
+      it "contains the options" do
+        expect(rendered).to have_css("input[type='radio'] + label", text: "Bristol")
+        expect(rendered).to have_css("input[type='radio'] + label", text: "London")
+        expect(rendered).to have_css("input[type='radio'] + label", text: "Manchester")
+      end
+
+      it "does not contain the 'None of the above' option" do
+        expect(rendered).not_to have_css("input[type='radio'] + label", text: "None of the above")
+      end
+    end
+
+    context "when the question is optional" do
+      let(:is_optional) { true }
+
+      it "contains the question" do
+        expect(rendered).to have_css("h1", text: "Which city do you live in?")
+      end
+
+      it "contains the options" do
+        expect(rendered).to have_css("input[type='radio'] + label", text: "Bristol")
+        expect(rendered).to have_css("input[type='radio'] + label", text: "London")
+        expect(rendered).to have_css("input[type='radio'] + label", text: "Manchester")
+      end
+
+      it "contains the 'None of the above' option" do
+        expect(rendered).to have_css("input[type='radio'] + label", text: "None of the above")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds a question type for selections, which can be either checkboxes or radios depending on the value of `answer_settings.allow_multiple_answers`.

Trello card: https://trello.com/c/VLYnibtv/225-add-selection-question-type-to-runner

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
