### PR TITLE
Ensure a form has a submission email and steps before sending submission email

### DIFF
--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -12,6 +12,8 @@ class FormSubmissionService
   end
 
   def submit_form_to_processing_team
+    raise StandardError, "Form id(#{@form.id}) has no steps i.e questions/answers to include in submission email" if @form.steps.blank?
+
     if !@preview_mode && @form.submission_email.blank?
       raise StandardError, "Form id(#{@form.id}) is missing a submission email address"
     end

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -12,14 +12,20 @@ class FormSubmissionService
   end
 
   def submit_form_to_processing_team
+    if !@preview_mode && @form.submission_email.blank?
+      raise StandardError, "Form id(#{@form.id}) is missing a submission email address"
+    end
+
     timestamp = submission_timestamp
 
-    FormSubmissionMailer
-      .email_completed_form(title: form_title,
-                            text_input: email_body,
-                            reference: @reference,
-                            timestamp:,
-                            submission_email: @form.submission_email).deliver_now
+    unless @form.submission_email.blank? && @preview_mode
+      FormSubmissionMailer
+        .email_completed_form(title: form_title,
+                              text_input: email_body,
+                              reference: @reference,
+                              timestamp:,
+                              submission_email: @form.submission_email).deliver_now
+    end
   end
 
   class NotifyTemplateBodyFilter

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe FormSubmissionService do
       end
     end
 
+    describe "validations" do
+      context "when form has no submission email" do
+        let(:form) { OpenStruct.new(id: 1, form_name: "Form 1", submission_email: nil, steps: [step]) }
+
+        it "raises an error" do
+          expect { service.submit_form_to_processing_team }.to raise_error("Form id(1) is missing a submission email address")
+        end
+      end
+    end
+
     context "when form being submitted is from previewed form" do
       let(:preview_mode) { true }
 
@@ -41,6 +51,24 @@ RSpec.describe FormSubmissionService do
               timestamp: Time.zone.now,
               submission_email: "testing@gov.uk" },
           ).once
+        end
+      end
+
+      describe "validations" do
+        context "when form has no submission email" do
+          let(:form) { OpenStruct.new(id: 1, form_name: "Form 1", submission_email: nil, steps: [step]) }
+
+          it "does not raise an error" do
+            expect { service.submit_form_to_processing_team }.not_to raise_error
+          end
+
+          it "does not called the FormSubmissionMailer" do
+            allow(FormSubmissionMailer).to receive(:email_completed_form).at_least(:once)
+
+            service.submit_form_to_processing_team
+
+            expect(FormSubmissionMailer).not_to have_received(:email_completed_form)
+          end
         end
       end
     end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe FormSubmissionService do
           expect { service.submit_form_to_processing_team }.to raise_error("Form id(1) is missing a submission email address")
         end
       end
+
+      context "when from has no steps (i.e questions/answers)" do
+        let(:form) { OpenStruct.new(id: 1, form_name: "Form 1", submission_email: "example@example.gov.uk", steps: []) }
+        let(:result) { service.submit_form_to_processing_team }
+
+        it "raises an error" do
+          expect { result }.to raise_error("Form id(1) has no steps i.e questions/answers to include in submission email")
+        end
+      end
     end
 
     context "when form being submitted is from previewed form" do
@@ -62,12 +71,21 @@ RSpec.describe FormSubmissionService do
             expect { service.submit_form_to_processing_team }.not_to raise_error
           end
 
-          it "does not called the FormSubmissionMailer" do
+          it "does not call the FormSubmissionMailer" do
             allow(FormSubmissionMailer).to receive(:email_completed_form).at_least(:once)
 
             service.submit_form_to_processing_team
 
             expect(FormSubmissionMailer).not_to have_received(:email_completed_form)
+          end
+        end
+
+        context "when from has no steps (i.e questions/answers)" do
+          let(:form) { OpenStruct.new(id: 1, form_name: "Form 1", submission_email: "example@example.gov.uk", steps: []) }
+          let(:result) { service.submit_form_to_processing_team }
+
+          it "raises an error" do
+            expect { result }.to raise_error("Form id(1) has no steps i.e questions/answers to include in submission email")
           end
         end
       end


### PR DESCRIPTION
#### What problem does the pull request solve?

We need to validate that when a form filler submits their
answer for a form, before attempting to call GOVUK Notify,
we check that the form actually has a submission email.

This should be very rare because live forms should have
a submission email before they are made live. The only real
use case where a submission email maybe blank is when a
the form creator is previewing a form and they haven't completed
the add submission email task before they previewed the form. Rather than attempting to call GOVUK Notify without
a submission email and for it to raise an unhandled error we
can instead ignore the call to the mailer and process
the request as though the submission email address was provided
(After all, this is just a preview form so it shouldn't really
matter but if the form creator has provided the email then we should continue to send the answers to that email address)

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
