### PR TITLE
Rename and negate 'allow multiple answers'

### DIFF
--- a/app/models/question/selection.rb
+++ b/app/models/question/selection.rb
@@ -6,7 +6,7 @@ module Question
     validate :selection, :validate_radio, unless: :allow_multiple_answers?
 
     def allow_multiple_answers?
-      answer_settings.allow_multiple_answers == "true"
+      answer_settings.only_one_option != "true"
     end
 
     def show_answer

--- a/spec/lib/step_factory_spec.rb
+++ b/spec/lib/step_factory_spec.rb
@@ -2,16 +2,15 @@ require "rails_helper"
 
 RSpec.describe StepFactory do
   describe StepFactory::PAGE_SLUG_REGEX do
-
     it "matches valid page_id values" do
       %w[1 123 0123456789 check_your_answers].each do |string|
-        expect(StepFactory::PAGE_SLUG_REGEX.match(string)).to be_truthy
+        expect(described_class.match(string)).to be_truthy
       end
     end
 
     it "does not match invalid page_id values" do
-      %w[no ten inspect_your_answers /secret/login.php ].each do |string|
-        expect(StepFactory::PAGE_SLUG_REGEX.match(string)).to be_falsy
+      %w[no ten inspect_your_answers /secret/login.php].each do |string|
+        expect(described_class.match(string)).to be_falsy
       end
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe Page, type: :model do
         id: 1,
         question_text: "Question text",
         answer_type: "selection",
-        answer_settings: { allow_multiple_answers: "true" },
+        answer_settings: { only_one_option: "true" },
       }.to_json
     end
 
     it "returns an answer settings object for answer_settings" do
-      expect(described_class.find(1, params: { form_id: 2 }).answer_settings.attributes).to eq({ "allow_multiple_answers" => "true" })
+      expect(described_class.find(1, params: { form_id: 2 }).answer_settings.attributes).to eq({ "only_one_option" => "true" })
     end
   end
 end

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 RSpec.describe Question::Selection, type: :model do
   subject(:question) { described_class.new({}, options) }
 
-  let(:options) { { is_optional:, answer_settings: OpenStruct.new({ allow_multiple_answers:, selection_options: [OpenStruct.new({ name: "option 1" }), OpenStruct.new({ name: "option 2" })] }) } }
+  let(:options) { { is_optional:, answer_settings: OpenStruct.new({ only_one_option:, selection_options: [OpenStruct.new({ name: "option 1" }), OpenStruct.new({ name: "option 2" })] }) } }
 
   context "when the selection question is a checkbox" do
-    let(:allow_multiple_answers) { "true" }
+    let(:only_one_option) { "false" }
     let(:is_optional) { false }
 
     before do
@@ -61,7 +61,7 @@ RSpec.describe Question::Selection, type: :model do
   end
 
   context "when the selection question is a radio button" do
-    let(:allow_multiple_answers) { "false" }
+    let(:only_one_option) { "true" }
     let(:is_optional) { false }
 
     before do

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "Page Controller", type: :request do
         "/form/2/1/index_sso.php",
         "/form/2/1/setup.php",
         "/form/2/1/test.cgi",
-        "/form/2/1/x"
+        "/form/2/1/x",
       ].each do |path|
         context "with an invalid URL: #{path}" do
           before do

--- a/spec/views/question/_selection.html.erb_spec.rb
+++ b/spec/views/question/_selection.html.erb_spec.rb
@@ -9,7 +9,7 @@ describe "question/_selection.html.erb" do
       hint_text: nil,
       answer_type: "selection",
       is_optional:,
-      answer_settings: OpenStruct.new({ allow_multiple_answers:, selection_options: [OpenStruct.new({ name: "Bristol" }), OpenStruct.new({ name: "London" }), OpenStruct.new({ name: "Manchester" })] }),
+      answer_settings: OpenStruct.new({ only_one_option:, selection_options: [OpenStruct.new({ name: "Bristol" }), OpenStruct.new({ name: "London" }), OpenStruct.new({ name: "Manchester" })] }),
     })
   end
 
@@ -29,7 +29,7 @@ describe "question/_selection.html.erb" do
   end
 
   context "when the question allows multiple answers" do
-    let(:allow_multiple_answers) { "true" }
+    let(:only_one_option) { "false" }
 
     context "when the question is not optional" do
       let(:is_optional) { false }
@@ -69,7 +69,7 @@ describe "question/_selection.html.erb" do
   end
 
   context "when the question does not allow multiple answers" do
-    let(:allow_multiple_answers) { "false" }
+    let(:only_one_option) { "true" }
 
     context "when the question is not optional" do
       let(:is_optional) { false }


### PR DESCRIPTION
#### What problem does the pull request solve?
Renames the 'allow multiple answers' field to match the way it's presented in the admin design. This requires negating it - `allow_multiple_answers`  and `only_one_option` are opposites.

Trello card: https://trello.com/c/9AKruIBG/321-add-selection-question-type-to-admin-radio-buttons-only

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
