### PR TITLE
Add organisation name answer type

### DIFF
--- a/app/lib/question_register.rb
+++ b/app/lib/question_register.rb
@@ -19,6 +19,8 @@ class QuestionRegister
               Question::Number
             when :selection
               Question::Selection
+            when :organisation_name
+              Question::OrganisationName
             else
               raise ArgumentError, "Unexpected answer_type for page #{page.id}: #{page.answer_type}"
             end

--- a/app/models/question/organisation_name.rb
+++ b/app/models/question/organisation_name.rb
@@ -1,0 +1,7 @@
+module Question
+  class OrganisationName < QuestionBase
+    attribute :text
+    validates :text, presence: true, unless: :is_optional?
+    validates :text, length: { maximum: 499 }
+  end
+end

--- a/app/views/question/_organisation_name.erb
+++ b/app/views/question/_organisation_name.erb
@@ -1,0 +1,1 @@
+<%= form.govuk_text_field :text, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }, autocomplete: "organization" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,11 @@ en:
               blank: Enter a number
               greater_than_or_equal_to: The answer must be greater than or equal to 0
               not_a_number: The answer must be a number
+        question/organisation_name:
+          attributes:
+            text:
+              blank: Enter an organisation name
+              too_long: The organisation name must be shorter than 500 characters
         question/phone_number:
           attributes:
             phone_number:

--- a/spec/lib/context_spec.rb
+++ b/spec/lib/context_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Context do
       support_url_text: "Contact us",
       pages:,
     })
-    f.pages.each {|p| p.form = f }
+    f.pages.each { |p| p.form = f }
     f
   end
 
@@ -98,7 +98,7 @@ RSpec.describe Context do
     end
   end
 
-  context 'with a page which changes question type mid-journey' do
+  context "with a page which changes question type mid-journey" do
     let(:pages) do
       [
         Page.new({
@@ -109,16 +109,17 @@ RSpec.describe Context do
           next_page: nil,
           question_short_name: nil,
           form: nil,
-          is_optional: nil
-        })]
+          is_optional: nil,
+        }),
+      ]
     end
 
-    it 'should not throw an error if the question type changes when an answer has already been submitted' do
+    it "does not throw an error if the question type changes when an answer has already been submitted" do
       store = {}
 
       # submit an answer to our page
       context1 = described_class.new(form:, store:)
-      current_step = context1.find_or_create('1')
+      current_step = context1.find_or_create("1")
       current_step.update!({ text: "This is a text answer" })
       context1.save_step(current_step)
 
@@ -127,9 +128,8 @@ RSpec.describe Context do
 
       # build another context with the previous answers
       context2 = nil
-      expect{context2 = described_class.new(form:, store:)}.to_not raise_error(ActiveModel::UnknownAttributeError )
-      expect(context2.find_or_create('1').show_answer).to eq('')
+      expect { context2 = described_class.new(form:, store:) }.not_to raise_error(ActiveModel::UnknownAttributeError)
+      expect(context2.find_or_create("1").show_answer).to eq("")
     end
   end
-
 end

--- a/spec/lib/question_register_spec.rb
+++ b/spec/lib/question_register_spec.rb
@@ -3,7 +3,7 @@ require "ostruct"
 
 RSpec.describe QuestionRegister do
   it "returns a class given a valid answer_type" do
-    %i[date single_line address email national_insurance_number phone_number long_text number].each do |type|
+    %i[date single_line address email national_insurance_number phone_number long_text number organisation_name].each do |type|
       page = OpenStruct.new(answer_type: type)
       expect { described_class.from_page(page) }.not_to raise_error
     end
@@ -21,7 +21,7 @@ RSpec.describe QuestionRegister do
 
   it "accepts is_optional for each answer_type" do
     [false, true].each do |is_optional|
-      %i[date single_line address email national_insurance_number phone_number].each do |type|
+      %i[date single_line address email national_insurance_number phone_number organisation_name].each do |type|
         page = OpenStruct.new(answer_type: type, is_optional:)
         expect(described_class.from_page(page).is_optional?).to eq(is_optional)
       end

--- a/spec/models/question/organisation_name_spec.rb
+++ b/spec/models/question/organisation_name_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe Question::OrganisationName, type: :model do
+  let(:question) { described_class.new }
+
+  it_behaves_like "a question model"
+
+  context "when given an empty string or nil" do
+    it "returns invalid with blank message" do
+      expect(question).not_to be_valid
+      expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/organisation_name.attributes.text.blank"))
+    end
+
+    it "returns invalid with empty string" do
+      question.text = ""
+      expect(question).not_to be_valid
+      expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/organisation_name.attributes.text.blank"))
+    end
+
+    it "shows as a blank string" do
+      expect(question.show_answer).to eq ""
+    end
+  end
+
+  context "when given a short string" do
+    it "validates without errors" do
+      question.text = "testing"
+      expect(question).to be_valid
+    end
+  end
+
+  context "when given a string which is too long" do
+    it "validates without errors" do
+      question.text = "a" * 500
+      expect(question).not_to be_valid
+      expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/organisation_name.attributes.text.too_long"))
+    end
+  end
+
+  context "when question is optional" do
+    let(:question) { described_class.new({}, { is_optional: true }) }
+
+    context "when given an empty string or nil" do
+      it "returns valid with blank message" do
+        expect(question).to be_valid
+        expect(question.errors[:text]).not_to include(I18n.t("activemodel.errors.models.question/organisation_name.attributes.text.blank"))
+      end
+
+      it "returns invalid with empty string" do
+        question.text = ""
+        expect(question).to be_valid
+        expect(question.errors[:text]).not_to include(I18n.t("activemodel.errors.models.question/organisation_name.attributes.text.blank"))
+      end
+
+      it "shows as a blank string" do
+        expect(question.show_answer).to eq ""
+      end
+    end
+
+    context "when given a short string" do
+      it "validates without errors" do
+        question.text = "testing"
+        expect(question).to be_valid
+      end
+    end
+
+    context "when given a string which is too long" do
+      it "validates without errors" do
+        question.text = "a" * 500
+        expect(question).not_to be_valid
+        expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/organisation_name.attributes.text.too_long"))
+      end
+    end
+  end
+end

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -42,6 +42,6 @@ describe "forms/check_your_answers/show.html.erb" do
   end
 
   it "contains a hidden notify reference" do
-    expect(rendered).to have_css("input", id:"notification-id", visible: false)
+    expect(rendered).to have_css("input", id: "notification-id", visible: :hidden)
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
Implements a new 'organisation name' answer type in the runner. This input is almost identical to the single line of text, but contains an autocomplete attribute. Because they're so similar, I _could_ have used the existing single line of text model/view for this, but:

- Separate models and views makes it easier for validation rules and messages to diverge
- We might merge the single line of text and longer text fields as part of the [text ticket in the same epic](https://trello.com/c/hiSdqQBI/394-text-implementation-of-autofill-work-in-production)
- This means less logic in the view

Trello card: https://trello.com/c/jRKIbnBl/369-org-name-implementation-of-autofill-work-in-production

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
