### PR TITLE
562 runner changes to nextpage logic for simple routing

### DIFF
--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -7,7 +7,7 @@ module Forms
       EventLogger.log_form_event(Context.new(form: current_form, store: session), request, "visit") unless mode.preview?
     end
 
-    rescue_from ActiveResource::ResourceNotFound do
+    rescue_from ActiveResource::ResourceNotFound, StepFactory::PageNotFoundError do
       render template: "errors/not_found", status: :not_found
     end
 

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -56,6 +56,16 @@ module Forms
     def next_page
       if @changing_existing_answer
         check_your_answers_path(form_id: current_context.form.id, form_slug: current_context.form.form_slug)
+      elsif @step.routing_conditions.any?
+        calculate_page_routing
+      else
+        form_page_path(@step.form_id, @step.form_slug, @step.next_page_slug)
+      end
+    end
+
+    def calculate_page_routing
+      if @step.question.show_answer == @step.routing_conditions.first.answer_value
+        form_page_path(@step.form_id, @step.form_slug, @step.goto_page_slug)
       else
         form_page_path(@step.form_id, @step.form_slug, @step.next_page_slug)
       end

--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -38,7 +38,7 @@ class Context
   def next_page_slug
     return nil if completed_steps.last&.end_page?
 
-    completed_steps.last&.next_page_slug || @step_factory.start_step.page_slug
+    completed_steps.last&.next_page_slug_after_routing || @step_factory.start_step.page_slug
   end
 
   def can_visit?(page_slug)

--- a/app/lib/journey.rb
+++ b/app/lib/journey.rb
@@ -25,7 +25,7 @@ private
 
     while current_step
       @completed_steps << current_step
-      next_page_slug = current_step.next_page_slug
+      next_page_slug = current_step.next_page_slug_after_routing
 
       break if next_page_slug.nil?
 

--- a/app/lib/step_factory.rb
+++ b/app/lib/step_factory.rb
@@ -24,9 +24,10 @@ class StepFactory
     raise PageNotFoundError, "Can't find page #{page_slug}" if page.nil?
 
     next_page_slug = page.has_next_page? ? page.next_page.to_s : CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG
+    goto_page_slug = page.routing_conditions.empty? ? nil : page.routing_conditions.first.goto_page_id.to_s
     question = QuestionRegister.from_page(page)
 
-    Step.new(question:, page_id: page.id, form_id: @form.id, form_slug: @form.form_slug, next_page_slug:, page_slug:, page_number: page.number(@form))
+    Step.new(question:, page_id: page.id, form_id: @form.id, form_slug: @form.form_slug, next_page_slug:, page_slug:, page_number: page.number(@form), routing_conditions: page.routing_conditions, goto_page_slug:)
   end
 
   def start_step

--- a/app/lib/step_factory.rb
+++ b/app/lib/step_factory.rb
@@ -24,10 +24,9 @@ class StepFactory
     raise PageNotFoundError, "Can't find page #{page_slug}" if page.nil?
 
     next_page_slug = page.has_next_page? ? page.next_page.to_s : CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG
-    goto_page_slug = page.routing_conditions.empty? ? nil : page.routing_conditions.first.goto_page_id.to_s
     question = QuestionRegister.from_page(page)
 
-    Step.new(question:, page_id: page.id, form_id: @form.id, form_slug: @form.form_slug, next_page_slug:, page_slug:, page_number: page.number(@form), routing_conditions: page.routing_conditions, goto_page_slug:)
+    Step.new(question:, page_id: page.id, form_id: @form.id, form_slug: @form.form_slug, next_page_slug:, page_slug:, page_number: page.number(@form), routing_conditions: page.routing_conditions)
   end
 
   def start_step

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -75,4 +75,12 @@ class Step
   def end_page?
     next_page_slug.nil?
   end
+
+  def next_page_slug_after_routing
+    if routing_conditions.any? && routing_conditions.first.answer_value == @question.selection
+      goto_page_slug
+    else
+      next_page_slug
+    end
+  end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,8 +1,8 @@
 class Step
   attr_accessor :page_id, :form_id, :form_slug, :question
-  attr_reader :next_page_slug, :page_slug, :page_number
+  attr_reader :next_page_slug, :page_slug, :page_number, :routing_conditions, :goto_page_slug
 
-  def initialize(question:, page_id:, form_id:, form_slug:, next_page_slug:, page_slug:, page_number:)
+  def initialize(question:, page_id:, form_id:, form_slug:, next_page_slug:, page_slug:, page_number:, routing_conditions:, goto_page_slug:)
     @question = question
     @page_id = page_id
     @page_slug = page_slug
@@ -10,6 +10,8 @@ class Step
     @form_slug = form_slug
     @next_page_slug = next_page_slug
     @page_number = page_number
+    @routing_conditions = routing_conditions
+    @goto_page_slug = goto_page_slug
   end
 
   alias_attribute :id, :page_id

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,8 +1,8 @@
 class Step
   attr_accessor :page_id, :form_id, :form_slug, :question
-  attr_reader :next_page_slug, :page_slug, :page_number, :routing_conditions, :goto_page_slug
+  attr_reader :next_page_slug, :page_slug, :page_number, :routing_conditions
 
-  def initialize(question:, page_id:, form_id:, form_slug:, next_page_slug:, page_slug:, page_number:, routing_conditions:, goto_page_slug:)
+  def initialize(question:, page_id:, form_id:, form_slug:, next_page_slug:, page_slug:, page_number:, routing_conditions:)
     @question = question
     @page_id = page_id
     @page_slug = page_slug
@@ -11,7 +11,6 @@ class Step
     @next_page_slug = next_page_slug
     @page_number = page_number
     @routing_conditions = routing_conditions
-    @goto_page_slug = goto_page_slug
   end
 
   alias_attribute :id, :page_id
@@ -82,5 +81,12 @@ class Step
     else
       next_page_slug
     end
+  end
+
+  def goto_page_slug
+    return nil if routing_conditions.empty?
+
+    condition = routing_conditions.first
+    condition.goto_page_id.to_s
   end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -87,6 +87,6 @@ class Step
     return nil if routing_conditions.empty?
 
     condition = routing_conditions.first
-    condition.goto_page_id.to_s
+    condition.goto_page_id.nil? && condition.skip_to_end ? CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG : condition.goto_page_id.to_s
   end
 end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
     trait :with_selections_settings do
       transient do
         only_one_option { "true" }
