### PR TITLE
Fix preview draft live links

### DIFF
--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -19,7 +19,11 @@ module Forms
   private
 
     def current_form
-      @current_form ||= Form.find_live(params.require(:form_id))
+      @current_form ||= if preview?
+                          Form.find(params.require(:form_id))
+                        else
+                          Form.find_live(params.require(:form_id))
+                        end
     end
 
     def current_context

--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -19,19 +19,39 @@ module Forms
   private
 
     def current_form
-      @current_form ||= if preview?
-                          Form.find(params.require(:form_id))
-                        else
-                          Form.find_live(params.require(:form_id))
-                        end
+      @current_form ||= fetch_form
     end
 
     def current_context
       @current_context ||= Context.new(form: current_form, store: session)
     end
 
+    def live
+      @live ||= !preview?
+    end
+
     def preview?
-      params[:mode] == "preview-form"
+      preview_draft? || preview_live?
+    end
+
+    def preview_draft?
+      mode == "preview-draft"
+    end
+
+    def preview_live?
+      mode == "preview-live"
+    end
+
+    def fetch_form
+      form_id = params.require(:form_id)
+
+      if preview_draft?
+        Form.find(form_id)
+      elsif preview_live?
+        Form.find_live(form_id)
+      elsif live
+        Form.find_live(form_id)
+      end
     end
 
     def mode

--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -46,7 +46,7 @@ module Forms
       form_id = params.require(:form_id)
 
       if preview_draft?
-        Form.find(form_id)
+        Form.find_draft(form_id)
       elsif preview_live?
         Form.find_live(form_id)
       elsif live

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -10,6 +10,10 @@ class Form < ActiveResource::Base
     find(:one, from: "#{prefix}forms/#{id}/live")
   end
 
+  def self.find_draft(id)
+    find(:one, from: "#{prefix}forms/#{id}/draft")
+  end
+
   def last_page
     pages.find { |p| !p.has_next_page? }
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,7 +47,7 @@
       <% end %>
       <%= yield(:before_content) %>
 
-      <main class="govuk-main-wrapper <%=main_classes(@current_form)%>" id="main-content" role="main">
+      <main class="govuk-main-wrapper <%=@live ? "" : "main--draft"%>" id="main-content" role="main">
         <%= yield %>
       </main>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   get "/help/accessibility-statement" => "application#accessibility_statement", as: :accessibility_statement
   get "/help/cookies" => "application#cookies", as: :cookies
 
-  scope "/:mode", mode: /preview-form|form/ do
+  scope "/:mode", mode: /preview-draft|preview-live|form/ do
     get "/:form_id" => "forms/base#redirect_to_friendly_url_start", as: :form_id
     scope "/:form_id/:form_slug" do
       get "/" => "forms/base#redirect_to_friendly_url_start", as: :form

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -62,10 +62,4 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
-
-  describe "#govuk_assets_path" do
-    it "returns the full node_modules asset path" do
-      expect(helper.govuk_assets_path).to eq "/node_modules/govuk-frontend/govuk/assets"
-    end
-  end
 end

--- a/spec/requests/check_your_answers_spec.rb
+++ b/spec/requests/check_your_answers_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Check Your Answers Controller", type: :request do
 
   describe "#show" do
     context "with preview mode on" do
-      let(:api_url_suffix) { "" }
+      let(:api_url_suffix) { "/draft" }
 
       context "without any questions answered" do
         it "redirects to first incomplete page of form" do

--- a/spec/requests/check_your_answers_spec.rb
+++ b/spec/requests/check_your_answers_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Check Your Answers Controller", type: :request do
 
       context "without any questions answered" do
         it "redirects to first incomplete page of form" do
-          get check_your_answers_path(mode: "preview-form", form_id: 2, form_slug: "form-1")
+          get check_your_answers_path(mode: "preview-draft", form_id: 2, form_slug: "form-1")
           expect(response.status).to eq(302)
           expect(response.location).to eq(form_page_url(2, "form-1", 1))
         end
@@ -74,10 +74,10 @@ RSpec.describe "Check Your Answers Controller", type: :request do
 
       context "with all questions answered and valid" do
         before do
