### PR TITLE
Adjust preview watermark sizes

### DIFF
--- a/app/components/main_component/_index.scss
+++ b/app/components/main_component/_index.scss
@@ -1,0 +1,51 @@
+$preview-draft-background-size: 100%;
+$preview-draft-background-size-desktop: 60%;
+
+$preview-draft-question-background-size: 50%;
+$preview-draft-question-background-size-desktop: 30%;
+
+$prevew-live-background-size: 100%;
+$prevew-live-background-size-desktop: 70%;
+
+$preview-live-question-background-size: 60%;
+$preview-live-question-background-size-desktop: 40%;
+
+.main--preview-draft {
+  background-image: url("@images/draft-watermark.png");
+  background-size: $preview-draft-background-size;
+  background-repeat: repeat-y;
+  background-position: 50% 0;
+
+  @include govuk-media-query(desktop) {
+    background-size: $preview-draft-background-size-desktop;
+  }
+
+  &.main--question {
+    background-repeat: repeat;
+    background-size: $preview-draft-question-background-size;
+
+    @include govuk-media-query(desktop) {
+      background-size: $preview-draft-question-background-size-desktop;
+    }
+  }
+}
+
+.main--preview-live {
+  background-image: url("@images/preview-watermark.png");
+  background-size: $prevew-live-background-size;
+  background-repeat: repeat-y;
+  background-position: 50% 0;
+
+  @include govuk-media-query(desktop) {
+    background-size: $prevew-live-background-size-desktop;
+  }
+
+  &.main--question {
+    background-repeat: repeat;
+    background-size: $preview-live-question-background-size;
+
+    @include govuk-media-query(desktop) {
+      background-size: $preview-live-question-background-size-desktop;
+    }
+  }
+}

--- a/app/components/main_component/view.rb
+++ b/app/components/main_component/view.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module MainComponent
+  class View < ViewComponent::Base
+    def initialize(mode:, is_question: false)
+      super
+      @mode = mode
+      @is_question = is_question
+    end
+
+    def call
+      tag.main(class: "govuk-main-wrapper #{mode_class} #{is_question_class}", id: "main-content", role: "main") do
+        content
+      end
+    end
+
+  private
+
+    def mode_class
+      "main--#{@mode}" if @mode.present?
+    end
+
+    def is_question_class
+      "main--question" if @is_question
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,10 +22,6 @@ class ApplicationController < ActionController::Base
     payload[:form_id] = params[:form_id] if params[:form_id].present?
   end
 
-  def mode
-    @mode ||= Mode.new(:static)
-  end
-
 private
 
   def add_robots_header

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -5,6 +5,7 @@ module Forms
     def show
       redirect_to form_page_path(@step.form_id, @step.form_slug, current_context.next_page_slug) unless current_context.can_visit?(@step.page_slug)
       back_link(@step.page_slug)
+      @is_question = true
     end
 
     def save
@@ -17,6 +18,7 @@ module Forms
         end
         redirect_to next_page
       else
+        @is_question = true
         render :show
       end
     end

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -5,17 +5,4 @@ $govuk-global-styles: true;
 
 @import "govuk/all";
 @import "../../components/form_header_component/";
-
-.main--preview-draft {
-  background-image: url("@images/draft-watermark.png");
-  background-repeat: repeat;
-  background-position: 50% 0;
-  background-size: 190px;
-}
-
-.main--preview-live {
-  background-image: url("@images/preview-watermark.png");
-  background-repeat: repeat;
-  background-position: 50% 0;
-  background-size: 190px;
-}
+@import "../../components/main_component/";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,9 +39,10 @@
 
       <%= yield(:before_content) %>
 
-      <main class="govuk-main-wrapper <%= "main--#{@mode || 'static'}" %>" id="main-content" role="main">
+      <%= render(MainComponent::View.new(mode: @mode, is_question: @is_question)) do %>
         <%= yield %>
-      </main>
+      <% end %>
+
     </div>
 
     <% meta_links = {t("footer.accessibility_statement") => accessibility_statement_path, t("footer.cookies") => cookies_path} %>

--- a/spec/components/main_component/main_component_preview.rb
+++ b/spec/components/main_component/main_component_preview.rb
@@ -1,0 +1,29 @@
+class MainComponent::MainComponentPreview < ViewComponent::Preview
+  def deafult
+    render(MainComponent::View.new(mode: nil))
+  end
+
+  def draft_preview
+    render(MainComponent::View.new(mode: 'preview-draft')) do
+      Array.new(10) { content_tag(:p, "This is the draft preview example content.") }.join.html_safe
+    end
+  end
+
+  def live_preview
+    render(MainComponent::View.new(mode: 'preview-live')) do
+      Array.new(10) { content_tag(:p, "This is the live preview example content.") }.join.html_safe
+    end
+  end
+
+  def draft_preview_question
+    render(MainComponent::View.new(mode: 'preview-draft', is_question: true)) do
+      Array.new(10) { content_tag(:p, "This is the draft preview example content for question pages.") }.join.html_safe
+    end
+  end
+
+  def live_preview_question
+    render(MainComponent::View.new(mode: 'preview-live', is_question: true)) do
+      Array.new(10) { content_tag(:p, "This is the live preview example content for question pages.") }.join.html_safe
+    end
+  end
+end

--- a/spec/components/main_component/view_spec.rb
+++ b/spec/components/main_component/view_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe MainComponent::View, type: :component do
+  it "adds class for mode" do
+    mode = 'preview-draft'
+    render_inline(described_class.new(mode:))
+    expect(page).to have_selector(".main--preview-draft")
+  end
+
+  it "does not add class for empty mode" do
+    mode = ''
+    render_inline(described_class.new(mode:))
+    expect(page).not_to have_selector(".main--")
+  end
+
+  it "adds question class if is_question is true" do
+    mode = ''
+    render_inline(described_class.new(mode:, is_question: true))
+    expect(page).to have_selector(".main--question")
+  end
+
+  it "does not add question class if is_question is not true" do
+    mode = ''
+    render_inline(described_class.new(mode:))
+    expect(page).not_to have_selector(".main--question")
+  end
+end


### PR DESCRIPTION
# Improve the sizing of watermarks in preview_live and preview_draft

The watermarks can be a bit busy on some pages at some screen sizes.

This commit pulls the watermark logic and styles into a new component and sets the sizes there.

Trello card: https://trello.com/c/RwwdXK95/690-change-size-of-preview-watermarks

<img width="992" alt="image" src="https://user-images.githubusercontent.com/11035856/233341841-4ba9b0e6-ca8e-4f8f-8396-087641771e56.png">

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
