### PR TITLE
Use settings instead of env to enable maintenance page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "climate_control"
+  gem "rails-controller-testing"
   gem "selenium-webdriver"
   gem "simplecov"
   gem "webdrivers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,10 @@ GEM
       activesupport (= 7.0.5)
       bundler (>= 1.15.0)
       railties (= 7.0.5)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -425,6 +429,7 @@ DEPENDENCIES
   nokogiri (~> 1.15.2)
   puma (~> 6.3.0)
   rails (~> 7.0.5)
+  rails-controller-testing
   redis
   redis-session-store
   rspec-rails

--- a/README.md
+++ b/README.md
@@ -58,10 +58,9 @@ Refer to the [settings file](config/settings.yml) for all the settings required 
 
 ### Environment variables
 
-| Name                  | Purpose                                                      |
-| --------------------- | ------------------------------------------------------------ |
-| `REDIS_URL`           | The URL for Redis (optional)                                 |
-| `SERVICE_UNAVAILABLE` | All pages will render 'Service unavailable' if set to `true` |
+| Name        | Purpose                      |
+| ----------- | ---------------------------- |
+| `REDIS_URL` | The URL for Redis (optional) |
 
 ### Running the app
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   def cookies; end
 
   def check_service_unavailable
-    if ENV["SERVICE_UNAVAILABLE"].present?
+    if Settings.service_unavailable
       render "errors/service_unavailable", status: :service_unavailable, formats: :html
     end
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,3 +19,5 @@ govuk_notify:
 sentry:
   dsn:
   environment: local
+
+service_unavailable: false

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -14,4 +14,19 @@ RSpec.describe ApplicationController, type: :request do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  context "when the service is unavailable" do
+    before do
+      allow(Settings).to receive(:service_unavailable).and_return(true)
+      get "/"
+    end
+
+    it "returns http code 503" do
+      expect(response).to have_http_status(:service_unavailable)
+    end
+
+    it "renders the service unavailable page" do
+      expect(response).to render_template("errors/service_unavailable")
+    end
+  end
 end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ApplicationController, type: :request do
   context "when the service is unavailable" do
     before do
       allow(Settings).to receive(:service_unavailable).and_return(true)
-      get "/"
+      get root_path
     end
 
     it "returns http code 503" do

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -34,14 +34,6 @@ RSpec.describe ErrorsController, type: :request do
     end
   end
 
-  describe "Service unavailable page" do
-    it "returns http code 503" do
-      stub_const "ENV", ENV.to_h.merge("SERVICE_UNAVAILABLE" => "true")
-      get root_path
-      expect(response).to have_http_status(:service_unavailable)
-    end
-  end
-
   describe "Submission error" do
     let(:form_response_data) do
       {


### PR DESCRIPTION
#### What problem does the pull request solve?
Uses the `settings` configuration files instead of the `SERVICE_UNAVAILABLE` env var to enable the service unavailable page.

forms-admin already uses the settings files for this, so this brings to two apps into alignemnt.

Trello card: None, but helps with https://trello.com/c/P9CEz21c/840-test-and-update-holding-page

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [x] I've updated the documentation in (If any documentation requires updating)
  - [x] README.md
  - [n/a] Elsewhere (please link)
