### PR TITLE
Pin node to minor version 18.16 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apk update
 RUN apk upgrade --available
-RUN apk add libc6-compat openssl-dev build-base libpq-dev nodejs=18.16.1-r0 npm
+RUN apk add libc6-compat openssl-dev build-base libpq-dev nodejs=~18.16 npm
 RUN adduser -D ruby
 RUN mkdir /node_modules && chown ruby:ruby -R /node_modules /app
 


### PR DESCRIPTION
#### What problem does the pull request solve?
Fixes an issue with x86 and ARM architectures supporting different versions of the [Alpine nodejs package](https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.17&repo=&arch=&maintainer=).

x86 architectures support 18.16.1 (so our Github action passed) but our build uses ARM, which currently only supports 18.16.0. Pinning to the minor version supports both, and should make build-breaking updates slightly less frequent.

#### Checklist

- [x] I've used the pull request template
- [n/a] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
