### PR TITLE
Address autofill

### DIFF
--- a/app/models/question/address.rb
+++ b/app/models/question/address.rb
@@ -6,14 +6,19 @@ module Question
     attribute :town_or_city
     attribute :county
     attribute :postcode
+    attribute :street_address
+    attribute :country
 
-    validates :address1, presence: true, unless: :skipping_question?
-    validates :town_or_city, presence: true, unless: :skipping_question?
-    validates :postcode, presence: true, unless: :skipping_question?
-    validate :postcode, :invalid_postcode?
+    validate :uk_address_valid?, unless: :is_international_address?
+    validate :postcode, :invalid_postcode?, unless: :is_international_address?
+    validate :international_adress_valid?, if: :is_international_address?
 
     def postcode=(str)
-      super UKPostcode.parse(str).to_s
+      super str.present? ? UKPostcode.parse(str).to_s : str
+    end
+
+    def is_international_address?
+      answer_settings.present? && answer_settings&.input_type&.international_address == "true"
     end
 
   private
@@ -28,8 +33,25 @@ module Question
     end
 
     def skipping_question?
-      fields = [address1, address2, town_or_city, county, postcode]
+      fields = [address1, address2, town_or_city, county, postcode, street_address, country]
       is_optional? && fields.none?(&:present?)
+    end
+
+    def uk_address_valid?
+      return if skipping_question?
+
+      errors.add(:address1, :blank) if address1.blank?
+      errors.add(:town_or_city, :blank) if town_or_city.blank?
+      errors.add(:postcode, :blank) if postcode.blank?
+      errors
+    end
+
+    def international_adress_valid?
+      return if skipping_question?
+
+      errors.add(:street_address, :blank) if street_address.blank?
+      errors.add(:country, :blank) if country.blank?
+      errors
     end
   end
 end