-        selection_options { [Forms::SelectionOption.new({ name: "Option 1" }), Forms::SelectionOption.new({ name: "Option 2" })] }
+        selection_options { [{ "name": "Option 1" }.as_json, { "name": "Option 2" }.as_json] }
       end
 
       answer_type { "selection" }

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
 
     trait :with_text_settings do
       transient do
-        input_type { Forms::TextSettingsForm::INPUT_TYPES.sample }
+        input_type { %w[single_line long_text].sample }
       end
 
       answer_type { "text" }
@@ -48,7 +48,7 @@ FactoryBot.define do
 
     trait :with_date_settings do
       transient do
-        input_type { Forms::DateSettingsForm::INPUT_TYPES.sample }
+        input_type { %w[date_of_birth other_date].sample }
       end
 
       answer_type { "date" }

--- a/spec/lib/context_spec.rb
+++ b/spec/lib/context_spec.rb
@@ -8,47 +8,24 @@ RSpec.describe Context do
 
   let(:pages) do
     [
-      Page.new({
-        id: 1,
-        question_text: "Question one",
-        answer_type: "text",
-        answer_settings: { input_type: "single_line" },
-        hint_text: "q1 hint",
-        next_page: 2,
-        form: nil,
-        is_optional: nil,
-      }),
-      Page.new({
-        id: 2,
-        question_text: "Question two",
-        hint_text: "Q2 hint text",
-        answer_type: "text",
-        answer_settings: { input_type: "single_line" },
-        question_short_name: nil,
-        form: nil,
-        is_optional: nil,
-      }),
+      (build :page, :with_text_settings,
+             id: 1,
+             next_page: 2
+      ),
+      (build :page, :with_text_settings,
+             id: 2
+      ),
     ]
   end
 
   let(:form) do