-          post save_form_page_path("preview-form", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-          post save_form_page_path("preview-form", 2, "form-1", 2), params: { question: { text: "answer text" }, changing_existing_answer: false }
+          post save_form_page_path("preview-draft", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+          post save_form_page_path("preview-draft", 2, "form-1", 2), params: { question: { text: "answer text" }, changing_existing_answer: false }
           allow(EventLogger).to receive(:log).at_least(:once)
-          get check_your_answers_path(mode: "preview-form", form_id: 2, form_slug: "form-1")
+          get check_your_answers_path(mode: "preview-draft", form_id: 2, form_slug: "form-1")
         end
 
         it "returns 200" do
@@ -85,7 +85,7 @@ RSpec.describe "Check Your Answers Controller", type: :request do
         end
 
         it "Displays a back link to the last page of the form" do
-          expect(response.body).to include(form_page_path("preview-form", 2, "form-1", 2))
+          expect(response.body).to include(form_page_path("preview-draft", 2, "form-1", 2))
         end
 
         it "Returns the correct X-Robots-Tag header" do
@@ -124,7 +124,7 @@ RSpec.describe "Check Your Answers Controller", type: :request do
 
         it "does not return 404" do
           travel_to timestamp_of_request do
-            get check_your_answers_path(mode: "preview-form", form_id: 2, form_slug: "form-1")
+            get check_your_answers_path(mode: "preview-draft", form_id: 2, form_slug: "form-1")
           end
 
           expect(response.status).not_to eq(404)

--- a/spec/requests/check_your_answers_spec.rb
+++ b/spec/requests/check_your_answers_spec.rb
@@ -52,14 +52,18 @@ RSpec.describe "Check Your Answers Controller", type: :request do
     }
   end
 
+  let(:api_url_suffix) { "/live" }
+
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2/live", req_headers, form_data, 200
+      mock.get "/api/v1/forms/2#{api_url_suffix}", req_headers, form_data, 200
     end
   end
 
   describe "#show" do
     context "with preview mode on" do
+      let(:api_url_suffix) { "" }
+
       context "without any questions answered" do
         it "redirects to first incomplete page of form" do
           get check_your_answers_path(mode: "preview-form", form_id: 2, form_slug: "form-1")

--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -122,13 +122,13 @@ RSpec.describe Forms::BaseController, type: :request do
       context "when a form exists" do
         before do
           travel_to timestamp_of_request do
-            get form_path(mode: "preview-form", form_id: 2, form_slug: "form-name")
+            get form_path(mode: "preview-draft", form_id: 2, form_slug: "form-name")
           end
         end
 
         context "when the form has a start page" do
           it "Redirects to the first page" do
-            expect(response).to redirect_to(form_page_path("preview-form", 2, "form-name", 1))
+            expect(response).to redirect_to(form_page_path("preview-draft", 2, "form-name", 1))
           end
 
           it "does not log the form_visit event" do
@@ -160,12 +160,12 @@ RSpec.describe Forms::BaseController, type: :request do
 
         describe "Privacy page" do
           it "returns http code 200" do
-            get form_privacy_path(mode: "preview-form", form_id: 2, form_slug: "form-name")
+            get form_privacy_path(mode: "preview-draft", form_id: 2, form_slug: "form-name")
             expect(response).to have_http_status(:ok)
           end
 
           it "contains link to data controller's privacy policy" do
-            get form_privacy_path(mode: "preview-form", form_id: 2, form_slug: "form-name")
+            get form_privacy_path(mode: "preview-draft", form_id: 2, form_slug: "form-name")
             expect(response.body).to include("http://www.example.gov.uk/privacy_policy")
           end
         end
@@ -191,7 +191,7 @@ RSpec.describe Forms::BaseController, type: :request do
 
       context "when a form doesn't exists" do
         before do
-          get form_path(mode: "preview-form", form_id: 9999, form_slug: "form-name-1")
+          get form_path(mode: "preview-draft", form_id: 9999, form_slug: "form-name-1")
         end
 
         it "Render the not found page" do
@@ -222,7 +222,7 @@ RSpec.describe Forms::BaseController, type: :request do
         end
 
         before do
-          get form_path(mode: "preview-form", form_id: 9999, form_slug: "form-name")
+          get form_path(mode: "preview-draft", form_id: 9999, form_slug: "form-name")
         end
 
         it "Render the not found page" do

--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -52,11 +52,13 @@ RSpec.describe Forms::BaseController, type: :request do
     }
   end
 
