### PR TITLE
Fix bug with existing dates

### DIFF
--- a/app/models/question/date.rb
+++ b/app/models/question/date.rb
@@ -25,7 +25,7 @@ module Question
     end
 
     def date_of_birth?
-      answer_settings&.input_type == "date_of_birth"
+      answer_settings != {} && answer_settings&.input_type == "date_of_birth"
     end
 
   private

--- a/spec/views/question/_date.html.erb_spec.rb
+++ b/spec/views/question/_date.html.erb_spec.rb
@@ -9,9 +9,11 @@ describe "question/date.html.erb" do
       hint_text: nil,
       answer_type: "date",
       is_optional: false,
-      answer_settings: OpenStruct.new({ input_type: }),
+      answer_settings:,
     })
   end
+
+  let(:answer_settings) { OpenStruct.new({ input_type: }) }
 
   let(:input_type) { nil }
 
@@ -60,6 +62,20 @@ describe "question/date.html.erb" do
 
   context "when the question is nil" do
     let(:input_type) { nil }
+
+    it "contains the question" do
+      expect(rendered).to have_css("h1", text: page.question_text)
+    end
+
+    it "does not contain autocomplete attributes" do
+      expect(rendered).to have_css("input[type='text']:not([autocomplete='bday-day'])")
+      expect(rendered).to have_css("input[type='text']:not([autocomplete='bday-month'])")
+      expect(rendered).to have_css("input[type='text']:not([autocomplete='bday-year'])")
+    end
+  end
+
+  context "when the date has no answer_settings" do
+    let(:answer_settings) { nil }
 
     it "contains the question" do
       expect(rendered).to have_css("h1", text: page.question_text)


### PR DESCRIPTION
#### What problem does the pull request solve?
Visiting a question page with an existing date field (i.e. one without an answer settings field) will result in an error, since the date question type expects the input type to be present.

This PR adds a check for this. This should be a temporary solution - the proper solution is to migrate the existing date (and address) fields. There is a ticket for this in the backlog which should be done in the next sprint.

#### Checklist

- [x] I've used the pull request template
- [n/a] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
