### PR TITLE
Use new live_form route in API

### DIFF
--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -14,7 +14,7 @@ module Forms
   private
 
     def current_form
-      @current_form ||= Form.find(params.require(:form_id))
+      @current_form ||= Form.find_live(params.require(:form_id))
     end
 
     def current_context

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -6,6 +6,10 @@ class Form < ActiveResource::Base
 
   has_many :pages
 
+  def self.find_live(id)
+    find(:one, from: "#{prefix}forms/#{id}/live")
+  end
+
   def last_page
     pages.find { |p| !p.has_next_page? }
   end

--- a/spec/requests/base_spec.rb
+++ b/spec/requests/base_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Base controller", type: :request do
       support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
       support_url: "https://example.gov.uk/contact",
       support_url_text: "Contact us",
+      pages: pages_data,
     }.to_json
   end
 
@@ -41,7 +42,7 @@ RSpec.describe "Base controller", type: :request do
         answer_type: "date",
         is_optional: nil,
       },
-    ].to_json
+    ]
   end
 
   let(:session) do
@@ -63,9 +64,8 @@ RSpec.describe "Base controller", type: :request do
   before do
     ActiveResource::HttpMock.respond_to do |mock|
       allow(EventLogger).to receive(:log).at_least(:once)
-      mock.get "/api/v1/forms/2", req_headers, form_response_data, 200
-      mock.get "/api/v1/forms/2/pages", req_headers, pages_data, 200
-      mock.get "/api/v1/forms/9999", req_headers, no_data_found_response, 404
+      mock.get "/api/v1/forms/2/live", req_headers, form_response_data, 200
+      mock.get "/api/v1/forms/9999/live", req_headers, no_data_found_response, 404
     end
   end
 

--- a/spec/requests/check_your_answers_spec.rb
+++ b/spec/requests/check_your_answers_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Check Your Answers Controller", type: :request do
       support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
       support_url: "https://example.gov.uk/contact",
       support_url_text: "Contact us",
+      pages: pages_data,
     }.to_json
   end
 
@@ -38,7 +39,7 @@ RSpec.describe "Check Your Answers Controller", type: :request do
         answer_type: "single_line",
         is_optional: nil,
       },
-    ].to_json
+    ]
   end
 
   let(:req_headers) do
@@ -50,8 +51,7 @@ RSpec.describe "Check Your Answers Controller", type: :request do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2", req_headers, form_data, 200
-      mock.get "/api/v1/forms/2/pages", req_headers, pages_data, 200
+      mock.get "/api/v1/forms/2/live", req_headers, form_data, 200
     end
   end
 
@@ -111,6 +111,7 @@ RSpec.describe "Check Your Answers Controller", type: :request do
             support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
             support_url: "https://example.gov.uk/contact",
             support_url_text: "Contact us",
+            pages: pages_data,
           }.to_json
         end
 

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Errors", type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/2", req_headers, form_response_data, 200
+        mock.get "/api/v1/forms/2/live", req_headers, form_response_data, 200
       end
 
       allow(form_submission_service).to receive(:submit_form_to_processing_team).and_throw("Oh no!").with(any_args)

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Page Controller", type: :request do
       support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
       support_url: "https://example.gov.uk/contact",
       support_url_text: "Contact us",
+      pages: pages_data,
     }.to_json
   end
 
@@ -37,7 +38,7 @@ RSpec.describe "Page Controller", type: :request do
         answer_type: "single_line",
         is_optional: nil,
       },
-    ].to_json
+    ]
   end
 
   let(:req_headers) do
@@ -49,8 +50,7 @@ RSpec.describe "Page Controller", type: :request do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2", req_headers, form_data, 200
-      mock.get "/api/v1/forms/2/pages", req_headers, pages_data, 200
+      mock.get "/api/v1/forms/2/live", req_headers, form_data, 200
     end
   end
 
@@ -300,6 +300,7 @@ RSpec.describe "Page Controller", type: :request do
           support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
           support_url: "https://example.gov.uk/contact",
           support_url_text: "Contact us",
+          pages: pages_data,
         }.to_json
       end
 
@@ -383,7 +384,7 @@ RSpec.describe "Page Controller", type: :request do
               answer_type: "single_line",
               is_optional: true,
             },
-          ].to_json
+          ]
         end
 
         context "when an optional question is completed" do


### PR DESCRIPTION
The runner only needs a read-only view of the form currently being served along with the pages of the form. Currently, two API requests are made whenever a form page is served - one to fetch the form and one to fetch the pages.

A new route has been added to the API to return the form including pages. This commit uses this endpoint to fetch the complete form.

#### What problem does the pull request solve?

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
