### PR TITLE
Fix undefined method `future?'  for date answer types

### DIFF
--- a/app/models/question/date.rb
+++ b/app/models/question/date.rb
@@ -34,8 +34,8 @@ module Question
       return if blank? && is_optional?
       return errors.add(:date, :blank) if blank?
       return errors.add(:date, :blank_date_fields, fields: blank_fields.to_sentence) if present? && blank_fields.any?
-      return errors.add(:date, :future_date) if date_of_birth? && future_date?
       return errors.add(:date, :invalid_date) if invalid?
+      return errors.add(:date, :future_date) if date_of_birth? && future_date?
     end
 
     def date_field_to_attribute(key)

--- a/spec/models/question/date_spec.rb
+++ b/spec/models/question/date_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Question::Date, type: :model do
     end
   end
 
-  context "when a date has a valid day, month or year but it's not a real date" do
+  context "when a date has a day, month or year but it's not a real date" do
     before do
       set_date("45", "02", "2021")
     end
@@ -77,6 +77,26 @@ RSpec.describe Question::Date, type: :model do
         set_date(*v)
         expect(question).not_to be_valid
         expect(question.errors[:date]).to include(I18n.t("activemodel.errors.models.question/date.attributes.date.invalid_date"))
+      end
+    end
+
+    context "when question is date of birth" do
+      let(:options) { OpenStruct.new(answer_settings: OpenStruct.new( input_type: "date_of_birth")) }
+
+      it "isn't valid" do
+        day_month_years = [
+          [1, "e", 2022],
+          ["pi", 1, 2022],
+          [1, 1, "zero"],
+        ]
+        question.answer_settings = { input_type: "date_of_birth" }
+
+        day_month_years.each do |v|
+          set_date(*v)
+          question.valid?
+          expect(question).not_to be_valid
+          expect(question.errors[:date]).to include(I18n.t("activemodel.errors.models.question/date.attributes.date.invalid_date"))
+        end
       end
     end
   end

--- a/spec/models/question/date_spec.rb
+++ b/spec/models/question/date_spec.rb
@@ -93,7 +93,6 @@ RSpec.describe Question::Date, type: :model do
 
         day_month_years.each do |v|
           set_date(*v)
-          question.valid?
           expect(question).not_to be_valid
           expect(question.errors[:date]).to include(I18n.t("activemodel.errors.models.question/date.attributes.date.invalid_date"))
         end


### PR DESCRIPTION
This method is a rails method that was being called on a Struct rather than a Date object

fixes https://sentry.io/organizations/govuk-forms/issues/3907609448/?project=6576261&query=is%3Aunresolved&referrer=issue-stream

#### What problem does the pull request solve?

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
