### PR TITLE
Sentry stop 404 for malicious get requests to from pages

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -1,7 +1,7 @@
 module Forms
   class CheckYourAnswersController < BaseController
     def show
-      return redirect_to form_page_path(current_context.form, current_context.form_slug, current_context.next_page_slug) unless current_context.can_visit?("check_your_answers")
+      return redirect_to form_page_path(current_context.form, current_context.form_slug, current_context.next_page_slug) unless current_context.can_visit?(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)
 
       previous_step = current_context.previous_step("check_your_answers")
       @back_link = form_page_path(current_context.form, current_context.form_slug, previous_step)

--- a/app/lib/step_factory.rb
+++ b/app/lib/step_factory.rb
@@ -1,6 +1,7 @@
 class StepFactory
   START_PAGE = "_start".freeze
   CHECK_YOUR_ANSWERS_PAGE = "check_your_answers".freeze
+  PAGE_SLUG_REGEX = /\d+|check_your_answers/
 
   class PageNotFoundError < StandardError
     def initialize(msg = "Page not found.")

--- a/app/lib/step_factory.rb
+++ b/app/lib/step_factory.rb
@@ -1,7 +1,6 @@
 class StepFactory
   START_PAGE = "_start".freeze
-  CHECK_YOUR_ANSWERS_PAGE = "check_your_answers".freeze
-  PAGE_SLUG_REGEX = /\d+|check_your_answers/
+  PAGE_SLUG_REGEX = Regexp.union([/\d+/, Regexp.new(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)])
 
   class PageNotFoundError < StandardError
     def initialize(msg = "Page not found.")
@@ -25,13 +24,13 @@ class StepFactory
     page_slug = page_slug_or_start.to_s == START_PAGE ? @form.start_page : page_slug_or_start
     page_slug = page_slug.to_s
 
-    return CheckYourAnswersStep.new(form_id: @form_id) if page_slug == CHECK_YOUR_ANSWERS_PAGE
+    return CheckYourAnswersStep.new(form_id: @form_id) if page_slug == CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG
 
     # for now, we use the page id as slug
     page = @pages.find { |p| p.id.to_s == page_slug }
     raise PageNotFoundError, "Can't find page #{page_slug}" if page.nil?
 
-    next_page_slug = page.has_next_page? ? page.next_page.to_s : CHECK_YOUR_ANSWERS_PAGE
+    next_page_slug = page.has_next_page? ? page.next_page.to_s : CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG
     question = QuestionRegister.from_page(page)
 
     Step.new(question:, page_id: page.id, form_id: @form_id, form_slug: @form_slug, next_page_slug:, page_slug:, page_number: page.number(@form))

--- a/app/models/check_your_answers_step.rb
+++ b/app/models/check_your_answers_step.rb
@@ -1,11 +1,13 @@
 class CheckYourAnswersStep
+  CHECK_YOUR_ANSWERS_PAGE_SLUG = "check_your_answers".freeze
+
   attr_reader :next_page_slug, :page_slug, :page_id, :form_id
 
   def initialize(form_id:)
     @form_id = form_id
-    @page_id = "check_your_answers"
+    @page_id = CHECK_YOUR_ANSWERS_PAGE_SLUG
     @next_page_slug = "_submit" # not used for now
-    @page_slug = "check_your_answers"
+    @page_slug = CHECK_YOUR_ANSWERS_PAGE_SLUG
   end
 
   def ==(other)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     get "/:form_id" => "forms/base#redirect_to_friendly_url_start", as: :form_id
     scope "/:form_id/:form_slug" do
       get "/" => "forms/base#redirect_to_friendly_url_start", as: :form
-      get "/check_your_answers" => "forms/check_your_answers#show", as: :check_your_answers
+      get "/#{CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG}" => "forms/check_your_answers#show", as: :check_your_answers
       post "/submit_answers" => "forms/submit_answers#submit_answers", as: :form_submit_answers
       get "/submitted" => "forms/submitted#submitted", as: :form_submitted
       get "/privacy" => "forms/privacy_page#show", as: :form_privacy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
       get "/submitted" => "forms/submitted#submitted", as: :form_submitted
       get "/privacy" => "forms/privacy_page#show", as: :form_privacy
       get "/:page_slug/change" => "forms/page#show", as: :form_change_answer, defaults: { changing_existing_answer: true }
-      get "/:page_slug" => "forms/page#show", as: :form_page
+      get "/:page_slug" => "forms/page#show", constraints: { page_slug: StepFactory::PAGE_SLUG_REGEX }, as: :form_page
       post "/:page_slug" => "forms/page#save", as: :save_form_page
     end
   end