-    f = Form.new({
-      id: 1,
-      name: "Form",
-      form_slug: "form",
-      submission_email: "jimbo@example.gov.uk",
-      start_page: "1",
-      privacy_policy_url: "http://www.example.gov.uk",
-      what_happens_next_text: "Good things come to those that wait",
-      declaration_text: "agree to the declaration",
-      support_email: "help@example.gov.uk",
-      support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
-      support_url: "https://example.gov.uk/contact",
-      support_url_text: "Contact us",
-      pages:,
-    })
-    f.pages.each { |p| p.form = f }
-    f
+    build(:form, :with_support,
+          id: 2,
+          start_page: 1,
+          privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+          what_happens_next_text: "Good things come to those that wait",
+          declaration_text: "agree to the declaration",
+          pages:)
   end
 
   [
@@ -101,21 +78,6 @@ RSpec.describe Context do
   end
 
   context "with a page which changes question type mid-journey" do
-    let(:pages) do
-      [
-        Page.new({
-          id: 1,
-          question_text: "A single line of text question",
-          answer_type: "text",
-          answer_settings: { input_type: "single_line" },
-          hint_text: nil,
-          next_page: nil,
-          form: nil,
-          is_optional: nil,
-        }),
-      ]
-    end
-
     it "does not throw an error if the question type changes when an answer has already been submitted" do
       store = {}
 

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -3,33 +3,13 @@ require_relative "../../app/lib/event_logger"
 
 RSpec.describe EventLogger do
   let(:page) do
-    Page.new({
-      id: 1,
-      question_text: "Question one",
-      answer_type: "text",
-      answer_settings: { input_type: "single_line" },
-      next_page: 2,
-      is_optional: false,
-    })
+    build :page, :with_text_settings, id: 1, form_id: 2, routing_conditions: []
   end
 
+  let(:form) { build :form, :with_support, id: 1, pages: [page], start_page: page.id }
   let(:context) do
     Context.new(
-      form: Form.new({
-        id: 1,
-        name: "Form 1",
-        form_slug: "form-1",
-        submission_email: "jimbo@example.gov.uk",
-        start_page: "1",
-        privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-        what_happens_next_text: "Good things come to those that wait",
-        declaration_text: "agree to the declaration",
-        support_email: "help@example.gov.uk",
-        support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
-        support_url: "https://example.gov.uk/contact",
-        support_url_text: "Contact us",
-        pages: [page],
-      }),
+      form:,
       store: {},
     )
   end
@@ -42,7 +22,7 @@ RSpec.describe EventLogger do
     {
       url: "http://example.gov.uk",
       method: "GET",
-      form: "Form 1",
+      form: form.name,
     }
   end
 
@@ -50,9 +30,9 @@ RSpec.describe EventLogger do
     {
       url: "http://example.gov.uk",
       method: "GET",
-      form: "Form 1",
-      question_number: 1,
-      question_text: "Question one",
+      form: form.name,
+      question_number: page.id,
+      question_text: page.question_text,
     }
   end
 
@@ -83,24 +63,13 @@ RSpec.describe EventLogger do
   end
 
   context "when skipping an optional question" do
-    let(:page) do
-      Page.new({
-        id: 1,
-        question_text: "Question one",
-        answer_type: "text",
-        answer_settings: { input_type: "single_line" },
-        next_page: 2,
-        is_optional: true,
-      })
-    end
-
     let(:page_log_item) do
       {
         url: "http://example.gov.uk",
         method: "GET",
-        form: "Form 1",
-        question_number: 1,
-        question_text: "Question one",
+        form: form.name,
+        question_number: page.id,
+        question_text: page.question_text,
         skipped_question: "true",
       }
     end

--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -2,24 +2,19 @@ require "rails_helper"
 
 RSpec.describe Forms::BaseController, type: :request do
   let(:timestamp_of_request) { Time.utc(2022, 12, 14, 10, 0o0, 0o0) }
+
   let(:form_response_data) do
-    {
-      id: 2,
-      name: "Form name",
-      form_slug: "form-name",
-      submission_email: "submission@email.com",
-      start_page: "1",
-      live_at: "2022-08-18 09:16:50 +0100",
-      privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-      what_happens_next_text: "Good things come to those that wait",
-      declaration_text: "agree to the declaration",
-      support_email: "help@example.gov.uk",
-      support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
-      support_url: "https://example.gov.uk/contact",
-      support_url_text: "Contact us",
-      pages: pages_data,
-    }.to_json
+    build(:form, :with_support,
+          id: 2,
+          live_at:,
+          start_page:,
+          privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+          what_happens_next_text: "Good things come to those that wait",
+          declaration_text: "agree to the declaration",
+          pages: pages_data)
   end
+  let(:start_page) { 1 }
+  let(:live_at) { "2022-08-18 09:16:50 +0100" }
 
   let(:no_data_found_response) do
     {
@@ -29,19 +24,17 @@ RSpec.describe Forms::BaseController, type: :request do
 
   let(:pages_data) do
     [
-      {
-        id: 1,
-        question_text: "Question one",
-        answer_type: "date",
-        next_page: 2,
-        is_optional: nil,
-      },
-      {
-        id: 2,
-        question_text: "Question two",
-        answer_type: "date",
-        is_optional: nil,
-      },
+      (build :page,
+             id: 1,
+             next_page: 2,
+             answer_type: "text",
+             answer_settings: { input_type: "single_line" }
+      ),
+      (build :page,
+             id: 2,
+             answer_type: "text",
+             answer_settings: { input_type: "single_line" }
+      ),
     ]
   end
 
@@ -57,45 +50,29 @@ RSpec.describe Forms::BaseController, type: :request do
   before do
     ActiveResource::HttpMock.respond_to do |mock|
       allow(EventLogger).to receive(:log).at_least(:once)
-      mock.get "/api/v1/forms/2#{api_url_suffix}", req_headers, form_response_data, 200
+      mock.get "/api/v1/forms/2#{api_url_suffix}", req_headers, form_response_data.to_json, 200
       mock.get "/api/v1/forms/9999#{api_url_suffix}", req_headers, no_data_found_response, 404
     end
   end
 
   describe "#redirect_to_user_friendly_url" do
+    before do
+      get form_id_path(mode: "form", form_id: 2)
+    end
+
     context "when the form exists and has a start page" do
-      before do
-        get form_id_path(mode: "form", form_id: 2)
-      end
+      let(:start_page) { 1 }
 
       it "redirects to the friendly URL start page" do
-        expect(response).to redirect_to(form_page_path("form", 2, "form-name", 1))
+        expect(response).to redirect_to(form_page_path("form", 2, form_response_data.form_slug, 1))
       end
     end
 
     context "when the form exists and has no start page" do
-      let(:form_response_data) do
-        {
-          id: 2,
-          name: "Form name",
-          form_slug: "form-name",
-          submission_email: "submission@email.com",
-          live_at: "2022-08-18 09:16:50 +0100",
-          start_page: nil,
-          privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-          support_email: "help@example.gov.uk",
-          support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
-          support_url: "https://example.gov.uk/contact",
-          support_url_text: "Contact us",
-        }.to_json
-      end
+      let(:start_page) { nil }
 
-      before do
-        get form_id_path(mode: "form", form_id: 2)
-      end
-
-      it "Redirects to the form page that includes the form slug" do
-        expect(response.status).to eq(404)
+      it "Returns a 404" do
+        expect(response).to have_http_status(:not_found)
       end
     end
   end
@@ -104,14 +81,14 @@ RSpec.describe Forms::BaseController, type: :request do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
         allow(EventLogger).to receive(:log).at_least(:once)
-        mock.get "/api/v1/forms/2/live", req_headers, form_response_data, 200
+        mock.get "/api/v1/forms/2/live", req_headers, form_response_data.to_json, 200
       end
 
-      get error_repeat_submission_path(mode: "form", form_id: 2, form_slug: "form-name")
+      get error_repeat_submission_path(mode: "form", form_id: 2, form_slug: form_response_data.form_slug)
     end
 
     it "renders the page with a link back to the form start page" do
-      expect(response.body).to include(form_page_path("form", 2, "form-name", 1))
+      expect(response.body).to include(form_page_path("form", 2, form_response_data.form_slug, 1))
     end
   end
 
@@ -123,13 +100,13 @@ RSpec.describe Forms::BaseController, type: :request do
         context "when a form exists" do
           before do
             travel_to timestamp_of_request do
-              get form_path(mode: "preview-draft", form_id: 2, form_slug: "form-name")
+              get form_path(mode: "preview-draft", form_id: 2, form_slug: form_response_data.form_slug)
             end
           end
 
           context "when the form has a start page" do
             it "Redirects to the first page" do
-              expect(response).to redirect_to(form_page_path("preview-draft", 2, "form-name", 1))
+              expect(response).to redirect_to(form_page_path("preview-draft", 2, form_response_data.form_slug, 1))
             end
 
             it "does not log the form_visit event" do
@@ -138,20 +115,10 @@ RSpec.describe Forms::BaseController, type: :request do
           end
 
           context "when the form has no start page" do
-            let(:form_response_data) do
-              {
-                id: 2,
-                name: "Form name",
-                form_slug: "form-name",
-                submission_email: "submission@email.com",
-                start_page: nil,
-                live_at: nil,
-                privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-              }.to_json
-            end
+            let(:start_page) { nil }
 
             it "returns 404" do
-              expect(response.status).to eq(404)
+              expect(response).to have_http_status(:not_found)
             end
           end
 
@@ -182,27 +149,12 @@ RSpec.describe Forms::BaseController, type: :request do
           end
 
           it "returns 404" do
-            expect(response.status).to eq(404)
+            expect(response).to have_http_status(:not_found)
           end
         end
 
         context "when the form has no start page" do
-          let(:form_response_data) do
-            {
-              id: 2,
-              name: "Form name",
-              form_slug: "form-name",
-              submission_email: "submission@email.com",
-              start_page: nil,
-              privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-              what_happens_next_text: "Good things come to those that wait",
-              declaration_text: "agree to the declaration",
-              support_email: "help@example.gov.uk",
-              support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
-              support_url: "https://example.gov.uk/contact",
-              support_url_text: "Contact us",
-            }.to_json
-          end
+          let(:start_page) { nil }
 
           before do
             get form_path(mode: "preview-draft", form_id: 9999, form_slug: "form-name")
@@ -213,7 +165,7 @@ RSpec.describe Forms::BaseController, type: :request do
           end
 
           it "returns 404" do
-            expect(response.status).to eq(404)
+            expect(response).to have_http_status(:not_found)
           end
         end
       end
@@ -224,13 +176,13 @@ RSpec.describe Forms::BaseController, type: :request do
         context "when a form exists" do
           before do
             travel_to timestamp_of_request do
-              get form_path(mode: "preview-live", form_id: 2, form_slug: "form-name")
+              get form_path(mode: "preview-live", form_id: 2, form_slug: form_response_data.form_slug)
             end
           end
 
           context "when the form has a start page" do
             it "Redirects to the first page" do
-              expect(response).to redirect_to(form_page_path("preview-live", 2, "form-name", 1))
+              expect(response).to redirect_to(form_page_path("preview-live", 2, form_response_data.form_slug, 1))
             end
 
             it "does not log the form_visit event" do
@@ -239,20 +191,10 @@ RSpec.describe Forms::BaseController, type: :request do
           end
 
           context "when the form has no start page" do
-            let(:form_response_data) do
-              {
-                id: 2,
-                name: "Form name",
-                form_slug: "form-name",
-                submission_email: "submission@email.com",
-                start_page: nil,
-                live_at: nil,
-                privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-              }.to_json
-            end
+            let(:start_page) { nil }
 
             it "returns 404" do
-              expect(response.status).to eq(404)
+              expect(response).to have_http_status(:not_found)
             end
           end
 
@@ -262,12 +204,12 @@ RSpec.describe Forms::BaseController, type: :request do
 
           describe "Privacy page" do
             it "returns http code 200" do
-              get form_privacy_path(mode: "preview-live", form_id: 2, form_slug: "form-name")
+              get form_privacy_path(mode: "preview-live", form_id: 2, form_slug: form_response_data.form_slug)
               expect(response).to have_http_status(:ok)
             end
 
             it "contains link to data controller's privacy policy" do
-              get form_privacy_path(mode: "preview-live", form_id: 2, form_slug: "form-name")
+              get form_privacy_path(mode: "preview-live", form_id: 2, form_slug: form_response_data.form_slug)
               expect(response.body).to include("http://www.example.gov.uk/privacy_policy")
             end
           end
@@ -283,27 +225,12 @@ RSpec.describe Forms::BaseController, type: :request do
           end
 
           it "returns 404" do
-            expect(response.status).to eq(404)
+            expect(response).to have_http_status(:not_found)
           end
         end
 
         context "when the form has no start page" do
-          let(:form_response_data) do
-            {
-              id: 2,
-              name: "Form name",
-              form_slug: "form-name",
-              submission_email: "submission@email.com",
-              start_page: nil,
-              privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-              what_happens_next_text: "Good things come to those that wait",
-              declaration_text: "agree to the declaration",
-              support_email: "help@example.gov.uk",
-              support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
-              support_url: "https://example.gov.uk/contact",
-              support_url_text: "Contact us",
-            }.to_json
-          end
+          let(:start_page) { nil }
 
           before do
             get form_path(mode: "preview-live", form_id: 9999, form_slug: "form-name")
@@ -314,7 +241,7 @@ RSpec.describe Forms::BaseController, type: :request do
           end
 
           it "returns 404" do
-            expect(response.status).to eq(404)
+            expect(response).to have_http_status(:not_found)
           end
         end
       end
@@ -325,39 +252,25 @@ RSpec.describe Forms::BaseController, type: :request do
         context "when a form exists" do
           before do
             travel_to timestamp_of_request do
-              get form_path(mode: "form", form_id: 2, form_slug: "form-name")
+              get form_path(mode: "form", form_id: 2, form_slug: form_response_data.form_slug)
             end
           end
 
           context "when the form has a start page" do
             it "Redirects to the first page" do
-              expect(response).to redirect_to(form_page_path("form", 2, "form-name", 1))
+              expect(response).to redirect_to(form_page_path("form", 2, form_response_data.form_slug, 1))
             end
 
             it "Logs the form_visit event" do
-              expect(EventLogger).to have_received(:log).with("form_visit", { form: "Form name", method: "GET", url: "http://www.example.com/form/2/form-name" })
+              expect(EventLogger).to have_received(:log).with("form_visit", { form: form_response_data.name, method: "GET", url: "http://www.example.com/form/2/#{form_response_data.form_slug}" })
             end
           end
 
           context "when the form has no start page" do
-            let(:form_response_data) do
-              {
-                id: 2,
-                name: "Form name",
-                form_slug: "form-name",
-                submission_email: "submission@email.com",
-                start_page: nil,
-                live_at: "2022-08-18 09:16:50 +0100",
-                privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-                support_email: "help@example.gov.uk",
-                support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
-                support_url: "https://example.gov.uk/contact",
-                support_url_text: "Contact us",
-              }.to_json
-            end
+            let(:start_page) { nil }
 
             it "returns 404" do
-              expect(response.status).to eq(404)
+              expect(response).to have_http_status(:not_found)
             end
           end
 
@@ -372,7 +285,7 @@ RSpec.describe Forms::BaseController, type: :request do
           end
 
           it "returns 404" do
-            expect(response.status).to eq(404)
+            expect(response).to have_http_status(:not_found)
           end
 
           it "Render the not found page" do

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -16,23 +16,26 @@ RSpec.describe Forms::PageController, type: :request do
   end
   let(:live_at) { "2022-08-18 09:16:50 +0100" }
 
-  let(:pages_data) do
-    [
-      (build :page,
-             id: 1,
-             next_page: 2,
-             answer_type: "text",
-             answer_settings: { input_type: "single_line" },
-             is_optional: false
-      ),
-      (build :page,
-             id: 2,
-             answer_type: "text",
-             answer_settings: { input_type: "single_line" },
-             is_optional:
-      ),
-    ]
+  let(:page_1) do
+    build :page, :with_text_settings,
+          id: 1,
+          next_page: 2,
+          is_optional: false
   end
+
+  let(:page_2) do
+    build :page, :with_text_settings,
+          id: 2,
+          is_optional:
+  end
+
+  let(:page_3) do
+    build :page, :with_text_settings,
+          id: 3,
+          is_optional:
+  end
+
+  let(:pages_data) { [page_1, page_2] }
 
   let(:is_optional) { false }
 

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -3,47 +3,38 @@ require "rails_helper"
 # rubocop:disable RSpec/AnyInstance
 RSpec.describe Forms::PageController, type: :request do
   let(:timestamp_of_request) { Time.utc(2022, 12, 14, 10, 0o0, 0o0) }
+
   let(:form_data) do
-    {
-      id: 2,
-      name: "Form 1",
-      form_slug: "form-1",
-      submission_email: "submission@email.com",
-      start_page: 1,
-      live_at: "2022-08-18 09:16:50 +0100",
-      privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-      what_happens_next_text: "Good things come to those that wait",
-      declaration_text: "agree to the declaration",
-      support_email: "help@example.gov.uk",
-      support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
-      support_url: "https://example.gov.uk/contact",
-      support_url_text: "Contact us",
-      pages: pages_data,
-    }.to_json
+    build(:form, :with_support,
+          id: 2,
+          live_at:,
+          start_page: 1,
+          privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+          what_happens_next_text: "Good things come to those that wait",
+          declaration_text: "agree to the declaration",
+          pages: pages_data)
   end
+  let(:live_at) { "2022-08-18 09:16:50 +0100" }
 
   let(:pages_data) do
     [
-      {
-        id: 1,
-        question_text: "Question one",
-        answer_type: "text",
-        answer_settings: { input_type: "single_line" },
-        hint_text: "",
-        next_page: 2,
-        is_optional: nil,
-      },
-      {
-        id: 2,
-        question_text: "Question two",
-        hint_text: "Q2 hint text",
-        answer_type: "text",
-        answer_settings: { input_type: "single_line" },
-        question_short_name: nil,
-        is_optional: nil,
-      },
+      (build :page,
+             id: 1,
+             next_page: 2,
+             answer_type: "text",
+             answer_settings: { input_type: "single_line" },
+             is_optional: false
+      ),
+      (build :page,
+             id: 2,
+             answer_type: "text",
+             answer_settings: { input_type: "single_line" },
+             is_optional:
+      ),
     ]
   end
+
+  let(:is_optional) { false }
 
   let(:req_headers) do
     {
@@ -56,7 +47,7 @@ RSpec.describe Forms::PageController, type: :request do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2#{api_url_suffix}", req_headers, form_data, 200
+      mock.get "/api/v1/forms/2#{api_url_suffix}", req_headers, form_data.to_json, 200
     end
   end
 
@@ -65,32 +56,32 @@ RSpec.describe Forms::PageController, type: :request do
       let(:api_url_suffix) { "/draft" }
 
       it "Returns a 200" do
-        get form_page_path("preview-draft", 2, "form-1", 1)
+        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
         expect(response.status).to eq(200)
       end
 
       it "redirects to first page if second request before first complete" do
-        get form_page_path("preview-draft", 2, "form-1", 2)
-        expect(response).to redirect_to(form_page_path(2, "form-1", 1))
+        get form_page_path("preview-draft", 2, form_data.form_slug, 2)
+        expect(response).to redirect_to(form_page_path(2, form_data.form_slug, 1))
       end
 
       it "Displays the question text on the page" do
-        get form_page_path("preview-draft", 2, "form-1", 1)
-        expect(response.body).to include("Question one")
+        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+        expect(response.body).to include(form_data.pages.first.question_text)
       end
 
       it "Displays the privacy policy link on the page" do
-        get form_page_path("preview-draft", 2, "form-1", 1)
+        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
         expect(response.body).to include("Privacy")
       end
 
       it "Displays the accessibility statement link on the page" do
-        get form_page_path("preview-draft", 2, "form-1", 1)
+        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
         expect(response.body).to include("Accessibility statement")
       end
 
       it "Displays the Cookies link on the page" do
-        get form_page_path("preview-draft", 2, "form-1", 1)
+        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
         expect(response.body).to include("Cookies")
       end
 
@@ -99,33 +90,33 @@ RSpec.describe Forms::PageController, type: :request do
           allow_any_instance_of(Context).to receive(:can_visit?)
                                               .and_return(true)
           allow_any_instance_of(Context).to receive(:previous_step).and_return(1)
-          get form_page_path("preview-draft", 2, "form-1", 2)
-          expect(response.body).to include(form_page_path(2, "form-1", 1))
+          get form_page_path("preview-draft", 2, form_data.form_slug, 2)
+          expect(response.body).to include(form_page_path(2, form_data.form_slug, 1))
         end
       end
 
       context "with a change answers page" do
         it "Displays a back link to the check your answers page" do
-          get form_change_answer_path("preview-draft", 2, "form-1", 1)
-          expect(response.body).to include(check_your_answers_path("preview-draft", 2, "form-1"))
+          get form_change_answer_path("preview-draft", 2, form_data.form_slug, 1)
+          expect(response.body).to include(check_your_answers_path("preview-draft", 2, form_data.form_slug))
         end
 
         it "Passes the changing answers parameter in its submit request" do
-          get form_change_answer_path("preview-draft", 2, "form-1", 1)
-          expect(response.body).to include(save_form_page_path("preview-draft", 2, "form-1", 1, changing_existing_answer: true))
+          get form_change_answer_path("preview-draft", 2, form_data.form_slug, 1)
+          expect(response.body).to include(save_form_page_path("preview-draft", 2, form_data.form_slug, 1, changing_existing_answer: true))
         end
       end
 
       it "Returns the correct X-Robots-Tag header" do
-        get form_page_path("preview-draft", 2, "form-1", 1)
+        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
         expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
       end
 
       context "with no questions answered" do
         it "redirects if a later page is requested" do
-          get check_your_answers_path("preview-draft", 2, "form-1")
+          get check_your_answers_path("preview-draft", 2, form_data.form_slug)
           expect(response.status).to eq(302)
-          expect(response.location).to eq(form_page_url("preview-draft", 2, "form-1", 1))
+          expect(response.location).to eq(form_page_url("preview-draft", 2, form_data.form_slug, 1))
         end
       end
     end
@@ -163,32 +154,32 @@ RSpec.describe Forms::PageController, type: :request do
       end
 
       it "Returns a 200" do
-        get form_page_path("form", 2, "form-1", 1)
+        get form_page_path("form", 2, form_data.form_slug, 1)
         expect(response.status).to eq(200)
       end
 
       it "redirects to first page if second request before first complete" do
-        get form_page_path("form", 2, "form-1", 2)
-        expect(response).to redirect_to(form_page_path(2, "form-1", 1))
+        get form_page_path("form", 2, form_data.form_slug, 2)
+        expect(response).to redirect_to(form_page_path(2, form_data.form_slug, 1))
       end
 
       it "Displays the question text on the page" do
-        get form_page_path("form", 2, "form-1", 1)
-        expect(response.body).to include("Question one")
+        get form_page_path("form", 2, form_data.form_slug, 1)
+        expect(response.body).to include(form_data.pages.first.question_text)
       end
 
       it "Displays the privacy policy link on the page" do
-        get form_page_path("form", 2, "form-1", 1)
+        get form_page_path("form", 2, form_data.form_slug, 1)
         expect(response.body).to include("Privacy")
       end
 
       it "Displays the accessibility statement link on the page" do
-        get form_page_path("form", 2, "form-1", 1)
+        get form_page_path("form", 2, form_data.form_slug, 1)
         expect(response.body).to include("Accessibility statement")
       end
 
       it "Displays the Cookies link on the page" do
-        get form_page_path("form", 2, "form-1", 1)
+        get form_page_path("form", 2, form_data.form_slug, 1)
         expect(response.body).to include("Cookies")
       end
 
@@ -197,52 +188,42 @@ RSpec.describe Forms::PageController, type: :request do
           allow_any_instance_of(Context).to receive(:can_visit?)
                                               .and_return(true)
           allow_any_instance_of(Context).to receive(:previous_step).and_return(1)
-          get form_page_path("form", 2, "form-1", 2)
-          expect(response.body).to include(form_page_path(2, "form-1", 1))
+          get form_page_path("form", 2, form_data.form_slug, 2)
+          expect(response.body).to include(form_page_path(2, form_data.form_slug, 1))
         end
       end
 
       context "with a change answers page" do
         it "Displays a back link to the check your answers page" do
-          get form_change_answer_path("form", 2, "form-1", 1)
-          expect(response.body).to include(check_your_answers_path("form", 2, "form-1"))
+          get form_change_answer_path("form", 2, form_data.form_slug, 1)
+          expect(response.body).to include(check_your_answers_path("form", 2, form_data.form_slug))
         end
 
         it "Passes the changing answers parameter in its submit request" do
-          get form_change_answer_path("form", 2, "form-1", 1)
-          expect(response.body).to include(save_form_page_path("form", 2, "form-1", 1, changing_existing_answer: true))
+          get form_change_answer_path("form", 2, form_data.form_slug, 1)
+          expect(response.body).to include(save_form_page_path("form", 2, form_data.form_slug, 1, changing_existing_answer: true))
         end
       end
 
       it "Returns the correct X-Robots-Tag header" do
-        get form_page_path("form", 2, "form-1", 1)
+        get form_page_path("form", 2, form_data.form_slug, 1)
         expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
       end
 
       context "with no questions answered" do
         it "redirects if a later page is requested" do
-          get check_your_answers_path("form", 2, "form-1")
+          get check_your_answers_path("form", 2, form_data.form_slug)
           expect(response.status).to eq(302)
-          expect(response.location).to eq(form_page_url("form", 2, "form-1", 1))
+          expect(response.location).to eq(form_page_url("form", 2, form_data.form_slug, 1))
         end
       end
 
       context "and a form has a live_at value in the future" do
-        let(:form_data) do
-          {
-            id: 2,
-            name: "Form name",
-            form_slug: "form-name",
-            submission_email: "submission@email.com",
-            live_at: "2023-01-01 09:00:00 +0100",
-            start_page: "1",
-            privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-          }.to_json
-        end
+        let(:live_at) { "2023-01-01 09:00:00 +0100" }
 
         it "returns 404" do
           travel_to timestamp_of_request do
-            get form_page_path("form", 2, "form-1", 1)
+            get form_page_path("form", 2, form_data.form_slug, 1)
           end
 
           expect(response.status).to eq(404)
@@ -256,66 +237,49 @@ RSpec.describe Forms::PageController, type: :request do
       let(:api_url_suffix) { "/draft" }
 
       it "Redirects to the next page" do
-        post save_form_page_path("preview-draft", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path("preview-draft", 2, "form-1", 2))
+        post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path("preview-draft", 2, form_data.form_slug, 2))
       end
 
       context "when changing an existing answer" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("preview-draft", 2, "form-1", 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
-          expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, "form-1"))
+          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, form_data.form_slug))
         end
 
         it "does not log the change_answer_page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-draft", 2, "form-1", 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
         end
       end
 
       context "with the first page" do
         it "Logs the first_page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-draft", 2, "form-1", 1), params: { question: { text: "answer text" } }
