### PR TITLE
Fix event triggers for Trello Poster action

### DIFF
--- a/.github/workflows/trello_poster.yml
+++ b/.github/workflows/trello_poster.yml
@@ -1,7 +1,7 @@
 name: Trello Poster
 on:
   pull_request:
-    types: [created, edited]
+    types: [opened, edited]
 jobs:
   trello-poster:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We noticed that the Trello Poster was only working some of the time, it
turns out there was a typo in the event trigger configuration, the
action `created` is not valid, it should be `opened` [[1]].

[1]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request