+  let(:api_url_suffix) { "/live" }
+
   before do
     ActiveResource::HttpMock.respond_to do |mock|
       allow(EventLogger).to receive(:log).at_least(:once)
-      mock.get "/api/v1/forms/2/live", req_headers, form_response_data, 200
-      mock.get "/api/v1/forms/9999/live", req_headers, no_data_found_response, 404
+      mock.get "/api/v1/forms/2#{api_url_suffix}", req_headers, form_response_data, 200
+      mock.get "/api/v1/forms/9999#{api_url_suffix}", req_headers, no_data_found_response, 404
     end
   end
 
@@ -115,6 +117,8 @@ RSpec.describe Forms::BaseController, type: :request do
 
   describe "#show" do
     context "with preview mode on" do
+      let(:api_url_suffix) { "" }
+
       context "when a form exists" do
         before do
           travel_to timestamp_of_request do
@@ -156,12 +160,12 @@ RSpec.describe Forms::BaseController, type: :request do
 
         describe "Privacy page" do
           it "returns http code 200" do
-            get form_privacy_path(mode: "form", form_id: 2, form_slug: "form-name")
+            get form_privacy_path(mode: "preview-form", form_id: 2, form_slug: "form-name")
             expect(response).to have_http_status(:ok)
           end
 
           it "contains link to data controller's privacy policy" do
-            get form_privacy_path(mode: "form", form_id: 2, form_slug: "form-name")
+            get form_privacy_path(mode: "preview-form", form_id: 2, form_slug: "form-name")
             expect(response.body).to include("http://www.example.gov.uk/privacy_policy")
           end
         end

--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -117,22 +117,72 @@ RSpec.describe Forms::BaseController, type: :request do
 
   describe "#show" do
     context "with preview mode on" do
-      let(:api_url_suffix) { "" }
+      context "with a draft form" do
+        let(:api_url_suffix) { "/draft" }
 
-      context "when a form exists" do
-        before do
-          travel_to timestamp_of_request do
-            get form_path(mode: "preview-draft", form_id: 2, form_slug: "form-name")
+        context "when a form exists" do
+          before do
+            travel_to timestamp_of_request do
+              get form_path(mode: "preview-draft", form_id: 2, form_slug: "form-name")
+            end
+          end
+
+          context "when the form has a start page" do
+            it "Redirects to the first page" do
+              expect(response).to redirect_to(form_page_path("preview-draft", 2, "form-name", 1))
+            end
+
+            it "does not log the form_visit event" do
+              expect(EventLogger).not_to have_received(:log)
+            end
+          end
+
+          context "when the form has no start page" do
+            let(:form_response_data) do
+              {
+                id: 2,
+                name: "Form name",
+                form_slug: "form-name",
+                submission_email: "submission@email.com",
+                start_page: nil,
+                live_at: nil,
+                privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+              }.to_json
+            end
+
+            it "returns 404" do
+              expect(response.status).to eq(404)
+            end
+          end
+
+          it "Returns the correct X-Robots-Tag header" do
+            expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
+          end
+
+          describe "Privacy page" do
+            it "returns http code 200" do
+              get form_privacy_path(mode: "preview-draft", form_id: 2, form_slug: "form-name")
+              expect(response).to have_http_status(:ok)
+            end
+
+            it "contains link to data controller's privacy policy" do
+              get form_privacy_path(mode: "preview-draft", form_id: 2, form_slug: "form-name")
+              expect(response.body).to include("http://www.example.gov.uk/privacy_policy")
+            end
           end
         end
 
-        context "when the form has a start page" do
-          it "Redirects to the first page" do
-            expect(response).to redirect_to(form_page_path("preview-draft", 2, "form-name", 1))
+        context "when a form doesn't exists" do
+          before do
+            get form_path(mode: "preview-draft", form_id: 9999, form_slug: "form-name-1")
           end
 