+          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "answer text" } }
         end
       end
 
       context "with a subsequent page" do
         it "Logs the page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-draft", 2, "form-1", 2), params: { question: { text: "answer text" } }
+          post save_form_page_path("preview-draft", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
         end
       end
 
       context "with the final page" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("preview-draft", 2, "form-1", 2), params: { question: { text: "answer text" } }
-          expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, "form-1"))
+          post save_form_page_path("preview-draft", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+          expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, form_data.form_slug))
         end
       end
 
       context "and a form has a live_at value in the future" do
-        let(:form_data) do
-          {
-            id: 2,
-            name: "Form name",
-            form_slug: "form-name",
-            submission_email: "submission@email.com",
-            live_at: "2023-01-01 09:00:00 +0100",
-            start_page: "1",
-            privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-            what_happens_next_text: "Good things come to those that wait",
-            declaration_text: "agree to the declaration",
-            support_email: "help@example.gov.uk",
-            support_phone: "Call 01610123456\n\nThis line is only open on Tuesdays.",
-            support_url: "https://example.gov.uk/contact",
-            support_url_text: "Contact us",
-            pages: pages_data,
-          }.to_json
-        end
+        let(:live_at) { "2023-01-01 09:00:00 +0100" }
 
         it "does not return 404" do
           travel_to timestamp_of_request do
