### PR TITLE
Update env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@
 .env.production.local
 
 coverage/
+
+# Vim
+*.swp

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,7 +3,7 @@ Sentry.init do |config|
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
   config.debug = true
   config.traces_sample_rate = 0.0
-  config.environment = ENV["PAAS_ENVIRONMENT"] || "local"
+  config.environment = ENV["PAAS_ENVIRONMENT"] || ENV["SENTRY_ENVIRONMENT"] || "local"
 end
 
 # Uncomment out the below to test Sentry - this


### PR DESCRIPTION
#### What problem does the pull request solve?
    Use SENTRY_ENVIRONMENT for new AWS Environments

    Rather than using `PAAS_ENVIRONMENT` to derive the sentry environment
    use `SENTRY_ENVIRONMENT` and remove `PAAS_ENVIRONMENT` once we've
    migrated.

### Notes
I presume this will be updated as we move further to use the `Settings.` config setup but this allows us to enable Sentry on AWS without using soon to be deprecated env var `PAAS_ENVIRONMENT`