### PR TITLE
Update content of two error messages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,7 @@ en:
             date:
               blank: Enter a date
               blank_date_fields: Enter a day, month and year
-              future_date: Enter a date that is in the past
+              future_date: Enter a date that’s in the past
               invalid_date: Enter a real date
         question/email:
           attributes:
@@ -56,7 +56,7 @@ en:
           attributes:
             phone_number:
               blank: Enter a phone number
-              invalid_phone_number: Enter a phone number using only numbers, spaces, ’ext’, ‘-’ or ‘+’
+              invalid_phone_number: The phone number can only include numbers, spaces, ‘ext’, ‘-’, ‘+’, ‘(’ and ‘)’
               phone_too_long: The phone number should have 15 digits or less
               phone_too_short: The phone number should have 8 digits or more
         question/selection:


### PR DESCRIPTION
#### What problem does the pull request solve?

A few small content changes to two error messages because:

- parentheses are allowed in a phone number but are not mentioned in the relevant error message
- the formatting error message is clearer as a description rather than an instruction (and this aligns with design system guidance)
- there's a closing quote that should be an opening quote
- there was a missing positive contraction

Trello card: https://trello.com/c/sYlADvRO/555-couple-of-tiny-error-message-fixes

#### Checklist

- [x] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [x] Elsewhere - in [the validation and error messages document](https://docs.google.com/document/d/1hHVb_Yj2pBURBcA_HhdcNqKcinp9rjd16sDwpWf7MIk/edit?usp=sharing)