-            post save_form_page_path("preview-draft", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+            post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
           end
           expect(response.status).not_to eq(404)
         end
@@ -324,105 +288,84 @@ RSpec.describe Forms::PageController, type: :request do
 
     context "with preview mode off" do
       it "Redirects to the next page" do
-        post save_form_page_path("form", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path("form", 2, "form-1", 2))
+        post save_form_page_path("form", 2, form_data.form_slug, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path("form", 2, form_data.form_slug, 2))
       end
 
       context "when changing an existing answer" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("form", 2, "form-1", 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
-          expect(response).to redirect_to(check_your_answers_path("form", 2, "form-1"))
+          post save_form_page_path("form", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          expect(response).to redirect_to(check_your_answers_path("form", 2, form_data.form_slug))
         end
 
         it "Logs the change_answer_page_save event" do
           expect(EventLogger).to receive(:log).with("change_answer_page_save",
-                                                    { form: "Form 1",
+                                                    { form: form_data.name,
                                                       method: "POST",
                                                       question_number: 1,
-                                                      question_text: "Question one",
-                                                      url: "http://www.example.com/form/2/form-1/1?changing_existing_answer=true&question%5Btext%5D=answer+text" })
-          post save_form_page_path("form", 2, "form-1", 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+                                                      question_text: form_data.pages.first.question_text,
+                                                      url: "http://www.example.com/form/2/#{form_data.form_slug}/1?changing_existing_answer=true&question%5Btext%5D=answer+text" })
+          post save_form_page_path("form", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
         end
       end
 
       context "with the first page" do
         it "Logs the first_page_save event" do
           expect(EventLogger).to receive(:log).with("first_page_save",
-                                                    { form: "Form 1",
+                                                    { form: form_data.name,
                                                       method: "POST",
                                                       question_number: 1,
-                                                      question_text: "Question one",
-                                                      url: "http://www.example.com/form/2/form-1/1" })
-          post save_form_page_path("form", 2, "form-1", 1), params: { question: { text: "answer text" } }
+                                                      question_text: form_data.pages.first.question_text,
+                                                      url: "http://www.example.com/form/2/#{form_data.form_slug}/1" })
+          post save_form_page_path("form", 2, form_data.form_slug, 1), params: { question: { text: "answer text" } }
         end
       end
 
       context "with a subsequent page" do
         it "Logs the page_save event" do
           expect(EventLogger).to receive(:log).with("page_save",
-                                                    { form: "Form 1",
+                                                    { form: form_data.name,
                                                       method: "POST",
                                                       question_number: 2,
-                                                      question_text: "Question two",
-                                                      url: "http://www.example.com/form/2/form-1/2" })
-          post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "answer text" } }
+                                                      question_text: form_data.pages.second.question_text,
+                                                      url: "http://www.example.com/form/2/#{form_data.form_slug}/2" })
+          post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
         end
       end
 
       context "with the final page" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "answer text" } }