-          it "does not log the form_visit event" do
-            expect(EventLogger).not_to have_received(:log)
+          it "Render the not found page" do
+            expect(response.body).to include(I18n.t("not_found.title"))
+          end
+
+          it "returns 404" do
+            expect(response.status).to eq(404)
           end
         end
 
@@ -144,9 +194,92 @@ RSpec.describe Forms::BaseController, type: :request do
               form_slug: "form-name",
               submission_email: "submission@email.com",
               start_page: nil,
-              live_at: nil,
               privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+              what_happens_next_text: "Good things come to those that wait",
+              declaration_text: "agree to the declaration",
+              support_email: "help@example.gov.uk",
+              support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
+              support_url: "https://example.gov.uk/contact",
+              support_url_text: "Contact us",
             }.to_json
+          end
+
+          before do
+            get form_path(mode: "preview-draft", form_id: 9999, form_slug: "form-name")
+          end
+
+          it "Render the not found page" do
+            expect(response.body).to include(I18n.t("not_found.title"))
+          end
+
+          it "returns 404" do
+            expect(response.status).to eq(404)
+          end
+        end
+      end
+
+      context "with a live form" do
+        let(:api_url_suffix) { "/live" }
+
+        context "when a form exists" do
+          before do
+            travel_to timestamp_of_request do
+              get form_path(mode: "preview-live", form_id: 2, form_slug: "form-name")
+            end
+          end
+
+          context "when the form has a start page" do
+            it "Redirects to the first page" do
+              expect(response).to redirect_to(form_page_path("preview-live", 2, "form-name", 1))
+            end
+
+            it "does not log the form_visit event" do
+              expect(EventLogger).not_to have_received(:log)
+            end
+          end
+
+          context "when the form has no start page" do
+            let(:form_response_data) do
+              {
+                id: 2,
+                name: "Form name",
+                form_slug: "form-name",
+                submission_email: "submission@email.com",
+                start_page: nil,
+                live_at: nil,
+                privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+              }.to_json
+            end
+
+            it "returns 404" do
+              expect(response.status).to eq(404)
+            end
+          end
+
+          it "Returns the correct X-Robots-Tag header" do
+            expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
+          end
+
+          describe "Privacy page" do
+            it "returns http code 200" do
+              get form_privacy_path(mode: "preview-live", form_id: 2, form_slug: "form-name")
+              expect(response).to have_http_status(:ok)
+            end
+
+            it "contains link to data controller's privacy policy" do
+              get form_privacy_path(mode: "preview-live", form_id: 2, form_slug: "form-name")
+              expect(response.body).to include("http://www.example.gov.uk/privacy_policy")
+            end
+          end
+        end
+
+        context "when a form doesn't exists" do
+          before do
+            get form_path(mode: "preview-live", form_id: 9999, form_slug: "form-name-1")
+          end
+
+          it "Render the not found page" do
+            expect(response.body).to include(I18n.t("not_found.title"))
           end
 
           it "returns 404" do
@@ -154,83 +287,35 @@ RSpec.describe Forms::BaseController, type: :request do
           end
         end
 
-        it "Returns the correct X-Robots-Tag header" do
-          expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
-        end
-
-        describe "Privacy page" do
-          it "returns http code 200" do
-            get form_privacy_path(mode: "preview-draft", form_id: 2, form_slug: "form-name")
-            expect(response).to have_http_status(:ok)
-          end
-
-          it "contains link to data controller's privacy policy" do
-            get form_privacy_path(mode: "preview-draft", form_id: 2, form_slug: "form-name")
-            expect(response.body).to include("http://www.example.gov.uk/privacy_policy")
-          end
-        end
-
-        context "and a form has a live_at value in the future" do
+        context "when the form has no start page" do
           let(:form_response_data) do
             {
               id: 2,
               name: "Form name",
               form_slug: "form-name",
               submission_email: "submission@email.com",
-              live_at: "2023-01-01 09:00:00 +0100",
-              start_page: "1",
+              start_page: nil,
               privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+              what_happens_next_text: "Good things come to those that wait",
+              declaration_text: "agree to the declaration",
+              support_email: "help@example.gov.uk",
+              support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
+              support_url: "https://example.gov.uk/contact",
+              support_url_text: "Contact us",
             }.to_json
           end
 
