### PR TITLE
Refactor Context form method uses form object and not just id

### DIFF
--- a/app/components/form_header_component/view.rb
+++ b/app/components/form_header_component/view.rb
@@ -22,7 +22,7 @@ module FormHeaderComponent
 
     def service_url
       if @service_url_overide == :not_set
-        form_path(form_id: @current_context.form, form_slug: @current_context.form_slug)
+        form_path(form_id: @current_context.form.id, form_slug: @current_context.form_slug)
       else
         @service_url_overide
       end

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -1,10 +1,10 @@
 module Forms
   class CheckYourAnswersController < BaseController
     def show
-      return redirect_to form_page_path(current_context.form, current_context.form_slug, current_context.next_page_slug) unless current_context.can_visit?(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)
+      return redirect_to form_page_path(current_context.form.id, current_context.form_slug, current_context.next_page_slug) unless current_context.can_visit?(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)
 
       previous_step = current_context.previous_step("check_your_answers")
-      @back_link = form_page_path(current_context.form, current_context.form_slug, previous_step)
+      @back_link = form_page_path(current_context.form.id, current_context.form_slug, previous_step)
       @rows = check_your_answers_rows
       @form_submit_path = form_submit_answers_path
       @notify_reference ||= SecureRandom.uuid

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -47,7 +47,7 @@ module Forms
     def back_link(page_slug)
       previous_step = current_context.previous_step(page_slug)
       if @changing_existing_answer
-        @back_link = check_your_answers_path(form_id: current_context.form)
+        @back_link = check_your_answers_path(form_id: current_context.form.id)
       elsif previous_step
         @back_link = form_page_path(@step.form_id, @step.form_slug, previous_step)
       end
@@ -55,7 +55,7 @@ module Forms
 
     def next_page
       if @changing_existing_answer
-        check_your_answers_path(form_id: current_context.form, form_slug: current_context.form_slug)
+        check_your_answers_path(form_id: current_context.form.id, form_slug: current_context.form_slug)
       else
         form_page_path(@step.form_id, @step.form_slug, @step.next_page_slug)
       end

--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -1,14 +1,14 @@
 class Context
-  attr_accessor :form_slug
+  attr_accessor :form_slug, :form
   attr_reader :form_name, :form_start_page, :privacy_policy_url, :what_happens_next_text, :support_details, :declaration_text
 
   def initialize(form:, store:)
+    @form = form
     @form_context = FormContext.new(store)
     @step_factory = StepFactory.new(form:)
     @journey = Journey.new(form_context: @form_context, step_factory: @step_factory)
 
     @completed_steps = @journey.completed_steps
-    @form_id = form.id
     @form_slug = form.form_slug
     @form_name = form.name
     @form_start_page = form.start_page
@@ -58,15 +58,11 @@ class Context
   end
 
   def clear
-    @form_context.clear(@form_id)
+    @form_context.clear(form.id)
   end
 
   def form_submitted?
-    @form_context.form_submitted?(@form_id)
-  end
-
-  def form
-    @form_id
+    @form_context.form_submitted?(form.id)
   end
 
   def submission_email

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,7 +47,7 @@
 
     <% meta_links = {t("footer.accessibility_statement") => accessibility_statement_path, t("footer.cookies") => cookies_path} %>
     <% if @current_context.present? %>
-      <% meta_links[t("footer.privacy_policy")] = form_privacy_path(@current_context.form) %>
+      <% meta_links[t("footer.privacy_policy")] = form_privacy_path(@current_context.form.id) %>
     <% end -%>
 
     <%= govuk_footer meta_items_title: t("footer.helpful_links"), meta_items: meta_links %>


### PR DESCRIPTION
#### What problem does the pull request solve?

Context.form was extremely confusing because when you looked at `current_context.form`, one may assume that it would return the form that the user is filling in. Instead it would just return the form id. Not only was this confusing but also it meant that for other form attributes we ended up created attributes in the context to play back the same attributes we had in the form already. There will be more refactors but I wanted to try keep them small and targetted.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