-          expect(response).to redirect_to(check_your_answers_path("form", 2, "form-1"))
+          post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+          expect(response).to redirect_to(check_your_answers_path("form", 2, form_data.form_slug))
         end
       end
 
       context "with an subsequent optional page" do
-        let(:pages_data) do
-          [
-            {
-              id: 1,
-              question_text: "Question one",
-              answer_type: "text",
-              answer_settings: { input_type: "single_line" },
-              hint_text: "",
-              next_page: 2,
-              is_optional: nil,
-            },
-            {
-              id: 2,
-              question_text: "Question two",
-              hint_text: "Q2 hint text",
-              answer_type: "text",
-              answer_settings: { input_type: "single_line" },
-              question_short_name: nil,
-              is_optional: true,
-            },
-          ]
-        end
+        let(:is_optional) { true }
 
         context "when an optional question is completed" do
           it "Logs the optional_save event with skipped_question as true" do
             expect(EventLogger).to receive(:log).with("optional_save",
-                                                      { form: "Form 1",
+                                                      { form: form_data.name,
                                                         method: "POST",
                                                         question_number: 2,
-                                                        question_text: "Question two",
+                                                        question_text: form_data.pages.second.question_text,
                                                         skipped_question: "false",
-                                                        url: "http://www.example.com/form/2/form-1/2" })
-            post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "answer text" } }
+                                                        url: "http://www.example.com/form/2/#{form_data.form_slug}/2" })
+            post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
           end
         end
 
         context "when an optional question is skipped" do
           it "Logs the optional_save event with skipped_question as false" do
             expect(EventLogger).to receive(:log).with("optional_save",
-                                                      { form: "Form 1",
+                                                      { form: form_data.name,
                                                         method: "POST",
                                                         question_number: 2,
-                                                        question_text: "Question two",
+                                                        question_text: form_data.pages.second.question_text,
                                                         skipped_question: "true",
-                                                        url: "http://www.example.com/form/2/form-1/2" })
-            post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "" } }
+                                                        url: "http://www.example.com/form/2/#{form_data.form_slug}/2" })
+            post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "" } }
           end
         end
       end