-          it "does not return 404" do
-            expect(response.status).not_to eq(404)
+          before do
+            get form_path(mode: "preview-live", form_id: 9999, form_slug: "form-name")
           end
-        end
-      end
 
-      context "when a form doesn't exists" do
-        before do
-          get form_path(mode: "preview-draft", form_id: 9999, form_slug: "form-name-1")
-        end
+          it "Render the not found page" do
+            expect(response.body).to include(I18n.t("not_found.title"))
+          end
 
-        it "Render the not found page" do
-          expect(response.body).to include(I18n.t("not_found.title"))
-        end
-
-        it "returns 404" do
-          expect(response.status).to eq(404)
-        end
-      end
-
-      context "when the form has no start page" do
-        let(:form_response_data) do
-          {
-            id: 2,
-            name: "Form name",
-            form_slug: "form-name",
-            submission_email: "submission@email.com",
-            start_page: nil,
-            privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-            what_happens_next_text: "Good things come to those that wait",
-            declaration_text: "agree to the declaration",
-            support_email: "help@example.gov.uk",
-            support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
-            support_url: "https://example.gov.uk/contact",
-            support_url_text: "Contact us",
-          }.to_json
-        end
-
-        before do
-          get form_path(mode: "preview-draft", form_id: 9999, form_slug: "form-name")
-        end
-
-        it "Render the not found page" do
-          expect(response.body).to include(I18n.t("not_found.title"))
-        end
-
-        it "returns 404" do
-          expect(response.status).to eq(404)
+          it "returns 404" do
+            expect(response.status).to eq(404)
+          end
         end
       end
     end
@@ -281,7 +366,7 @@ RSpec.describe Forms::BaseController, type: :request do
           end
         end
 
-        context "when a form doesn't exist" do
+        context "when a live form doesn't exist" do
           before do
             get form_path(mode: "form", form_id: 9999, form_slug: "form-name")
           end
@@ -293,34 +378,6 @@ RSpec.describe Forms::BaseController, type: :request do
           it "Render the not found page" do
             expect(response.body).to include(I18n.t("not_found.title"))
           end
-        end
-      end
-
-      context "and a form has a live_at value in the future" do
-        let(:form_response_data) do
-          {
-            id: 2,
-            name: "Form name",
-            form_slug: "form-name",
-            submission_email: "submission@email.com",
-            live_at: "2023-08-18 09:16:50 +0100",
-            start_page: nil,
-            privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-            support_email: "help@example.gov.uk",
-            support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
-            support_url: "https://example.gov.uk/contact",
-            support_url_text: "Contact us",
-          }.to_json
-        end
-
-        before do
-          travel_to timestamp_of_request do
-            get form_path(mode: "form", form_id: 2, form_slug: "form-name")
-          end
-        end
-
-        it "returns 404" do
-          expect(response.status).to eq(404)
         end
       end
     end

--- a/spec/requests/forms/submit_answers_controller_spec.rb
+++ b/spec/requests/forms/submit_answers_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Forms::SubmitAnswersController, type: :request do
   describe "#submit_answers" do
     context "with preview mode on" do
       before do
-        post form_submit_answers_path("preview-form", 2, "form-name", 1)
+        post form_submit_answers_path("preview-live", 2, "form-name", 1)
       end
 
       it "does not log the form_submission event" do

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -64,32 +64,32 @@ RSpec.describe "Page Controller", type: :request do
       let(:api_url_suffix) { "" }
 
       it "Returns a 200" do
-        get form_page_path("preview-form", 2, "form-1", 1)
+        get form_page_path("preview-draft", 2, "form-1", 1)
         expect(response.status).to eq(200)
       end
 
       it "redirects to first page if second request before first complete" do
-        get form_page_path("preview-form", 2, "form-1", 2)
+        get form_page_path("preview-draft", 2, "form-1", 2)
         expect(response).to redirect_to(form_page_path(2, "form-1", 1))
       end
 
       it "Displays the question text on the page" do
-        get form_page_path("preview-form", 2, "form-1", 1)
+        get form_page_path("preview-draft", 2, "form-1", 1)
         expect(response.body).to include("Question one")
       end
 
       it "Displays the privacy policy link on the page" do
