### PR TITLE
Add hidden field for notify reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,8 @@
 
 .env
 .env.development.local
-.env.test.local	
-.env.production.local	
+.env.test.local
+.env.production.local
 
 coverage/
 

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -7,6 +7,7 @@ module Forms
       @back_link = form_page_path(current_context.form, current_context.form_slug, previous_step)
       @rows = check_your_answers_rows
       @form_submit_path = form_submit_answers_path
+      @notify_reference ||= SecureRandom.uuid
       unless preview?
         EventLogger.log_form_event(current_context, request, "check_answers")
       end

--- a/app/controllers/forms/submit_answers_controller.rb
+++ b/app/controllers/forms/submit_answers_controller.rb
@@ -5,7 +5,7 @@ module Forms
         EventLogger.log_form_event(current_context, request, "submission")
       end
 
-      NotifyService.new.send_email(current_context, preview_mode: preview?)
+      NotifyService.new.send_email(current_context, params[:notify_reference], preview_mode: preview?)
       current_context.clear
       redirect_to :form_submitted
     rescue StandardError => e

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -5,7 +5,7 @@ class NotifyService
     @notify_api_key = ENV["NOTIFY_API_KEY"]
   end
 
-  def send_email(form, preview_mode: false)
+  def send_email(form, reference, preview_mode: false)
     email_address = form.submission_email
     title = form.form_name
     text_input = build_question_answers_section(form)
@@ -16,10 +16,11 @@ class NotifyService
     end
 
     client = Notifications::Client.new(@notify_api_key)
-    client.send_email(**email(email_address, title, text_input))
+
+    client.send_email(**email(email_address, title, text_input, reference))
   end
 
-  def email(email_address, title, text_input)
+  def email(email_address, title, text_input, reference)
     title = "TEST FORM: #{title}" if @preview_mode
     timestamp = submission_timestamp
     {
@@ -31,6 +32,7 @@ class NotifyService
         submission_time: timestamp.strftime("%H:%M:%S"),
         submission_date: timestamp.strftime("%-d %B %Y"),
       },
+      reference:,
     }
   end
 

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -25,6 +25,7 @@
     <% end %>
 
     <%= form_with url: @form_submit_path do |form| %>
+      <%= form.hidden_field :notify_reference, id: 'notification-id', value: @notify_reference %>
       <%= form.govuk_submit 'Submit' %>
     <% end %>
   </div>

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe NotifyService do
   let(:notify_api_key) { nil }
+  let(:notify_reference) { SecureRandom.uuid }
 
   around do |example|
     ClimateControl.modify NOTIFY_API_KEY: notify_api_key do
@@ -23,7 +24,7 @@ RSpec.describe NotifyService do
         travel_to submission_datetime do
           notify_service = described_class.new
           form = OpenStruct.new(submission_email: "fake-email", form_name: "title", steps: [OpenStruct.new(question_text: "text", show_answer: "Testing")])
-          notify_service.send_email(form)
+          notify_service.send_email(form, notify_reference)
           expect(fake_notify_client).to have_received(:send_email).with(
             { email_address: "fake-email",
               personalisation: {
@@ -32,6 +33,7 @@ RSpec.describe NotifyService do
                 text_input: "# text\nTesting\n",
                 title: "title",
               },
+              reference: notify_reference,
               template_id: "427eb8bc-ce0d-40a3-bf54-d76e8c3ec916" },
           ).once
         end
@@ -49,7 +51,7 @@ RSpec.describe NotifyService do
         travel_to submission_datetime do
           notify_service = described_class.new
           form = OpenStruct.new(submission_email: "fake-email", form_name: "title", steps: [OpenStruct.new(question_text: "text", show_answer: "Testing")])
-          notify_service.send_email(form)
+          notify_service.send_email(form, notify_reference)
           expect(fake_notify_client).to have_received(:send_email).with(
             { email_address: "fake-email",
               personalisation: {
@@ -58,6 +60,7 @@ RSpec.describe NotifyService do
                 text_input: "# text\nTesting\n",
                 title: "title",
               },
+              reference: notify_reference,
               template_id: "427eb8bc-ce0d-40a3-bf54-d76e8c3ec916" },
           ).once
         end
@@ -75,7 +78,7 @@ RSpec.describe NotifyService do
         travel_to submission_datetime do
           notify_service = described_class.new
           form = OpenStruct.new(submission_email: "fake-email", form_name: "title", steps: [OpenStruct.new(question_text: "text", show_answer: "Testing")])
-          notify_service.send_email(form, preview_mode: true)
+          notify_service.send_email(form, notify_reference, preview_mode: true)
           expect(fake_notify_client).to have_received(:send_email).with(
             { email_address: "fake-email",
               personalisation: {
@@ -84,6 +87,7 @@ RSpec.describe NotifyService do
                 text_input: "# text\nTesting\n",
                 title: "TEST FORM: title",
               },
+              reference: notify_reference,
               template_id: "427eb8bc-ce0d-40a3-bf54-d76e8c3ec916" },
           ).once
         end
@@ -100,7 +104,7 @@ RSpec.describe NotifyService do
 
       notify_service = described_class.new
       form = OpenStruct.new(submission_email: "fake-email", form_name: "title", steps: [OpenStruct.new(question_text: "text", show_answer: "Testing")])
-      notify_service.send_email(form)
+      notify_service.send_email(form, notify_reference)
       expect(fake_notify_client).not_to have_received(:send_email)
     end
   end

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -40,4 +40,8 @@ describe "forms/check_your_answers/show.html.erb" do
       expect(rendered).to have_css(".govuk-grid-column-full")
     end
   end
+
+  it "contains a hidden notify reference" do
+    expect(rendered).to have_css("input", id:"notification-id", visible: false)
+  end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
This PR is part of a set, the other being in forms-deploy https://github.com/alphagov/forms-deploy/pull/54

Trello card: https://trello.com/c/R9jqd9GT/341-e2e-add-checking-notify-has-received-and-sent-off-the-completed-submitted-form

The idea is to check that submitting a form correctly triggers a Notify email, which is successfully delivered.

The changes on the runner side are to provide the reference to Notify as part of the `notify_service`, and also to display the reference as a hidden field on the check your answers page, so that the e2e tests can obtain it. 

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
