### PR TITLE
Remove submission_email from Context

### DIFF
--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -57,8 +57,4 @@ class Context
   def form_submitted?
     @form_context.form_submitted?(form.id)
   end
-
-  def submission_email
-    @step_factory.submission_email
-  end
 end

--- a/app/lib/step_factory.rb
+++ b/app/lib/step_factory.rb
@@ -8,13 +8,12 @@ class StepFactory
     end
   end
 
-  attr_accessor :submission_email, :form_id
+  attr_accessor :form_id
 
   def initialize(form:)
     @form = form
     @pages = form.pages
 
-    @submission_email = form.submission_email
     @form_id = form.id
     @form_slug = form.form_slug
   end


### PR DESCRIPTION
#### What problem does the pull request solve?

Step Factory doesn't need that form submission email and context has a copy of the form data stored in  `form`. So there no real reason to use the submission_email method in context to get this info

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