--- a/spec/views/question/_address.html.erb_spec.rb
+++ b/spec/views/question/_address.html.erb_spec.rb
@@ -2,14 +2,10 @@ require "rails_helper"
 
 describe "question/address.html.erb" do
   let(:page) do
-    Page.new({
-      id: 1,
-      question_text: "What is your address?",
-      hint_text: nil,
-      answer_type: "address",
-      is_optional: false,
-      answer_settings:,
-    })
+    build(:page,
+          answer_type: "address",
+          routing_conditions:,
+          answer_settings:)
   end
 
   let(:answer_settings) { OpenStruct.new({ input_type: }) }
@@ -17,11 +13,15 @@ describe "question/address.html.erb" do
   let(:international_address) { "false" }
   let(:uk_address) { "true" }
 
+  let(:routing_conditions) { [] }
+
+  let(:goto_page_slug) { nil }
+
   let(:question) do
     QuestionRegister.from_page(page)
   end
 
-  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1) }
+  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions:, goto_page_slug:) }
 
   let(:form) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/views/question/_address.html.erb_spec.rb
+++ b/spec/views/question/_address.html.erb_spec.rb
@@ -15,13 +15,11 @@ describe "question/address.html.erb" do
 
   let(:routing_conditions) { [] }
 
-  let(:goto_page_slug) { nil }
-
   let(:question) do
     QuestionRegister.from_page(page)
   end
 
-  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions:, goto_page_slug:) }
+  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions:) }
 
   let(:form) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/views/question/_date.html.erb_spec.rb
+++ b/spec/views/question/_date.html.erb_spec.rb
@@ -2,25 +2,19 @@ require "rails_helper"
 
 describe "question/date.html.erb" do
   let(:page) do
-    Page.new({
-      id: 1,
-      question_text: "What is the date?",
-      hint_text: nil,
-      answer_type: "date",
-      is_optional: false,
-      answer_settings:,
-    })
+    build(:page, :with_date_settings, input_type:, routing_conditions:)
   end
 
