### PR TITLE
Fix attribute error

### DIFF
--- a/app/lib/form_context.rb
+++ b/app/lib/form_context.rb
@@ -14,6 +14,10 @@ class FormContext
     @store.dig(ROOT_KEY, form_key(step), page_key(step))
   end
 
+  def clear_stored_answer(step)
+    @store.dig(ROOT_KEY, form_key(step))&.delete(page_key(step))
+  end
+
   def clear(form_id)
     @store[ROOT_KEY][form_id.to_s] = nil
   end

--- a/app/lib/journey.rb
+++ b/app/lib/journey.rb
@@ -14,6 +14,9 @@ private
   def find_existing_step(page_slug)
     step = @step_factory.create_step(page_slug)
     step.load_from_context(@form_context) unless @form_context.get_stored_answer(step).nil?
+  rescue ActiveModel::UnknownAttributeError
+    @form_context.clear_stored_answer(step)
+    nil
   end
 
   def generate_completed_steps

--- a/spec/lib/form_context_spec.rb
+++ b/spec/lib/form_context_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe FormContext do
     expect(result).to eq("test answer")
   end
 
+  it "clears a single answer for a step" do
+    fc = described_class.new(store)
+    fc.save_step(step, "test answer")
+    expect(fc.get_stored_answer(step)).to eq("test answer")
+    fc.clear_stored_answer(step)
+    expect(fc.get_stored_answer(step)).to be_nil
+  end
+
+  it "does not error if removing a step which doesn't exist in the store" do
+    fc = described_class.new(store)
+    fc.save_step(step, "test answer")
+    fc.clear_stored_answer(step2)
+    expect(fc.get_stored_answer(step)).to eq("test answer")
+  end
+
   it "clears the session for a form" do
     fc = described_class.new(store)
     fc.save_step(step, "test answer")


### PR DESCRIPTION
## Fix failing form filler journeys when question type is changed

https://sentry.io/organizations/govuk-forms/issues/3670884315/?environment=local&project=6576261&query=is%3Aunresolved&referrer=issue-stream
https://trello.com/c/wyCLgyHJ/342-unknownattributeerror-when-changing-question-types

Form creators changing questions between some answer types can cause an
UnknownAttributeError for form fillers.

Steps to reproduce
- create a long text answer in admin
- preview the form and add text to the long text answer (so data is
  stored in Redis as text)
- change the long text question to a number in admin
- preview the page

Expected Behaviour

The new page should be loaded without an error, with the text I saved
earlier either preserved or deleted

Actual behaviour

The page throws an UnknownAttributeError because the runner attempts to
load the saved answer as text but the Number input only has a number
attribute.

This commit adds a test and fix to stop this disrupting form filler journeys.


#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