-        get form_page_path("preview-form", 2, "form-1", 1)
+        get form_page_path("preview-draft", 2, "form-1", 1)
         expect(response.body).to include("Privacy")
       end
 
       it "Displays the accessibility statement link on the page" do
-        get form_page_path("preview-form", 2, "form-1", 1)
+        get form_page_path("preview-draft", 2, "form-1", 1)
         expect(response.body).to include("Accessibility statement")
       end
 
       it "Displays the Cookies link on the page" do
-        get form_page_path("preview-form", 2, "form-1", 1)
+        get form_page_path("preview-draft", 2, "form-1", 1)
         expect(response.body).to include("Cookies")
       end
 
@@ -98,33 +98,33 @@ RSpec.describe "Page Controller", type: :request do
           allow_any_instance_of(Context).to receive(:can_visit?)
                                               .and_return(true)
           allow_any_instance_of(Context).to receive(:previous_step).and_return(1)
-          get form_page_path("preview-form", 2, "form-1", 2)
+          get form_page_path("preview-draft", 2, "form-1", 2)
           expect(response.body).to include(form_page_path(2, "form-1", 1))
         end
       end
 
       context "with a change answers page" do
         it "Displays a back link to the check your answers page" do
-          get form_change_answer_path("preview-form", 2, "form-1", 1)
-          expect(response.body).to include(check_your_answers_path("preview-form", 2, "form-1"))
+          get form_change_answer_path("preview-draft", 2, "form-1", 1)
+          expect(response.body).to include(check_your_answers_path("preview-draft", 2, "form-1"))
         end
 
         it "Passes the changing answers parameter in its submit request" do
-          get form_change_answer_path("preview-form", 2, "form-1", 1)
-          expect(response.body).to include(save_form_page_path("preview-form", 2, "form-1", 1, changing_existing_answer: true))
+          get form_change_answer_path("preview-draft", 2, "form-1", 1)
+          expect(response.body).to include(save_form_page_path("preview-draft", 2, "form-1", 1, changing_existing_answer: true))
         end
       end
 
       it "Returns the correct X-Robots-Tag header" do
-        get form_page_path("preview-form", 2, "form-1", 1)
+        get form_page_path("preview-draft", 2, "form-1", 1)
         expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
       end
 
       context "with no questions answered" do
         it "redirects if a later page is requested" do
-          get check_your_answers_path("preview-form", 2, "form-1")
+          get check_your_answers_path("preview-draft", 2, "form-1")
           expect(response.status).to eq(302)
-          expect(response.location).to eq(form_page_url("preview-form", 2, "form-1", 1))
+          expect(response.location).to eq(form_page_url("preview-draft", 2, "form-1", 1))
         end
       end
     end
@@ -255,40 +255,40 @@ RSpec.describe "Page Controller", type: :request do
       let(:api_url_suffix) { "" }
       it "Redirects to the next page" do
 
-        post save_form_page_path("preview-form", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path("preview-form", 2, "form-1", 2))
+        post save_form_page_path("preview-draft", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path("preview-draft", 2, "form-1", 2))
       end
 
       context "when changing an existing answer" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("preview-form", 2, "form-1", 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
-          expect(response).to redirect_to(check_your_answers_path("preview-form", 2, "form-1"))
+          post save_form_page_path("preview-draft", 2, "form-1", 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, "form-1"))
         end
 
         it "does not log the change_answer_page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-form", 2, "form-1", 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          post save_form_page_path("preview-draft", 2, "form-1", 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
         end
       end
 
       context "with the first page" do
         it "Logs the first_page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-form", 2, "form-1", 1), params: { question: { text: "answer text" } }
+          post save_form_page_path("preview-draft", 2, "form-1", 1), params: { question: { text: "answer text" } }
         end
       end
 
       context "with a subsequent page" do
         it "Logs the page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-form", 2, "form-1", 2), params: { question: { text: "answer text" } }
+          post save_form_page_path("preview-draft", 2, "form-1", 2), params: { question: { text: "answer text" } }
         end
       end
 
       context "with the final page" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("preview-form", 2, "form-1", 2), params: { question: { text: "answer text" } }
