### PR TITLE
Use form's name/start page instead of context & refactor calls to form_submission_service

### DIFF
--- a/app/components/form_header_component/view.rb
+++ b/app/components/form_header_component/view.rb
@@ -9,7 +9,7 @@ module FormHeaderComponent
 
     def call
       if @current_context.present?
-        govuk_header(service_name: @current_context.form_name,
+        govuk_header(service_name: @current_context.form.name,
                      homepage_url: "https://www.gov.uk/",
                      service_url:,
                      classes: "govuk-header--#{@mode}")

--- a/app/controllers/forms/submit_answers_controller.rb
+++ b/app/controllers/forms/submit_answers_controller.rb
@@ -8,7 +8,7 @@ module Forms
           EventLogger.log_form_event(current_context, request, "submission")
         end
 
-        FormSubmissionService.call(form: current_context,
+        FormSubmissionService.call(current_context:,
                                    reference: params[:notify_reference],
                                    preview_mode: mode.preview?).submit_form_to_processing_team
         redirect_to :form_submitted

--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -1,6 +1,5 @@
 class Context
-  attr_accessor :form
-  attr_reader :form_name, :support_details
+  attr_reader :form, :support_details
 
   def initialize(form:, store:)
     @form = form
@@ -9,7 +8,6 @@ class Context
     @journey = Journey.new(form_context: @form_context, step_factory: @step_factory)
 
     @completed_steps = @journey.completed_steps
-    @form_name = form.name
     @support_details = OpenStruct.new({
       email: form.support_email,
       phone: form.support_phone,

--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -1,6 +1,6 @@
 class Context
   attr_accessor :form
-  attr_reader :form_name, :form_start_page, :support_details
+  attr_reader :form_name, :support_details
 
   def initialize(form:, store:)
     @form = form
@@ -10,7 +10,6 @@ class Context
 
     @completed_steps = @journey.completed_steps
     @form_name = form.name
-    @form_start_page = form.start_page
     @support_details = OpenStruct.new({
       email: form.support_email,
       phone: form.support_phone,

--- a/app/lib/event_logger.rb
+++ b/app/lib/event_logger.rb
@@ -7,7 +7,7 @@ class EventLogger
     item_to_log = {
       url: request&.url,
       method: request&.method,
-      form: context.form_name,
+      form: context.form.name,
     }
 
     log("form_#{event}", item_to_log)
@@ -17,7 +17,7 @@ class EventLogger
     item_to_log = {
       url: request&.url,
       method: request&.method,
-      form: context.form_name,
+      form: context.form.name,
       question_text: page.question.question_text,
       question_number: page.page_number,
     }

--- a/app/services/log_event_service.rb
+++ b/app/services/log_event_service.rb
@@ -30,6 +30,6 @@ private
   end
 
   def is_starting_form
-    @current_context.form_start_page == @step.id
+    @current_context.form.start_page == @step.id
   end
 end

--- a/app/views/errors/repeat_submission.html.erb
+++ b/app/views/errors/repeat_submission.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(form_title(form_name: @current_context.form_name, page_name: t('repeat_submission.title'), mode: @mode)) %>
+<% set_page_title(form_title(form_name: @current_context.form.name, page_name: t('repeat_submission.title'), mode: @mode)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(form_title(form_name: @current_context.form_name, page_name: t('form.check_your_answers.title'), mode: @mode)) %>
+<% set_page_title(form_title(form_name: @current_context.form.name, page_name: t('form.check_your_answers.title'), mode: @mode)) %>
 
 <% content_for :before_content do %>
   <% if @back_link %>

--- a/app/views/forms/page/show.html.erb
+++ b/app/views/forms/page/show.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(form_title(form_name: @current_context.form_name, page_name: @step.question_text, mode: @mode, error: @step.question&.errors&.any?)) %>
+<% set_page_title(form_title(form_name: @current_context.form.name, page_name: @step.question_text, mode: @mode, error: @step.question&.errors&.any?)) %>
 
 <% content_for :before_content do %>
   <% if @back_link.present? %>

--- a/app/views/forms/privacy_page/show.html.erb
+++ b/app/views/forms/privacy_page/show.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(form_title(form_name: @current_context.form_name, page_name: 'Privacy', mode: @mode)) %>
+<% set_page_title(form_title(form_name: @current_context.form.name, page_name: 'Privacy', mode: @mode)) %>
 
 <% content_for :before_content do %>
   <% if @back_link.present? %>

--- a/app/views/forms/submitted/submitted.html.erb
+++ b/app/views/forms/submitted/submitted.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title form_title(form_name: @current_context.form_name, page_name: t('form.submitted.title'), mode: @mode) %>
+<% set_page_title form_title(form_name: @current_context.form.name, page_name: t('form.submitted.title'), mode: @mode) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/components/form_header_component/view_spec.rb
+++ b/spec/components/form_header_component/view_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe FormHeaderComponent::View, type: :component do
   let(:mode) { Mode.new }
-  let(:current_context) { OpenStruct.new(form: 1, form_name: "test_form_name", form_slug: "test") }
+  let(:form) { OpenStruct.new(id: 1, name: "test_form_name", form_slug: "test") }
+  let(:current_context) { OpenStruct.new(form:) }
 
   it "has service name" do
     render_inline(described_class.new(current_context:, mode:, service_url_overide: "/form/1/test"))

--- a/spec/requests/forms/submit_answers_controller_spec.rb
+++ b/spec/requests/forms/submit_answers_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Forms::SubmitAnswersController, type: :request do
     allow(EventLogger).to receive(:log).at_least(:once)
     current_context = instance_double(Context)
     allow(current_context).to receive(:form_submitted?).and_return(repeat_form_submission)
-    allow(current_context).to receive(:form_name).and_return("Form name")
+    allow(current_context).to receive(:form).and_return(JSON.parse(form_response_data, object_class: OpenStruct))
     allow(Context).to receive(:new).and_return(current_context)
     allow(FormSubmissionService).to receive(:call).and_return(OpenStruct.new(submit_form_to_processing_team: true))
   end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe FormSubmissionService do
-  let(:service) { described_class.call(form:, reference: "for-my-ref", preview_mode:) }
-  let(:form) { OpenStruct.new(form_name: "Form 1", submission_email: "testing@gov.uk", steps: [step]) }
+  let(:service) { described_class.call(current_context:, reference: "for-my-ref", preview_mode:) }
+  let(:form) { OpenStruct.new(id: 1, name: "Form 1", submission_email: "testing@gov.uk") }
+  let(:current_context) { OpenStruct.new(form:, steps: [step]) }
   let(:step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer_in_email: "42" }) }
   let(:preview_mode) { false }
 
@@ -33,8 +34,8 @@ RSpec.describe FormSubmissionService do
         end
       end
 
-      context "when from has no steps (i.e questions/answers)" do
-        let(:form) { OpenStruct.new(id: 1, form_name: "Form 1", submission_email: "example@example.gov.uk", steps: []) }
+      context "when current context has no completed steps (i.e questions/answers)" do
+        let(:current_context) { OpenStruct.new(form:, steps: []) }
         let(:result) { service.submit_form_to_processing_team }
 
         it "raises an error" do
@@ -81,7 +82,7 @@ RSpec.describe FormSubmissionService do
         end
 
         context "when from has no steps (i.e questions/answers)" do
-          let(:form) { OpenStruct.new(id: 1, form_name: "Form 1", submission_email: "example@example.gov.uk", steps: []) }
+          let(:current_context) { OpenStruct.new(form:, steps: []) }
           let(:result) { service.submit_form_to_processing_team }
 
           it "raises an error" do


### PR DESCRIPTION
#### What problem does the pull request solve?

See individual commit messages:

- Use forms name rather than context.form_name
- Use forms start_page rather then context.form_start_page
- refactor form submission service (mostly renaming vars to help clarify what is being passed in and what a dev can expect

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
