### PR TITLE
Rename context steps method to complete_steps

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -27,11 +27,11 @@ module Forms
     end
 
     def check_your_answers_rows
-      current_context.steps.map { |page| page_to_row(page) }
+      current_context.completed_steps.map { |page| page_to_row(page) }
     end
 
     def answers_need_full_width
-      @full_width = current_context.steps.any? { |step| step.question.has_long_answer? }
+      @full_width = current_context.completed_steps.any? { |step| step.question.has_long_answer? }
     end
   end
 end

--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -7,7 +7,6 @@ class Context
     @step_factory = StepFactory.new(form:)
     @journey = Journey.new(form_context: @form_context, step_factory: @step_factory)
 
-    @completed_steps = @journey.completed_steps
     @support_details = OpenStruct.new({
       email: form.support_email,
       phone: form.support_phone,
@@ -17,7 +16,7 @@ class Context
   end
 
   def find_or_create(page_slug)
-    step = @completed_steps.find { |s| s.page_slug == page_slug }
+    step = completed_steps.find { |s| s.page_slug == page_slug }
     step || @step_factory.create_step(page_slug)
   end
 
@@ -28,26 +27,26 @@ class Context
   end
 
   def previous_step(page_slug)
-    index = @completed_steps.find_index { |step| step.page_slug == page_slug }
-    return nil if @completed_steps.empty? || index&.zero?
+    index = completed_steps.find_index { |step| step.page_slug == page_slug }
+    return nil if completed_steps.empty? || index&.zero?
 
-    return @completed_steps.last.page_id if index.nil?
+    return completed_steps.last.page_id if index.nil?
 
-    @completed_steps[index - 1].page_id
+    completed_steps[index - 1].page_id
   end
 
   def next_page_slug
-    return nil if @completed_steps.last&.end_page?
+    return nil if completed_steps.last&.end_page?
 
-    @completed_steps.last&.next_page_slug || @step_factory.start_step.page_slug
+    completed_steps.last&.next_page_slug || @step_factory.start_step.page_slug
   end
 
   def can_visit?(page_slug)
-    (@completed_steps.map(&:page_slug).include? page_slug) || page_slug == next_page_slug
+    (completed_steps.map(&:page_slug).include? page_slug) || page_slug == next_page_slug
   end
 
-  def steps
-    @completed_steps
+  def completed_steps
+    @journey.completed_steps
   end
 
   def clear

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -13,7 +13,7 @@ class FormSubmissionService
   end
 
   def submit_form_to_processing_team
-    raise StandardError, "Form id(#{@form.id}) has no steps i.e questions/answers to include in submission email" if @current_context.steps.blank?
+    raise StandardError, "Form id(#{@form.id}) has no completed steps i.e questions/answers to include in submission email" if @current_context.completed_steps.blank?
 
     if !@preview_mode && @form.submission_email.blank?
       raise StandardError, "Form id(#{@form.id}) is missing a submission email address"
@@ -33,7 +33,7 @@ class FormSubmissionService
 
   class NotifyTemplateBodyFilter
     def build_question_answers_section(current_context)
-      current_context.steps.map { |page|
+      current_context.completed_steps.map { |page|
         [prep_question_title(page.question_text),
          prep_answer_text(page.show_answer_in_email)].join
       }.join("\n\n---\n\n").concat("\n")

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe FormSubmissionService do
   let(:service) { described_class.call(current_context:, reference: "for-my-ref", preview_mode:) }
   let(:form) { OpenStruct.new(id: 1, name: "Form 1", submission_email: "testing@gov.uk") }
-  let(:current_context) { OpenStruct.new(form:, steps: [step]) }
+  let(:current_context) { OpenStruct.new(form:, completed_steps: [step]) }
   let(:step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer_in_email: "42" }) }
   let(:preview_mode) { false }
 
@@ -39,7 +39,7 @@ RSpec.describe FormSubmissionService do
         let(:result) { service.submit_form_to_processing_team }
 
         it "raises an error" do
-          expect { result }.to raise_error("Form id(1) has no steps i.e questions/answers to include in submission email")
+          expect { result }.to raise_error("Form id(1) has no completed steps i.e questions/answers to include in submission email")
         end
       end
     end
@@ -86,7 +86,7 @@ RSpec.describe FormSubmissionService do
           let(:result) { service.submit_form_to_processing_team }
 
           it "raises an error" do
-            expect { result }.to raise_error("Form id(1) has no steps i.e questions/answers to include in submission email")
+            expect { result }.to raise_error("Form id(1) has no completed steps i.e questions/answers to include in submission email")
           end
         end
       end
@@ -97,7 +97,7 @@ RSpec.describe FormSubmissionService do
     let(:notify_template_body_filter) { FormSubmissionService::NotifyTemplateBodyFilter.new }
 
     describe "#build_question_answers_section" do
-      let(:form) { OpenStruct.new(steps: [step]) }
+      let(:form) { OpenStruct.new(completed_steps: [step]) }
 
       let(:step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer_in_email: "42" }) }
 
@@ -106,7 +106,7 @@ RSpec.describe FormSubmissionService do
       end
 
       context "when there is more than one step" do
-        let(:form) { OpenStruct.new(steps: [step, step]) }
+        let(:form) { OpenStruct.new(completed_steps: [step, step]) }
 
         it "contains a horizontal rule between each step" do
           expect(notify_template_body_filter.build_question_answers_section(form)).to include "\n\n---\n\n"


### PR DESCRIPTION
#### What problem does the pull request solve?
Its confusing to read `current_context.steps` and not realise that steps is actually the Question/answers that a user has completed and not all questions for a form.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