-          expect(response).to redirect_to(check_your_answers_path("preview-form", 2, "form-1"))
+          post save_form_page_path("preview-draft", 2, "form-1", 2), params: { question: { text: "answer text" } }
+          expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, "form-1"))
         end
       end
 
@@ -314,7 +314,7 @@ RSpec.describe "Page Controller", type: :request do
 
         it "does not return 404" do
           travel_to timestamp_of_request do
-            post save_form_page_path("preview-form", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+            post save_form_page_path("preview-draft", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
           end
           expect(response.status).not_to eq(404)
         end

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -51,14 +51,18 @@ RSpec.describe "Page Controller", type: :request do
     }
   end
 
+  let(:api_url_suffix) { "/live" }
+
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2/live", req_headers, form_data, 200
+      mock.get "/api/v1/forms/2#{api_url_suffix}", req_headers, form_data, 200
     end
   end
 
   describe "#show" do
     context "with preview mode on" do
+      let(:api_url_suffix) { "" }
+
       it "Returns a 200" do
         get form_page_path("preview-form", 2, "form-1", 1)
         expect(response.status).to eq(200)
@@ -248,7 +252,9 @@ RSpec.describe "Page Controller", type: :request do
 
   describe "#save" do
     context "with preview mode on" do
+      let(:api_url_suffix) { "" }
       it "Redirects to the next page" do
+
         post save_form_page_path("preview-form", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
         expect(response).to redirect_to(form_page_path("preview-form", 2, "form-1", 2))
       end
@@ -285,33 +291,33 @@ RSpec.describe "Page Controller", type: :request do
           expect(response).to redirect_to(check_your_answers_path("preview-form", 2, "form-1"))
         end
       end
-    end
 
-    context "and a form has a live_at value in the future" do
-      let(:form_data) do
-        {
-          id: 2,
-          name: "Form name",
-          form_slug: "form-name",
-          submission_email: "submission@email.com",
-          live_at: "2023-01-01 09:00:00 +0100",
-          start_page: "1",
-          privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-          what_happens_next_text: "Good things come to those that wait",
-          declaration_text: "agree to the declaration",
-          support_email: "help@example.gov.uk",
-          support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
-          support_url: "https://example.gov.uk/contact",
-          support_url_text: "Contact us",
-          pages: pages_data,
-        }.to_json
-      end
-
-      it "does not return 404" do
-        travel_to timestamp_of_request do
-          post save_form_page_path("preview-form", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+      context "and a form has a live_at value in the future" do
+        let(:form_data) do
+          {
+            id: 2,
+            name: "Form name",
+            form_slug: "form-name",
+            submission_email: "submission@email.com",
+            live_at: "2023-01-01 09:00:00 +0100",
+            start_page: "1",
+            privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+            what_happens_next_text: "Good things come to those that wait",
+            declaration_text: "agree to the declaration",
+            support_email: "help@example.gov.uk",
+            support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
+            support_url: "https://example.gov.uk/contact",
+            support_url_text: "Contact us",
+            pages: pages_data,
+          }.to_json
         end
-        expect(response.status).not_to eq(404)
+
+        it "does not return 404" do
+          travel_to timestamp_of_request do
+            post save_form_page_path("preview-form", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+          end
+          expect(response.status).not_to eq(404)
+        end
       end
     end
 

--- a/spec/requests/page_spec.rb
+++ b/spec/requests/page_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Page Controller", type: :request do
 
   describe "#show" do
     context "with preview mode on" do
-      let(:api_url_suffix) { "" }
+      let(:api_url_suffix) { "/draft" }
 
       it "Returns a 200" do
         get form_page_path("preview-draft", 2, "form-1", 1)
@@ -252,7 +252,7 @@ RSpec.describe "Page Controller", type: :request do
 
   describe "#save" do
     context "with preview mode on" do
-      let(:api_url_suffix) { "" }
+      let(:api_url_suffix) { "/draft" }
       it "Redirects to the next page" do
 
         post save_form_page_path("preview-draft", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }


### PR DESCRIPTION
#### Add draft/live preview links

Trello card: https://trello.com/c/YajCpcgm/557-enable-form-preview-for-draft-and-live-forms
See: https://github.com/alphagov/forms-admin/pull/339


#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