-  let(:answer_settings) { OpenStruct.new({ input_type: }) }
-
   let(:input_type) { nil }
+  let(:routing_conditions) { [] }
+
+  let(:goto_page_slug) { nil }
 
   let(:question) do
     QuestionRegister.from_page(page)
   end
 
-  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1) }
+  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions:, goto_page_slug:) }
 
   let(:form) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/views/question/_date.html.erb_spec.rb
+++ b/spec/views/question/_date.html.erb_spec.rb
@@ -8,13 +8,11 @@ describe "question/date.html.erb" do
   let(:input_type) { nil }
   let(:routing_conditions) { [] }
 
-  let(:goto_page_slug) { nil }
-
   let(:question) do
     QuestionRegister.from_page(page)
   end
 
-  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions:, goto_page_slug:) }
+  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions:) }
 
   let(:form) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/views/question/_name.html.erb_spec.rb
+++ b/spec/views/question/_name.html.erb_spec.rb
@@ -13,13 +13,11 @@ describe "question/_name.html.erb" do
   let(:title_needed) { "false" }
   let(:routing_conditions) { [] }
 
-  let(:goto_page_slug) { nil }
-
   let(:question) do
     QuestionRegister.from_page(page)
   end
 
-  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions:, goto_page_slug:) }
+  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions:) }
 
   let(:form) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/views/question/_name.html.erb_spec.rb
+++ b/spec/views/question/_name.html.erb_spec.rb
@@ -2,25 +2,24 @@ require "rails_helper"
 
 describe "question/_name.html.erb" do
   let(:page) do
-    Page.new({
-      id: 1,
-      question_text: "What is your name?",
-      hint_text: nil,
-      answer_type: "name",
-      is_optional: false,
-      answer_settings:,
-    })
+    build(:page,
+          answer_type: "name",
+          routing_conditions:,
+          answer_settings:)
   end
 
   let(:answer_settings) { OpenStruct.new({ input_type:, title_needed: }) }
   let(:input_type) { "full_name" }
   let(:title_needed) { "false" }
+  let(:routing_conditions) { [] }
+
+  let(:goto_page_slug) { nil }
 
   let(:question) do
     QuestionRegister.from_page(page)
   end
 
-  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1) }
+  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions:, goto_page_slug:) }
 
   let(:form) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
@@ -35,7 +34,7 @@ describe "question/_name.html.erb" do
   context "when the question needs a title" do
     let(:title_needed) { "true" }
 
-    it "contains the correct autocomplete atrtibute for a title" do
+    it "contains the correct autocomplete attribute for a title" do
       expect(rendered).to have_css("input[type='text'][autocomplete='honorific-prefix']")
     end
   end

--- a/spec/views/question/_selection.html.erb_spec.rb
+++ b/spec/views/question/_selection.html.erb_spec.rb
@@ -2,21 +2,26 @@ require "rails_helper"
 
 describe "question/_selection.html.erb" do
   let(:page) do
-    Page.new({
-      id: 1,
-      question_text: "Which city do you live in?",
-      hint_text: nil,
-      answer_type: "selection",
-      is_optional:,
-      answer_settings: OpenStruct.new({ only_one_option:, selection_options: [OpenStruct.new({ name: "Bristol" }), OpenStruct.new({ name: "London" }), OpenStruct.new({ name: "Manchester" })] }),
-    })
+    build(:page,
+          id: 1,
+          answer_type: "selection",
+          is_optional:,
+          routing_conditions:,
+          answer_settings: OpenStruct.new({ only_one_option:,
+                                            selection_options: [OpenStruct.new({ name: "Bristol" }),
+                                                                OpenStruct.new({ name: "London" }),
+                                                                OpenStruct.new({ name: "Manchester" })] }))
   end
+
+  let(:routing_conditions) { [] }
+
+  let(:goto_page_slug) { nil }
 
   let(:question) do
     QuestionRegister.from_page(page)
   end
 
-  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1) }
+  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions: page.routing_conditions, goto_page_slug:) }
 
   let(:form) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
@@ -35,7 +40,7 @@ describe "question/_selection.html.erb" do
       let(:is_optional) { false }
 
       it "contains the question" do
-        expect(rendered).to have_css("h1", text: "Which city do you live in?")
+        expect(rendered).to have_css("h1", text: page.question_text)
       end
 
       it "contains the options" do
@@ -53,7 +58,7 @@ describe "question/_selection.html.erb" do
       let(:is_optional) { true }
 
       it "contains the question" do
-        expect(rendered).to have_css("h1", text: "Which city do you live in?")
+        expect(rendered).to have_css("h1", text: page.question_text)
       end
 
       it "contains the options" do
@@ -75,7 +80,7 @@ describe "question/_selection.html.erb" do
       let(:is_optional) { false }
 
       it "contains the question" do
-        expect(rendered).to have_css("h1", text: "Which city do you live in?")
+        expect(rendered).to have_css("h1", text: page.question_text)
       end
 
       it "contains the options" do
@@ -93,7 +98,7 @@ describe "question/_selection.html.erb" do
       let(:is_optional) { true }
 
       it "contains the question" do
-        expect(rendered).to have_css("h1", text: "Which city do you live in?")
+        expect(rendered).to have_css("h1", text: page.question_text)
       end
 
       it "contains the options" do

--- a/spec/views/question/_selection.html.erb_spec.rb
+++ b/spec/views/question/_selection.html.erb_spec.rb
@@ -15,13 +15,11 @@ describe "question/_selection.html.erb" do
 
   let(:routing_conditions) { [] }
 
-  let(:goto_page_slug) { nil }
-
   let(:question) do
     QuestionRegister.from_page(page)
   end
 
-  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions: page.routing_conditions, goto_page_slug:) }
+  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions: page.routing_conditions) }
 
   let(:form) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,


### PR DESCRIPTION
#### What problem does the pull request solve?

Adds basic routing support to forms-runner, by updating the next_page logic. A user should now be able to be routed to the goto page of the routing condition if they select a specific answer. They should be able to change their answer and continue through the form as expected. 


"Check your answers" page works by playing back the journey the user would have had to have gone through along with their answers. This means no changes were needed to support basic routing These "completed_steps" is also what is also used and played back to the submit form service email so again no changes were needed.



Trello card: https://trello.com/c/EZ67GrJQ/562-runner-changes-to-nextpage-logic-for-simple-routing

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
