### PR TITLE
Autofill cleanup task

### DIFF
--- a/app/views/question/_name.html.erb
+++ b/app/views/question/_name.html.erb
@@ -1,19 +1,23 @@
-<%= form.govuk_fieldset legend: { text: question_text_with_optional_suffix(page), tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-name-hint" : nil do %>
-  <% if page.hint_text.present? %>
-    <p id="govuk-name-hint" class="govuk-hint"><%= page.hint_text %></p>
-  <% end %>
-  <% if page.question.needs_title? %>
-    <%= form.govuk_text_field :title, label: { text: t("question/name.label.title") }, width: "one-quarter", autocomplete: "honorific-prefix" %>
-  <% end %>
-  <% if page.question.is_full_name? %>
-    <%= form.govuk_text_field :full_name, label: { text: t("question/name.label.full_name") }, autocomplete: "name" %>
-  <% else %>
-    <%= form.govuk_text_field :first_name, label: { text: t("question/name.label.first_name") }, width: "one-half", autocomplete: "given-name" %>
-
-    <% if page.question.include_middle_name? %>
-      <%= form.govuk_text_field :middle_names, label: { text: t("question/name.label.middle_names") }, width: "two-thirds", autocomplete: "additional-name" %>
+<% if page.question.is_full_name? && !page.question.needs_title? %>
+  <%= form.govuk_text_field :full_name, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page) }, hint: { text: page.hint_text }, autocomplete: "name" %>
+<% else %>
+  <%= form.govuk_fieldset legend: { text: question_text_with_optional_suffix(page), tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-name-hint" : nil do %>
+    <% if page.hint_text.present? %>
+      <p id="govuk-name-hint" class="govuk-hint"><%= page.hint_text %></p>
     <% end %>
+    <% if page.question.needs_title? %>
+      <%= form.govuk_text_field :title, label: { text: t("question/name.label.title") }, width: "one-quarter", autocomplete: "honorific-prefix" %>
+    <% end %>
+    <% if page.question.is_full_name? %>
+      <%= form.govuk_text_field :full_name, label: { text: t("question/name.label.full_name") }, autocomplete: "name" %>
+    <% else %>
+      <%= form.govuk_text_field :first_name, label: { text: t("question/name.label.first_name") }, width: "one-half", autocomplete: "given-name" %>
 
-    <%= form.govuk_text_field :last_name, label: { text: t("question/name.label.last_name") }, width: "one-half", autocomplete: "family-name" %>
+      <% if page.question.include_middle_name? %>
+        <%= form.govuk_text_field :middle_names, label: { text: t("question/name.label.middle_names") }, width: "two-thirds", autocomplete: "additional-name" %>
+      <% end %>
+
+      <%= form.govuk_text_field :last_name, label: { text: t("question/name.label.last_name") }, width: "one-half", autocomplete: "family-name" %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/question/_name.html.erb
+++ b/app/views/question/_name.html.erb
@@ -3,7 +3,7 @@
     <p id="govuk-name-hint" class="govuk-hint"><%= page.hint_text %></p>
   <% end %>
   <% if page.question.needs_title? %>
-    <%= form.govuk_text_field :title, label: { text: t("page.optional", question_text: t("question/name.label.title")) }, width: "one-quarter", autocomplete: "honorific-prefix" %>
+    <%= form.govuk_text_field :title, label: { text: t("question/name.label.title") }, width: "one-quarter", autocomplete: "honorific-prefix" %>
   <% end %>
   <% if page.question.is_full_name? %>
     <%= form.govuk_text_field :full_name, label: { text: t("question/name.label.full_name") }, autocomplete: "name" %>
@@ -11,7 +11,7 @@
     <%= form.govuk_text_field :first_name, label: { text: t("question/name.label.first_name") }, width: "one-half", autocomplete: "given-name" %>
 
     <% if page.question.include_middle_name? %>
-      <%= form.govuk_text_field :middle_names, label: { text: t("page.optional", question_text: t("question/name.label.middle_names")) }, width: "two-thirds", autocomplete: "additional-name" %>
+      <%= form.govuk_text_field :middle_names, label: { text: t("question/name.label.middle_names") }, width: "two-thirds", autocomplete: "additional-name" %>
     <% end %>
 
     <%= form.govuk_text_field :last_name, label: { text: t("question/name.label.last_name") }, width: "one-half", autocomplete: "family-name" %>


### PR DESCRIPTION
#### What problem does the pull request solve?

Resolves some divergences with the design - namely:
- Removes the 'Optional' text on the optional name inputs, in line with design system guidance
- If a name question is set to full name, and there's no title, it will now use the question text as the label rather than have a reedundant 'full name' label.

Trello card: https://trello.com/c/nPbS36yK/483-autofill-cleanup-tasks

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
