### PR TITLE
Remove alpine edge repository from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apk update
 RUN apk upgrade --available
-RUN apk add libc6-compat openssl-dev build-base libpq-dev nodejs npm
+RUN apk add libc6-compat openssl-dev build-base libpq-dev nodejs=18.14.2-r0 npm
 RUN adduser -D ruby
 RUN mkdir /node_modules && chown ruby:ruby -R /node_modules /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,9 @@ FROM ruby:3.2.0-alpine3.17@sha256:c690d3b45ef65e0098104c272f1736b0595b824908d563
 
 WORKDIR /app
 
-# Edge repo is necessary for Node 16 and openssl 3
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 RUN apk update
 RUN apk upgrade --available
-RUN apk add libc6-compat openssl-dev build-base libpq-dev nodejs=18.15.0-r0 npm
+RUN apk add libc6-compat openssl-dev build-base libpq-dev nodejs npm
 RUN adduser -D ruby
 RUN mkdir /node_modules && chown ruby:ruby -R /node_modules /app
 
@@ -33,7 +31,7 @@ RUN SECRET_KEY_BASE=dummyvalue rails assets:precompile
 
 CMD ["bash"]
 
-FROM ruby:3.2.0-alpine3.17@sha256:c690d3b45ef65e0098104c272f1736b0595b824908d5639c3a3d17636581a905 AS app
+FROM ruby:3.2.0-alpine3.17@sha256:c690d3b45ef65e0098104c272f1736b0595b824908d5639c3a3d17636581a905  AS app
 
 ENV RAILS_ENV="${RAILS_ENV:-production}" \
     PATH="${PATH}:/home/ruby/.local/bin" \

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ ruby "3.2.0"
 gem "rails", "~> 7.0.4"
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem "nokogiri", "~> 1.14.2"
+gem "nokogiri", "~> 1.14.3"
 gem "puma", "~> 6.2.1"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,13 +223,13 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.14.2-aarch64-linux)
+    nokogiri (1.14.3-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.14.2-arm64-darwin)
+    nokogiri (1.14.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.2-x86_64-darwin)
+    nokogiri (1.14.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.2-x86_64-linux)
+    nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)
       jwt (>= 1.5, < 3)
@@ -418,7 +418,7 @@ DEPENDENCIES
   i18n-tasks (~> 1.0.12)
   jbuilder
   lograge
-  nokogiri (~> 1.14.2)
+  nokogiri (~> 1.14.3)
   pry
   pry-byebug
   puma (~> 6.2.1)


### PR DESCRIPTION
This removes the edge repository from the alpine install steps in Dockerfile.

We do this to make the build more stable and to match the PRs against admin and runner.

#### What problem does the pull request solve?

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
