### PR TITLE
Add date of birth with autocomplete attributes

### DIFF
--- a/app/models/question/date.rb
+++ b/app/models/question/date.rb
@@ -25,7 +25,7 @@ module Question
     end
 
     def date_of_birth?
-      answer_settings.input_type == "date_of_birth"
+      answer_settings&.input_type == "date_of_birth"
     end
 
   private
@@ -34,6 +34,7 @@ module Question
       return if blank? && is_optional?
       return errors.add(:date, :blank) if blank?
       return errors.add(:date, :blank_date_fields, fields: blank_fields.to_sentence) if present? && blank_fields.any?
+      return errors.add(:date, :future_date) if date_of_birth? && future_date?
       return errors.add(:date, :invalid_date) if invalid?
     end
 
@@ -55,6 +56,10 @@ module Question
 
       date_fields = %i[day month year]
       date.to_h.slice(*date_fields).all? { |_, v| v.blank? }
+    end
+
+    def future_date?
+      date.future?
     end
 
     def blank_fields

--- a/app/models/question/date.rb
+++ b/app/models/question/date.rb
@@ -24,6 +24,10 @@ module Question
       end
     end
 
+    def date_of_birth?
+      answer_settings.input_type == "date_of_birth"
+    end
+
   private
 
     def date_valid

--- a/app/views/question/_date.html.erb
+++ b/app/views/question/_date.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_date_field :date, legend: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text } %>
+<%= form.govuk_date_field :date, date_of_birth: page.question.date_of_birth?, legend: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,7 @@ en:
             date:
               blank: Enter a date
               blank_date_fields: Enter a day, month and year
-              future_date: Enter a date that is not in the future
+              future_date: Enter a date that is in the past
               invalid_date: Enter a real date
         question/email:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
             date:
               blank: Enter a date
               blank_date_fields: Enter a day, month and year
+              future_date: Enter a date that is not in the future
               invalid_date: Enter a real date
         question/email:
           attributes:

--- a/spec/models/question/date_spec.rb
+++ b/spec/models/question/date_spec.rb
@@ -151,6 +151,32 @@ RSpec.describe Question::Date, type: :model do
         end
       end
     end
+
+    context "when the input type is a date of birth" do
+      let(:options) { { answer_settings: OpenStruct.new({ input_type: "date_of_birth" }) } }
+
+      before do
+        set_date(*date_input)
+      end
+
+      context "when the date is in the past" do
+        let(:date_input) { ["01", "01", (Time.zone.today.year - 1).to_s] }
+
+        it "is valid" do
+          expect(question).to be_valid
+          expect(question.errors[:date]).to eq []
+        end
+      end
+
+      context "when the date is in the future" do
+        let(:date_input) { ["01", "01", (Time.zone.today.year + 1).to_s] }
+
+        it "isn't valid" do
+          expect(question).not_to be_valid
+          expect(question.errors[:date]).to include(I18n.t("activemodel.errors.models.question/date.attributes.date.future_date"))
+        end
+      end
+    end
   end
 
   describe "#date_of_birth?" do

--- a/spec/models/question/date_spec.rb
+++ b/spec/models/question/date_spec.rb
@@ -153,6 +153,34 @@ RSpec.describe Question::Date, type: :model do
     end
   end
 
+  describe "#date_of_birth?" do
+    let(:options) { { answer_settings: OpenStruct.new({ input_type: }) } }
+
+    context "when the input type is a date of birth" do
+      let(:input_type) { "date_of_birth" }
+
+      it "returns true" do
+        expect(question.date_of_birth?).to be true
+      end
+    end
+
+    context "when the input type is set to other_date" do
+      let(:input_type) { "other_date" }
+
+      it "returns false" do
+        expect(question.date_of_birth?).to be false
+      end
+    end
+
+    context "when the input type is not set" do
+      let(:input_type) { nil }
+
+      it "returns false" do
+        expect(question.date_of_birth?).to be false
+      end
+    end
+  end
+
 private
 
   def set_date(day, month, year)

--- a/spec/views/question/_date.html.erb_spec.rb
+++ b/spec/views/question/_date.html.erb_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+describe "question/date.html.erb" do
+  let(:page) do
+    Page.new({
+      id: 1,
+      question_text: "What is the date?",
+      question_short_name: nil,
+      hint_text: nil,
+      answer_type: "date",
+      is_optional: false,
+      answer_settings: OpenStruct.new({ input_type: }),
+    })
+  end
+
+  let(:input_type) { nil }
+
+  let(:question) do
+    QuestionRegister.from_page(page)
+  end
+
+  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1) }
+
+  let(:form) do
+    GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+  end
+
+  before do
+    render partial: "question/date", locals: { page: step, form: }
+  end
+
+  context "when the question is a date of birth" do
+    let(:input_type) { "date_of_birth" }
+
+    it "contains the question" do
+      expect(rendered).to have_css("h1", text: page.question_text)
+    end
+
+    it "contains the autocomplete attributes" do
+      expect(rendered).to have_css("input[type='text'][autocomplete='bday-day']")
+      expect(rendered).to have_css("input[type='text'][autocomplete='bday-month']")
+      expect(rendered).to have_css("input[type='text'][autocomplete='bday-year']")
+    end
+  end
+
+  context "when the question is an other date" do
+    let(:input_type) { "other_date" }
+
+    it "contains the question" do
+      expect(rendered).to have_css("h1", text: page.question_text)
+    end
+
+    it "does not contain autocomplete attributes" do
+      expect(rendered).to have_css("input[type='text']:not([autocomplete='bday-day'])")
+      expect(rendered).to have_css("input[type='text']:not([autocomplete='bday-month'])")
+      expect(rendered).to have_css("input[type='text']:not([autocomplete='bday-year'])")
+    end
+  end
+
+  context "when the question is nil" do
+    let(:input_type) { nil }
+
+    it "contains the question" do
+      expect(rendered).to have_css("h1", text: page.question_text)
+    end
+
+    it "does not contain autocomplete attributes" do
+      expect(rendered).to have_css("input[type='text']:not([autocomplete='bday-day'])")
+      expect(rendered).to have_css("input[type='text']:not([autocomplete='bday-month'])")
+      expect(rendered).to have_css("input[type='text']:not([autocomplete='bday-year'])")
+    end
+  end
+end


### PR DESCRIPTION
Co-authored-by: Samuel Culley <SamJamCul@users.noreply.github.com>

#### What problem does the pull request solve?

Adds appropriate autocomplete attributes when the date is set as a date of birth. Also validates that dates of birth aren't in the future.

Trello card: https://trello.com/c/sDrOCmAp/383-dob-implementation-of-autofill-work-in-production

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
