### PR TITLE
Allow manual deploys of arbitrary branch to CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@ name: Deploy to GOV.UK PaaS
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -12,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref_to_deploy }}
 
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@9669f3ee51dc3f4eda8447ab696b3ab19a90d14b # ruby 3.1.1


### PR DESCRIPTION
#### What problem does the pull request solve?

Allows us to deploy a branch to the PaaS dev server. We already have this for admin. 

This github action isn't likely to last very long since we're switching over to AWS soon, where I think we can already do arbitrary deploys. I'm planning to use this to test the changes in https://github.com/alphagov/forms-runner/pull/281.

Trello card: https://trello.com/c/Q6RLPY64/409-allow-manual-deploys-to-dev-environment

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