--- a/app/views/question/_address.html.erb
+++ b/app/views/question/_address.html.erb
@@ -1,10 +1,19 @@
+
 <%= form.govuk_fieldset legend: { text: question_text_with_optional_suffix(page), tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-address-hint" : nil do %>
-  <% if page.hint_text.present? %>
-    <p id="govuk-address-hint" class="govuk-hint"><%= page.hint_text %></p>
+  <% if page.question.is_international_address? %>
+    <% if page.hint_text.present? %>
+      <p id="govuk-address-hint" class="govuk-hint"><%= page.hint_text %></p>
+    <% end %>
+    <%= form.govuk_text_area :street_address, label: { text: "Street address" }, rows: 5, autocomplete: "street-address" %>
+    <%= form.govuk_text_field :country, label: { text: "Country" }, width: 20, autocomplete: "country-name" %>
+  <% else %>
+    <% if page.hint_text.present? %>
+      <p id="govuk-address-hint" class="govuk-hint"><%= page.hint_text %></p>
+    <% end %>
+    <%= form.govuk_text_field :address1, label: { text: "Address line 1" }, autocomplete: "address-line1" %>
+    <%= form.govuk_text_field :address2, label: {  text: "Address line 2 (optional)"  }, autocomplete: "address-line2" %>
+    <%= form.govuk_text_field :town_or_city, label: {  text: "Town or City" }, width: 'two-thirds', autocomplete: "address-level2" %>
+    <%= form.govuk_text_field :county, label: {  text: "County (optional)" }, width: 'two-thirds' %>
+    <%= form.govuk_text_field :postcode, label: {  text: "Postcode" }, width: 10, autocomplete: "postal-code" %>
   <% end %>
-  <%= form.govuk_text_field :address1, label: { text: "Address line 1" }, autocomplete: "address-line1" %>
-  <%= form.govuk_text_field :address2, label: {  text: "Address line 2 (optional)"  }, autocomplete: "address-line2" %>
-  <%= form.govuk_text_field :town_or_city, label: {  text: "Town or City" }, width: 'two-thirds', autocomplete: "address-level2" %>
-  <%= form.govuk_text_field :county, label: {  text: "County (optional)" }, width: 'two-thirds' %>
-  <%= form.govuk_text_field :postcode, label: {  text: "Postcode" }, width: 10, autocomplete: "postal-code" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,9 +7,13 @@ en:
           attributes:
             address1:
               blank: Enter the first line of the address
+            country:
+              blank: Enter the country
             postcode:
               blank: Enter the postcode
               invalid_postcode: Enter a real postcode
+            street_address:
+              blank: Enter the address
             town_or_city:
               blank: Enter the town or city
         question/date:

--- a/spec/models/question/address_spec.rb
+++ b/spec/models/question/address_spec.rb
@@ -1,86 +1,32 @@
 require "rails_helper"
 
 RSpec.describe Question::Address, type: :model do
-  let(:question) { described_class.new }
+  subject(:question) { described_class.new({}, options) }
+
+  let(:options) { { is_optional:, answer_settings: } }
+  let(:answer_settings) { OpenStruct.new({ input_type: }) }
+  let(:input_type) { OpenStruct.new({ international_address:, uk_address: }) }
+  let(:is_optional) { false }
+  let(:international_address) { "false" }
+  let(:uk_address) { "true" }
 
   it_behaves_like "a question model"
 
-  context "when an address is blank" do
-    it "returns invalid with blank address fields" do
-      expect(question).not_to be_valid
-      expect(question.errors[:address1]).to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.blank"))
-    end
-
-    it "returns invalid with empty string address fields" do
-      question.address1 = ""
-      question.address2 = ""
-      question.town_or_city = ""
-      question.county = ""
-      question.postcode = ""
-      expect(question).not_to be_valid
-      expect(question.errors[:address1]).to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.blank"))
-    end
-
-    it "returns \"\" for show_answer" do
-      expect(question.show_answer).to eq ""
-    end
-  end
-
-  context "when an address has all mandatory fields filled" do
-    before do
-      question.address1 = "The mews"
-      question.address2 = nil
-      question.town_or_city = "Leeds"
-      question.county = nil
-      question.postcode = "LS11AF"
-    end
-
-    it "is valid" do
-      expect(question).to be_valid
-    end
-
-    it "prints correct details" do
-      expect(question.show_answer).to eq "The mews, Leeds, LS1 1AF"
-    end
-  end
-
-  context "when given an invalid postcode" do
-    it "returns invalid" do
-      question.postcode = "jskladjaksd"
-      expect(question).not_to be_valid
-      expect(question.errors[:postcode]).to include(I18n.t("activemodel.errors.models.question/address.attributes.postcode.invalid_postcode"))
-    end
-  end
-
-  context "when question is optional" do
-    let(:question) { described_class.new({}, { is_optional: true }) }
-
+  context "when the address is a UK address" do
     context "when an address is blank" do
-      it "returns valid with blank address fields" do
-        expect(question).to be_valid
-        expect(question.errors[:address1]).not_to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.blank"))
+      it "returns invalid with blank address fields" do
+        expect(question).not_to be_valid
+        expect(question.errors[:address1]).to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.blank"))
       end
 
-      it "returns valid with empty string address fields" do
+      it "returns invalid with empty string address fields" do
         question.address1 = ""
         question.address2 = ""
         question.town_or_city = ""
         question.county = ""
         question.postcode = ""
-        expect(question).to be_valid
-        expect(question.errors[:address1]).not_to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.blank"))
-      end
-
-      it "validates required fields when any fields are filled in" do
-        question.address1 = ""
-        question.address2 = ""
-        question.town_or_city = ""
-        question.county = "Lancashire"
-        question.postcode = ""
         expect(question).not_to be_valid
         expect(question.errors[:address1]).to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.blank"))
-        expect(question.errors[:town_or_city]).to include(I18n.t("activemodel.errors.models.question/address.attributes.town_or_city.blank"))
-        expect(question.errors[:postcode]).to include(I18n.t("activemodel.errors.models.question/address.attributes.postcode.blank"))
       end
 
       it "returns \"\" for show_answer" do
@@ -111,6 +57,197 @@ RSpec.describe Question::Address, type: :model do
         question.postcode = "jskladjaksd"
         expect(question).not_to be_valid
         expect(question.errors[:postcode]).to include(I18n.t("activemodel.errors.models.question/address.attributes.postcode.invalid_postcode"))
+      end
+    end
+
+    context "when question is optional" do
+      let(:is_optional) { true }
+
+      context "when an address is blank" do
+        it "returns valid with blank address fields" do
+          expect(question).to be_valid
+          expect(question.errors[:address1]).not_to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.blank"))
+        end
+
+        it "returns valid with empty string address fields" do
+          question.address1 = ""
+          question.address2 = ""
+          question.town_or_city = ""
+          question.county = ""
+          question.postcode = ""
+          expect(question).to be_valid
+          expect(question.errors[:address1]).not_to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.blank"))
+        end
+
+        it "validates required fields when any fields are filled in" do
+          question.address1 = ""
+          question.address2 = ""
+          question.town_or_city = ""
+          question.county = "Lancashire"
+          question.postcode = ""
+          expect(question).not_to be_valid
+          expect(question.errors[:address1]).to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.blank"))
+          expect(question.errors[:town_or_city]).to include(I18n.t("activemodel.errors.models.question/address.attributes.town_or_city.blank"))
+          expect(question.errors[:postcode]).to include(I18n.t("activemodel.errors.models.question/address.attributes.postcode.blank"))
+        end
+
+        it "returns \"\" for show_answer" do
+          expect(question.show_answer).to eq ""
+        end
+      end
+
+      context "when an address has all mandatory fields filled" do
+        before do
+          question.address1 = "The mews"
+          question.address2 = nil
+          question.town_or_city = "Leeds"
+          question.county = nil
+          question.postcode = "LS11AF"
+        end
+
+        it "is valid" do
+          expect(question).to be_valid
+        end
+
+        it "prints correct details" do
+          expect(question.show_answer).to eq "The mews, Leeds, LS1 1AF"
+        end
+      end
+
+      context "when given an invalid postcode" do
+        it "returns invalid" do
+          question.postcode = "jskladjaksd"
+          expect(question).not_to be_valid
+          expect(question.errors[:postcode]).to include(I18n.t("activemodel.errors.models.question/address.attributes.postcode.invalid_postcode"))
+        end
+      end
+    end
+  end
+
+  context "when the address is an international address" do
+    let(:international_address) { "true" }
+
+    context "when an address is blank" do
+      it "returns invalid with blank address fields" do
+        expect(question).not_to be_valid
+        expect(question.errors[:street_address]).to include(I18n.t("activemodel.errors.models.question/address.attributes.street_address.blank"))
+        expect(question.errors[:country]).to include(I18n.t("activemodel.errors.models.question/address.attributes.country.blank"))
+      end
+
+      it "returns invalid with empty string address fields" do
+        question.street_address = ""
+        question.country = ""
+        expect(question).not_to be_valid
+        expect(question.errors[:street_address]).to include(I18n.t("activemodel.errors.models.question/address.attributes.street_address.blank"))
+        expect(question.errors[:country]).to include(I18n.t("activemodel.errors.models.question/address.attributes.country.blank"))
+      end
+
+      it "returns \"\" for show_answer" do
+        expect(question.show_answer).to eq ""
+      end
+    end
+
+    context "when an address has all mandatory fields filled" do
+      before do
+        question.street_address = "Laskerstraße 5, 10245 Berlin"
+        question.country = "Germany"
+      end
+
+      it "is valid" do
+        expect(question).to be_valid
+      end
+
+      it "prints correct details" do
+        expect(question.show_answer).to eq "Laskerstraße 5, 10245 Berlin, Germany"
+      end
+    end
+
+    context "when question is optional" do
+      let(:is_optional) { true }
+
+      context "when an address is blank" do
+        it "returns valid with blank address fields" do
+          expect(question).to be_valid
+          expect(question.errors[:street_address]).not_to include(I18n.t("activemodel.errors.models.question/address.attributes.street_address.blank"))
+        end
+
+        it "returns valid with empty string address fields" do
+          question.street_address = ""
+          question.country = ""
+          expect(question).to be_valid
+          expect(question.errors[:street_address]).not_to include(I18n.t("activemodel.errors.models.question/address.attributes.street_address.blank"))
+        end
+
+        it "validates required fields when any fields are filled in" do
+          question.street_address = ""
+          question.country = "France"
+          expect(question).not_to be_valid
+          expect(question.errors[:street_address]).to include(I18n.t("activemodel.errors.models.question/address.attributes.street_address.blank"))
+        end
+
+        it "returns \"\" for show_answer" do
+          expect(question.show_answer).to eq ""
+        end
+      end
+
+      context "when an address has all mandatory fields filled" do
+        before do
+          question.street_address = "Laskerstraße 5, 10245 Berlin"
+          question.country = "Germany"
+        end
+
+        it "is valid" do
+          expect(question).to be_valid
+        end
+
+        it "prints correct details" do
+          expect(question.show_answer).to eq "Laskerstraße 5, 10245 Berlin, Germany"
+        end
+      end
+    end
+  end
+
+  describe "#is_international_address?" do
+    context "when the question allows both UK and international addresses" do
+      let(:international_address) { "true" }
+      let(:uk_address) { "true" }
+
+      it "returns true" do
+        expect(question.is_international_address?).to be true
+      end
+    end
+
+    context "when the question allows only international addresses" do
+      let(:international_address) { "true" }
+      let(:uk_address) { "false" }
+
+      it "returns true" do
+        expect(question.is_international_address?).to be true
+      end
+    end
+
+    context "when the question allows only UK addresses" do
+      let(:international_address) { "false" }
+      let(:uk_address) { "true" }
+
+      it "returns false" do
+        expect(question.is_international_address?).to be false
+      end
+    end
+
+    context "when the input type is not set" do
+      let(:input_type) { nil }
+
+      it "returns false" do
+        expect(question.is_international_address?).to be false
+      end
+    end
+
+    context "when answer_settings is not set" do
+      let(:answer_settings) { {} }
+
+      it "returns false" do
+        expect(question.is_international_address?).to be false
       end
     end
   end

--- a/spec/views/question/_address.html.erb_spec.rb
+++ b/spec/views/question/_address.html.erb_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+describe "question/address.html.erb" do
+  let(:page) do
+    Page.new({
+      id: 1,
+      question_text: "What is your address?",
+      question_short_name: nil,
+      hint_text: nil,
+      answer_type: "address",
+      is_optional: false,
+      answer_settings:,
+    })
+  end
+
+  let(:answer_settings) { OpenStruct.new({ input_type: }) }
+  let(:input_type) { OpenStruct.new({ international_address:, uk_address: }) }
+  let(:international_address) { "false" }
+  let(:uk_address) { "true" }
+
+  let(:question) do
+    QuestionRegister.from_page(page)
+  end
+
+  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1) }
+
+  let(:form) do
+    GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+  end
+
+  before do
+    render partial: "question/address", locals: { page: step, form: }
+  end
+
+  context "when the question is an international address" do
+    let(:international_address) { "true" }
+
+    it "contains the question" do
+      expect(rendered).to have_css("h1", text: page.question_text)
+    end
+
+    it "contains the correct autocomplete attributes for an international address" do
+      expect(rendered).to have_css("textarea[autocomplete='street-address']")
+      expect(rendered).to have_css("input[type='text'][autocomplete='country-name']")
+    end
+  end
+
+  context "when the question is not an international address" do
+    let(:international_address) { "false" }
+
+    it "contains the question" do
+      expect(rendered).to have_css("h1", text: page.question_text)
+    end
+
+    it "contains the correct autocomplete attributes for a UK address" do
+      expect(rendered).to have_css("input[type='text'][autocomplete='address-line1']")
+      expect(rendered).to have_css("input[type='text'][autocomplete='address-line2']")
+      expect(rendered).to have_css("input[type='text'][autocomplete='address-level2']")
+      expect(rendered).to have_css("input[type='text'][autocomplete='postal-code']")
+    end
+  end
+
+  context "when the input type is nil" do
+    let(:input_type) { nil }
+
+    it "contains the question" do
+      expect(rendered).to have_css("h1", text: page.question_text)
+    end
+
+    it "contains the correct autocomplete attributes for a UK address" do
+      expect(rendered).to have_css("input[type='text'][autocomplete='address-line1']")
+      expect(rendered).to have_css("input[type='text'][autocomplete='address-line2']")
+      expect(rendered).to have_css("input[type='text'][autocomplete='address-level2']")
+      expect(rendered).to have_css("input[type='text'][autocomplete='postal-code']")
+    end
+  end
+
+  context "when the address has no answer_settings" do
+    let(:answer_settings) { nil }
+
+    it "contains the question" do
+      expect(rendered).to have_css("h1", text: page.question_text)
+    end
+
+    it "contains the correct autocomplete attributes for a UK address" do
+      expect(rendered).to have_css("input[type='text'][autocomplete='address-line1']")
+      expect(rendered).to have_css("input[type='text'][autocomplete='address-line2']")
+      expect(rendered).to have_css("input[type='text'][autocomplete='address-level2']")
+      expect(rendered).to have_css("input[type='text'][autocomplete='postal-code']")
+    end
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?
Uses the new autofill settings on the address input type to determine whether the UK address or international address fields should be displayed to a form filler. Includes validation specific to each address type.

Trello card: https://trello.com/c/zdoo448d/382-address-implementation-of-autofill-work-in-production

Related PRs:
- Admin: https://github.com/alphagov/forms-admin/pull/270
- API: https://github.com/alphagov/forms-api/pull/168

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)

