### PR TITLE
Address rspec depreciation warning about using stub

### DIFF
--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -28,17 +28,15 @@ RSpec.describe HostingEnvironment do
     end
 
     context "when in local development" do
-      before { Rails.env.stub(production?: false) }
-
       it "returns true" do
+        allow(Rails).to receive(:env).and_return(OpenStruct.new(production?: false))
         expect(described_class.test_environment?).to be(true)
       end
     end
 
     context "when in production" do
-      before { Rails.env.stub(production?: true) }
-
       it "returns false" do
+        allow(Rails).to receive(:env).and_return(OpenStruct.new(production?: true))
         expect(described_class.test_environment?).to be(false)
       end
     end


### PR DESCRIPTION
#### What problem does the pull request solve?
We no longer receive the following deprecation warning when running rspec.

```
Deprecation Warnings:

Using 'stub' from rspec-mocks' old ':should' syntax without explicitly enabling the syntax is deprecated. Use the new ':expect' syntax or explicitly enable ':should' instead.
Called from /Users/gds/forms-runner/spec/lib/hosting_environment_spec.rb:31:in `block (4 levels) in <top (required)>'.

If you need more of the backtrace for any of these deprecations to identify where to make the necessary changes, you can configure `config.raise_errors_for_deprecations!`, and it will turn the deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total
```


Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
