### PR TITLE
simple catch of preview submit, probably needs more sentry context?

### DIFF
--- a/app/controllers/forms/submit_answers_controller.rb
+++ b/app/controllers/forms/submit_answers_controller.rb
@@ -4,10 +4,15 @@ module Forms
       unless preview?
         EventLogger.log_form_event(current_context, request, "submission")
       end
-
-      FormSubmissionService.call(form: current_context,
+      if form.email.nil?
+        Sentry.capture_message("preview submitted, caught")
+        render "errors/submission_error", status: :internal_server_error
+      else
+        FormSubmissionService.call(form: current_context,
                                  reference: params[:notify_reference],
                                  preview_mode: preview?).submit_form_to_processing_team
+
+      end
 
       current_context.clear
       redirect_to :form_submitted


### PR DESCRIPTION
#### What problem does the pull request solve?

Preview submissions send emails, they should not!

Related to https://trello.com/c/8v62dCzt/551-users-can-use-the-back-button-to-submit-a-form-twice-resulting-in-blank-emails-in-processing-inboxes


