### PR TITLE
Fix missing routing conditions method

### DIFF
--- a/app/lib/step_factory.rb
+++ b/app/lib/step_factory.rb
@@ -26,7 +26,7 @@ class StepFactory
     next_page_slug = page.has_next_page? ? page.next_page.to_s : CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG
     question = QuestionRegister.from_page(page)
 
-    Step.new(question:, page_id: page.id, form_id: @form.id, form_slug: @form.form_slug, next_page_slug:, page_slug:, page_number: page.number(@form), routing_conditions: page.routing_conditions)
+    Step.new(question:, page:, form_id: @form.id, form_slug: @form.form_slug, next_page_slug:, page_slug:)
   end
 
   def start_step

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -14,12 +14,6 @@ class Page < ActiveResource::Base
     @attributes.include?("next_page") && !@attributes["next_page"].nil?
   end
 
-  # TODO: - Remove this method and use the page.position instead
-  def number(form)
-    index = form.pages.index(self)
-    index + 1
-  end
-
   def answer_settings
     @attributes["answer_settings"] || {}
   end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -10,7 +10,7 @@ class Step
     @form_slug = form_slug
     @next_page_slug = next_page_slug
     @page_number = page.position
-    @routing_conditions = page.routing_conditions
+    @routing_conditions = page.respond_to?(:routing_conditions) ? page.routing_conditions : []
   end
 
   alias_attribute :id, :page_id

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -2,15 +2,15 @@ class Step
   attr_accessor :page_id, :form_id, :form_slug, :question
   attr_reader :next_page_slug, :page_slug, :page_number, :routing_conditions
 
-  def initialize(question:, page_id:, form_id:, form_slug:, next_page_slug:, page_slug:, page_number:, routing_conditions:)
+  def initialize(question:, page:, form_id:, form_slug:, next_page_slug:, page_slug:)
     @question = question
-    @page_id = page_id
+    @page_id = page.id
     @page_slug = page_slug
     @form_id = form_id
     @form_slug = form_slug
     @next_page_slug = next_page_slug
-    @page_number = page_number
-    @routing_conditions = routing_conditions
+    @page_number = page.position
+    @routing_conditions = page.routing_conditions
   end
 
   alias_attribute :id, :page_id

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     answer_settings { nil }
     hint_text { nil }
     routing_conditions { [] }
-    position { 1 }
+    sequence(:position) { |n| n }
 
     trait :with_hints do
       hint_text { Faker::Quote.yoda }

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -227,6 +227,22 @@ RSpec.describe Forms::PageController, type: :request do
         end
       end
     end
+
+    context "when viewing a live form with no routing_conditions" do
+      let(:page_1) do
+        page_without_routing_condition = build(:page, :with_text_settings,
+                                               id: 1,
+                                               next_page: 2,
+                                               is_optional: false)
+
+        Page.new(page_without_routing_condition.attributes.except(:routing_conditions))
+      end
+
+      it "Returns a 200" do
+        get form_page_path("preview-live", 2, form_data.form_slug, 1)
+        expect(response.status).to eq(200)
+      end
+    end
   end
 
   describe "#save" do
@@ -299,7 +315,7 @@ RSpec.describe Forms::PageController, type: :request do
           expect(EventLogger).to receive(:log).with("change_answer_page_save",
                                                     { form: form_data.name,
                                                       method: "POST",
-                                                      question_number: 1,
+                                                      question_number: form_data.pages.first.position,
                                                       question_text: form_data.pages.first.question_text,
                                                       url: "http://www.example.com/form/2/#{form_data.form_slug}/1?changing_existing_answer=true&question%5Btext%5D=answer+text" })
           post save_form_page_path("form", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
@@ -311,7 +327,7 @@ RSpec.describe Forms::PageController, type: :request do
           expect(EventLogger).to receive(:log).with("first_page_save",
                                                     { form: form_data.name,
                                                       method: "POST",
-                                                      question_number: 1,
+                                                      question_number: form_data.pages.first.position,
                                                       question_text: form_data.pages.first.question_text,
                                                       url: "http://www.example.com/form/2/#{form_data.form_slug}/1" })
           post save_form_page_path("form", 2, form_data.form_slug, 1), params: { question: { text: "answer text" } }
@@ -323,7 +339,7 @@ RSpec.describe Forms::PageController, type: :request do
           expect(EventLogger).to receive(:log).with("page_save",
                                                     { form: form_data.name,
                                                       method: "POST",
-                                                      question_number: 2,
+                                                      question_number: form_data.pages.second.position,
                                                       question_text: form_data.pages.second.question_text,
                                                       url: "http://www.example.com/form/2/#{form_data.form_slug}/2" })
           post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
@@ -345,7 +361,7 @@ RSpec.describe Forms::PageController, type: :request do
             expect(EventLogger).to receive(:log).with("optional_save",
                                                       { form: form_data.name,
                                                         method: "POST",
-                                                        question_number: 2,
+                                                        question_number: form_data.pages.second.position,
                                                         question_text: form_data.pages.second.question_text,
                                                         skipped_question: "false",
                                                         url: "http://www.example.com/form/2/#{form_data.form_slug}/2" })
@@ -358,7 +374,7 @@ RSpec.describe Forms::PageController, type: :request do
             expect(EventLogger).to receive(:log).with("optional_save",
                                                       { form: form_data.name,
                                                         method: "POST",
-                                                        question_number: 2,
+                                                        question_number: form_data.pages.second.position,
                                                         question_text: form_data.pages.second.question_text,
                                                         skipped_question: "true",
                                                         url: "http://www.example.com/form/2/#{form_data.form_slug}/2" })

--- a/spec/views/question/_address.html.erb_spec.rb
+++ b/spec/views/question/_address.html.erb_spec.rb
@@ -19,7 +19,7 @@ describe "question/address.html.erb" do
     QuestionRegister.from_page(page)
   end
 
-  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions:) }
+  let(:step) { Step.new(question:, page:, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1) }
 
   let(:form) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/views/question/_date.html.erb_spec.rb
+++ b/spec/views/question/_date.html.erb_spec.rb
@@ -12,7 +12,7 @@ describe "question/date.html.erb" do
     QuestionRegister.from_page(page)
   end
 
-  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions:) }
+  let(:step) { Step.new(question:, page:, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1) }
 
   let(:form) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/views/question/_name.html.erb_spec.rb
+++ b/spec/views/question/_name.html.erb_spec.rb
@@ -17,7 +17,7 @@ describe "question/_name.html.erb" do
     QuestionRegister.from_page(page)
   end
 
-  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions:) }
+  let(:step) { Step.new(question:, page:, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1) }
 
   let(:form) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/views/question/_selection.html.erb_spec.rb
+++ b/spec/views/question/_selection.html.erb_spec.rb
@@ -19,7 +19,7 @@ describe "question/_selection.html.erb" do
     QuestionRegister.from_page(page)
   end
 
-  let(:step) { Step.new(question:, page_id: page.id, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1, page_number: 1, routing_conditions: page.routing_conditions) }
+  let(:step) { Step.new(question:, page:, form_id: 1, form_slug: "", next_page_slug: 2, page_slug: 1) }
 
   let(:form) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,


### PR DESCRIPTION
#### What problem does the pull request solve?

Suggest reviewing each commit made. 

- Simplify the params that we pass into Steps model
- Commit to show how to replicate the error we saw in AWS where existing live forms with missing routing_conditions raised an error
- Fix the error by handling the error within the Step model. If pages has routing_conditions method use it otherwise return an empty array which is what newer pages with not routing_conditions will return.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
