### PR TITLE
Add before_action for goto_page_before_routing_page error

### DIFF
--- a/app/lib/journey.rb
+++ b/app/lib/journey.rb
@@ -24,8 +24,12 @@ private
     current_step = find_existing_step(:_start)
 
     while current_step
-      @completed_steps << current_step
       next_page_slug = current_step.next_page_slug_after_routing
+
+      # Prevent infinite loop if a route goes back on itself
+      break if @completed_steps.map(&:page_slug).include?(next_page_slug)
+
+      @completed_steps << current_step
 
       break if next_page_slug.nil?
 

--- a/app/views/errors/goto_page_before_routing_page.html.erb
+++ b/app/views/errors/goto_page_before_routing_page.html.erb
@@ -1,0 +1,8 @@
+<% set_page_title(t("goto_page_before_routing_page.title")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('goto_page_before_routing_page.title') %></h1>
+    <%= t('goto_page_before_routing_page.body_html', link_url:, question_number:) %>
+  </div>
+</div>

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -1,5 +1,10 @@
 ---
 en:
+  goto_page_before_routing_page:
+    body_html: |
+      <p>The question you’re taking the person to is now above the question route, so the route cannot work.</p>
+      <p>To fix this <a href="%{link_url}">edit or delete question %{question_number}’s route</a>.</p>
+    title: There’s a problem
   internal_server_error:
     body: Please try again later.
     title: Sorry, there is a problem with the service
@@ -9,7 +14,7 @@ en:
       If you pasted the web address, check you copied the entire address.
     title: Page not found
   repeat_submission:
-    body: We deleted your answers because they‘ve been submitted successfully already.
+    body: We deleted your answers because they’ve been submitted successfully already.
     body_2: If you want to submit the form again, you need to
     link_text: go back to the start
     title: For your security, we deleted your answers

--- a/spec/lib/journey_spec.rb
+++ b/spec/lib/journey_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+require_relative "../../app/lib/journey"
+
+RSpec.describe Journey do
+  let(:store) { {} }
+  let(:form_context) { FormContext.new(store) }
+  let(:step_factory) { StepFactory.new(form:) }
+  let(:journey) { described_class.new(form_context:, step_factory:) }
+
+  let(:form) do
+    build(:form, :with_support,
+          id: 2,
+          start_page: 1,
+          pages: pages_data)
+  end
+
+  let(:page_1) do
+    build :page, :with_selections_settings,
+          id: 1,
+          next_page: 2,
+          routing_conditions: [DataStruct.new(id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3, answer_value: "Option 1", validation_errors:)]
+  end
+
+  let(:validation_errors) { [] }
+
+  let(:page_2) do
+    build :page, :with_text_settings,
+          id: 2,
+          next_page: 3
+  end
+
+  let(:page_3) do
+    build :page, :with_text_settings,
+          id: 3
+  end
+
+  let(:pages_data) { [page_1, page_2, page_3] }
+
+  let(:step_1) { step_factory.create_step(page_1.id.to_s).load_from_context(form_context) }
+  let(:step_2) { step_factory.create_step(page_2.id.to_s).load_from_context(form_context) }
+  let(:step_3) { step_factory.create_step(page_3.id.to_s).load_from_context(form_context) }
+
+  context "when no pages have been completed" do
+    it "completed_steps is empty" do
+      expect(journey.completed_steps).to eq []
+    end
+  end
+
+  context "when all pages have been completed" do
+    let(:store) { { answers: { "2" => { "1" => { selection: "Option 2" }, "2" => { text: "Example text" }, "3" => { text: "More example text" } } } } }
+
+    it "completed_steps includes all pages" do
+      expect(journey.completed_steps.to_json).to eq [step_1, step_2, step_3].to_json
+    end
+  end
+
+  context "when page has a cannot_have_goto_page_before_routing_page error" do
+    let(:validation_errors) { [{ name: "cannot_have_goto_page_before_routing_page" }] }
+
+    let(:page_1) do
+      build :page, :with_text_settings,
+            id: 1,
+            next_page: 2
+    end
+
+    let(:page_2) do
+      build :page, :with_selections_settings,
+            id: 2,
+            next_page: 3,
+            routing_conditions: [DataStruct.new(id: 1, routing_page_id: 2, check_page_id: 2, goto_page_id: 1, answer_value: "Option 1", validation_errors:)],
+            is_optional: false
+    end
+
+    let(:store) { { answers: { "2" => { "1" => { text: "Example text" }, "2" => { selection: page_2.routing_conditions.first.answer_value }, "3" => { text: "More example text" } } } } }
+    let(:pages_data) { [page_1, page_2, page_3] }
+
+    it "stops generating the completed_steps when it reaches the question with the error" do
+      expect(journey.completed_steps.to_json).to eq [step_1].to_json
+    end
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?
Blocks users from previewing or submitting a page when the page's route points to an earlier question in the form.
- shows an error page when this happens
- also resolves the underlying infinite loop issue in `journey.rb` that can cause the server to hang/crash if the user follows a looping route.

Trello card: https://trello.com/c/igNu5fny/819-block-users-from-previewing-a-draft-form-that-causes-endless-looping

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