--- a/spec/lib/context_spec.rb
+++ b/spec/lib/context_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe Context do
 
   [
     ["no input", { answers: [], request_step: 1 }, { next_page_slug: "2", start_id: 1, next_incomplete_page_id: "1", current_step_id: 1, previous_step_id: nil }],
-    ["first question complete, request second step", { answers: [{ text: "q1 answer" }], request_step: 2 }, { next_page_slug: "check_your_answers", start_id: 1, previous_step_id: 1, next_incomplete_page_id: "2", current_step_id: 2 }],
+    ["first question complete, request second step", { answers: [{ text: "q1 answer" }], request_step: 2 }, { next_page_slug: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG, start_id: 1, previous_step_id: 1, next_incomplete_page_id: "2", current_step_id: 2 }],
     ["first question complete, request first step", { answers: [{ text: "q1 answer" }], request_step: 1 }, { next_page_slug: "2", start_id: 1, previous_step_id: nil, next_incomplete_page_id: "2", current_step_id: 1 }],
-    ["all questions complete, request second step", { answers: [{ text: "q1 answer" }, { text: "q2 answer" }], request_step: 2 }, { next_page_slug: "check_your_answers", start_id: 1, previous_step_id: 1, next_incomplete_page_id: "check_your_answers", current_step_id: 2 }],
+    ["all questions complete, request second step", { answers: [{ text: "q1 answer" }, { text: "q2 answer" }], request_step: 2 }, { next_page_slug: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG, start_id: 1, previous_step_id: 1, next_incomplete_page_id: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG, current_step_id: 2 }],
   ].each do |variation, input, expected_output|
     context "with #{variation}" do
       before do

--- a/spec/lib/step_factory_spec.rb
+++ b/spec/lib/step_factory_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe StepFactory do
+  describe StepFactory::PAGE_SLUG_REGEX do
+
+    it "matches valid page_id values" do
+      %w[1 123 0123456789 check_your_answers].each do |string|
+        expect(StepFactory::PAGE_SLUG_REGEX.match(string)).to be_truthy
+      end
+    end
+
+    it "does not match invalid page_id values" do
+      %w[no ten inspect_your_answers /secret/login.php ].each do |string|
+        expect(StepFactory::PAGE_SLUG_REGEX.match(string)).to be_falsy
+      end
+    end
+  end
+end

--- a/spec/requests/check_your_answers_spec.rb
+++ b/spec/requests/check_your_answers_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe "Check Your Answers Controller", type: :request do
         end
 
         it "Logs the form_check_answers event" do
-          expect(EventLogger).to have_received(:log).with("form_check_answers", { form: "Form 1", method: "GET", url: "http://www.example.com/form/2/form-1/check_your_answers" })
+          expect(EventLogger).to have_received(:log).with("form_check_answers", { form: "Form 1", method: "GET", url: "http://www.example.com/form/2/form-1/#{CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG}" })
         end
       end
 

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -125,6 +125,31 @@ RSpec.describe "Page Controller", type: :request do
     end
 
     context "with preview mode off" do
+      [
+        "/form/2/1/__",
+        "/form/2/1/debug.cgi",
+        "/form/2/1/hsqldb%0A",
+        "/form/2/1/index_sso.php",
+        "/form/2/1/setup.php",
+        "/form/2/1/test.cgi",
+        "/form/2/1/x"
+      ].each do |path|
+        context "with an invalid URL: #{path}" do
+          before do
+            allow(Sentry).to receive(:capture_exception)
+            get path
+          end
+
+          it "returns a 404" do
+            expect(response.status).to eq(404)
+          end
+
+          it "does not send an expception to sentry" do
+            expect(Sentry).not_to have_received(:capture_exception)
+          end
+        end
+      end
+
       it "Returns a 200" do
         get form_page_path("form", 2, "form-1", 1)
         expect(response.status).to eq(200)

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -126,6 +126,12 @@ RSpec.describe "Page Controller", type: :request do
 
     context "with preview mode off" do
       [
+        "/form/2/1/check_your_answers_trailing",
+        "/form/2/1/leading_check_your_answers",
+        "/form/2/1/1/check_your_answers",
+        "/form/2/1/1/ChEck_YouR_aNswers",
+        "/form/2/1/1/0",
+        "/form/2/1/1/%20123",
         "/form/2/1/__",
         "/form/2/1/debug.cgi",
         "/form/2/1/hsqldb%0A",


### PR DESCRIPTION
# Reduce sentry noise by removing PageNotFound error from step controller

Sentry reports errors thrown by the pages controller when URLs for form pages contain invalid page URLs or trailing characters. This happens a lot because of bots looking for well known exploitable URLS.

The sentry issue can be found here:
https://sentry.io/organizations/govuk-forms/issues/3551642298/?project=6576261&query=is%3Aunresolved&referrer=issue-stream

This PR includes a failing test and a fix. 

The fix adds a regex constraint on the route which connects requests to the forms/page_controller. By restricting the page_id to being a string of digits or "check_your_answers" we can stop the controller action being called when given invalid urls. This causes the standard 404 route to match, returning a 404.

Only the get page route has been modified. If we find the other page_id requests have similar issues, we might consider wrapping them with constraints, or adding a guard clause to the base_controller.

Trello card: https://trello.com/c/hDbXwqQ6/326-sentry-stop-logging-404-errors-for-bots-trying-to-hack-forms-runner

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
