### PR TITLE
Add text question type

### DIFF
--- a/app/lib/question_register.rb
+++ b/app/lib/question_register.rb
@@ -21,6 +21,8 @@ class QuestionRegister
               Question::Selection
             when :organisation_name
               Question::OrganisationName
+            when :text
+              Question::Text
             else
               raise ArgumentError, "Unexpected answer_type for page #{page.id}: #{page.answer_type}"
             end

--- a/app/models/question/text.rb
+++ b/app/models/question/text.rb
@@ -1,0 +1,16 @@
+module Question
+  class Text < QuestionBase
+    attribute :text
+    validates :text, presence: true, unless: :is_optional?
+    validates :text, length: { maximum: 499, message: I18n.t("activemodel.errors.models.question/text.attributes.text.single_line_too_long") }, if: :is_single_line?
+    validates :text, length: { maximum: 4999, message: I18n.t("activemodel.errors.models.question/text.attributes.text.long_text_too_long") }, unless: :is_single_line?
+
+    def is_single_line?
+      answer_settings.input_type == "single_line"
+    end
+
+    def has_long_answer?
+      !is_single_line?
+    end
+  end
+end

--- a/app/views/question/_text.html.erb
+++ b/app/views/question/_text.html.erb
@@ -1,0 +1,5 @@
+<% if page.answer_settings.input_type == "single_line" %>
+  <%= form.govuk_text_field :text, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }, width: 'one-half' %>
+<% else %>
+  <%= form.govuk_text_area :text, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }, rows: 5 %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,12 @@ en:
             text:
               blank: Enter an answer
               too_long: The answer must be shorter than 500 characters
+        question/text:
+          attributes:
+            text:
+              blank: Enter an answer
+              long_text_too_long: The answer must be shorter than 5000 characters
+              single_line_too_long: The answer must be shorter than 500 characters
   footer:
     accessibility_statement: Accessibility statement
     cookies: Cookies

--- a/spec/lib/question_register_spec.rb
+++ b/spec/lib/question_register_spec.rb
@@ -3,7 +3,7 @@ require "ostruct"
 
 RSpec.describe QuestionRegister do
   it "returns a class given a valid answer_type" do
-    %i[date single_line address email national_insurance_number phone_number long_text number organisation_name].each do |type|
+    %i[date single_line address email national_insurance_number phone_number long_text number organisation_name text].each do |type|
       page = OpenStruct.new(answer_type: type)
       expect { described_class.from_page(page) }.not_to raise_error
     end
@@ -21,7 +21,7 @@ RSpec.describe QuestionRegister do
 
   it "accepts is_optional for each answer_type" do
     [false, true].each do |is_optional|
-      %i[date single_line address email national_insurance_number phone_number organisation_name].each do |type|
+      %i[date single_line address email national_insurance_number phone_number long_text number organisation_name text].each do |type|
         page = OpenStruct.new(answer_type: type, is_optional:)
         expect(described_class.from_page(page).is_optional?).to eq(is_optional)
       end

--- a/spec/models/question/text_spec.rb
+++ b/spec/models/question/text_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe Question::Text, type: :model do
+  subject(:question) { described_class.new({}, options) }
+
+  let(:options) { { is_optional:, answer_settings: OpenStruct.new(input_type:) } }
+
+  let(:is_optional) { false }
+
+  context "with input type set to single_line" do
+    let(:input_type) { "single_line" }
+
+    it_behaves_like "a question model"
+
+    it "returns invalid with nil text" do
+      expect(question).not_to be_valid
+      expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/text.attributes.text.blank"))
+    end
+
+    it "returns invalid with blank text" do
+      question.text = ""
+      expect(question).not_to be_valid
+      expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/text.attributes.text.blank"))
+    end
+
+    it "returns invalid with text length over 499 characters" do
+      question.text = "a" * 500
+      expect(question).not_to be_valid
+      expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/text.attributes.text.single_line_too_long"))
+    end
+
+    it "returns valid with text length under 500 characters" do
+      question.text = "a" * 499
+      expect(question).to be_valid
+      expect(question.errors[:text]).to eq []
+    end
+  end
+
+  context "with input type set to long_text" do
+    let(:input_type) { "long_text" }
+
+    it_behaves_like "a question model"
+
+    it "returns invalid with text length over 5000 characters" do
+      question.text = "a" * 5000
+      expect(question).not_to be_valid
+      expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/text.attributes.text.long_text_too_long"))
+    end
+
+    it "returns valid with text length under 5000 characters" do
+      question.text = "a" * rand(1..4999)
+      expect(question).to be_valid
+      expect(question.errors[:text]).to eq []
+    end
+  end
+end


### PR DESCRIPTION
Co-authored-by: Samuel Culley <SamJamCul@users.noreply.github.com>

Adds text question type, which does the same thing as the current 'single_line' and 'long_text' inputs depending on what 'input_type' is set to in the API.

We've made a small change to the validation for long_text  - it now accepts input of 4999 characters or fewer instead of 5000 characters or fewer. This matches the validation message and is also consitent with the 499 we use for single_line inputs.

#### What problem does the pull request solve?

Trello card:https://trello.com/c/hiSdqQBI/375-text-implementation-of-autofill-work-in-production

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
