### PR TITLE
Add environment tags

### DIFF
--- a/app/components/form_header_component/_index.scss
+++ b/app/components/form_header_component/_index.scss
@@ -1,7 +1,7 @@
-.govuk-header--preview-draft .govuk-header__container {
+.app-header--preview-draft .govuk-header__container {
   border-bottom-color: govuk-colour("purple");
 }
 
-.govuk-header--preview-live .govuk-header__container {
+.app-header--preview-live .govuk-header__container {
   border-bottom-color: govuk-colour("blue");
 }

--- a/app/components/form_header_component/_index.scss
+++ b/app/components/form_header_component/_index.scss
@@ -5,3 +5,10 @@
 .app-header--preview-live .govuk-header__container {
   border-bottom-color: govuk-colour("blue");
 }
+
+.app-header .govuk-header__link--homepage {
+  display: inline-flex;
+  align-items: center;
+  gap: .25em;
+  flex-wrap: wrap;
+}

--- a/app/components/form_header_component/view.rb
+++ b/app/components/form_header_component/view.rb
@@ -12,7 +12,7 @@ module FormHeaderComponent
         govuk_header(service_name: @current_context.form.name,
                      homepage_url: "https://www.gov.uk/",
                      service_url:,
-                     classes: "govuk-header--#{@mode}")
+                     classes: "app-header--#{@mode}")
       else
         govuk_header(homepage_url: "https://www.gov.uk/")
       end

--- a/app/components/form_header_component/view.rb
+++ b/app/components/form_header_component/view.rb
@@ -1,9 +1,10 @@
 module FormHeaderComponent
   class View < ViewComponent::Base
-    def initialize(current_context:, mode:, service_url_overide: :not_set)
+    def initialize(current_context:, mode:, service_url_overide: :not_set, hosting_environment: HostingEnvironment)
       @current_context = current_context
       @mode = mode
       @service_url_overide = service_url_overide
+      @hosting_environment = hosting_environment
       super
     end
 
@@ -12,13 +13,38 @@ module FormHeaderComponent
         govuk_header(service_name: @current_context.form.name,
                      homepage_url: "https://www.gov.uk/",
                      service_url:,
-                     classes: "app-header--#{@mode}")
+                     classes: ["app-header", "app-header--#{@mode}"]) do |header|
+          header.with_product_name(name: service_name_with_tag)
+        end
       else
-        govuk_header(homepage_url: "https://www.gov.uk/")
+        govuk_header(homepage_url: "https://www.gov.uk/", classes: ["app-header", "app-header--#{@mode}"]) do |header|
+          header.with_product_name(name: service_name_with_tag)
+        end
       end
     end
 
   private
+
+    def service_name_with_tag
+      govuk_tag(colour: colour_for_environment, text: environment_name).html_safe unless environment_name == "production"
+    end
+
+    def environment_name
+      @hosting_environment.friendly_environment_name
+    end
+
+    def colour_for_environment
+      case environment_name
+      when "local"
+        "pink"
+      when "development"
+        "green"
+      when "staging"
+        "yellow"
+      else
+        "blue"
+      end
+    end
 
     def service_url
       if @service_url_overide == :not_set

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -3,6 +3,12 @@ module HostingEnvironment
     ENV.fetch("PAAS_ENVIRONMENT", "unknown-environment")
   end
 
+  def self.friendly_environment_name
+    key = local_development? ? "local" : environment_name
+
+    I18n.t("environment_names.#{key}", default: key)
+  end
+
   def self.local_development?
     environment_name == "unknown-environment" && !Rails.env.production?
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,16 @@ en:
               blank: Enter an answer
               long_text_too_long: The answer must be shorter than 5000 characters
               single_line_too_long: The answer must be shorter than 500 characters
+  environment_names:
+    aws-dev: development
+    aws-production: production
+    aws-staging: staging
+    aws-user-research: user research
+    dev: development
+    local: local
+    production: production
+    staging: staging
+    user-research: user research
   footer:
     accessibility_statement: Accessibility statement
     cookies: Cookies

--- a/spec/components/form_header_component/view_spec.rb
+++ b/spec/components/form_header_component/view_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FormHeaderComponent::View, type: :component do
     render_inline(described_class.new(current_context:, mode:, service_url_overide: "/form/1/test"))
 
     expect(page).to have_selector(".govuk-header__service-name")
-    expect(page).to have_content("test_form_name")
+    expect(page).to have_text("test_form_name")
   end
 
   context "when mode is preview_draft" do
@@ -33,6 +33,35 @@ RSpec.describe FormHeaderComponent::View, type: :component do
       expect(page).to have_selector(".govuk-header__service-name")
       expect(page).to have_selector(".app-header--preview-live")
       expect(page).to have_content("test_form_name")
+    end
+  end
+
+  context "when the environment is production" do
+    before do
+      allow(HostingEnvironment).to receive(:friendly_environment_name).and_return("production")
+      render_inline(described_class.new(current_context:, mode:, service_url_overide: "/form/1/test"))
+    end
+
+    it "does not show an environment tag" do
+      expect(page).not_to have_css(".govuk-tag", text: "production")
+    end
+  end
+
+  [
+    { name: "local", colour: "pink" },
+    { name: "development", colour: "green" },
+    { name: "user research", colour: "blue" },
+    { name: "staging", colour: "yellow" },
+  ].each do |environment|
+    context "when the environment is #{environment[:name]}" do
+      before do
+        allow(HostingEnvironment).to receive(:friendly_environment_name).and_return(environment[:name])
+        render_inline(described_class.new(current_context:, mode:, service_url_overide: "/form/1/test"))
+      end
+
+      it "shows the environment tag" do
+        expect(page).to have_css(".govuk-tag--#{environment[:colour]}", text: environment[:name])
+      end
     end
   end
 

--- a/spec/components/form_header_component/view_spec.rb
+++ b/spec/components/form_header_component/view_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe FormHeaderComponent::View, type: :component do
       render_inline(described_class.new(current_context:, mode:, service_url_overide: "/form/1/test"))
 
       expect(page).to have_selector(".govuk-header__service-name")
-      expect(page).to have_selector(".govuk-header--preview-draft")
+      expect(page).to have_selector(".app-header--preview-draft")
       expect(page).to have_content("test_form_name")
     end
   end
@@ -31,7 +31,7 @@ RSpec.describe FormHeaderComponent::View, type: :component do
       render_inline(described_class.new(current_context:, mode:, service_url_overide: "/form/1/test"))
 
       expect(page).to have_selector(".govuk-header__service-name")
-      expect(page).to have_selector(".govuk-header--preview-live")
+      expect(page).to have_selector(".app-header--preview-live")
       expect(page).to have_content("test_form_name")
     end
   end

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -41,4 +41,37 @@ RSpec.describe HostingEnvironment do
       end
     end
   end
+
+  describe "#friendly_environment_name" do
+    before do
+      allow(described_class).to receive(:environment_name).and_return(environment_name)
+      allow(described_class).to receive(:local_development?).and_return(is_local_development)
+    end
+
+    [
+      { environment_name: "unknown_environment", is_local_development: true, expected_key: "local" },
+      { environment_name: "dev", is_local_development: false, expected_key: "dev" },
+      { environment_name: "production", is_local_development: false, expected_key: "production" },
+      { environment_name: "aws-staging", is_local_development: false, expected_key: "aws-staging" },
+      { environment_name: "aws-user-research", is_local_development: false, expected_key: "aws-user-research" },
+    ].each do |scenario|
+      context "with environment name set to '#{scenario[:environment_name]}' and is_local_development set to '#{scenario[:is_local_development]}" do
+        let(:environment_name) { scenario[:environment_name] }
+        let(:is_local_development) { scenario[:is_local_development] }
+
+        it "returns the correct translation" do
+          expect(described_class.friendly_environment_name).to eq(I18n.t("environment_names.#{scenario[:expected_key]}"))
+        end
+      end
+    end
+
+    context "with environment name set to an unknown value and rails_env set to production" do
+      let(:environment_name) { "some_unknown_environemnt_string" }
+      let(:is_local_development) { false }
+
+      it "returns the environment name as default text" do
+        expect(described_class.friendly_environment_name).to eq(environment_name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
- Displays a tag with the name of the environment on non-production environments
- Unlike the [associated admin PR](https://github.com/alphagov/forms-admin/pull/508), we aren't adding a coloured border-bottom to the header. This is because we already use this border colour for denoting whether the form is in live, preview-live, or preview-draft mode.
- Adds a custom `app-header` CSS class to the header, so we can add our own styles without any risk of name collision with govuk-frontend styles
     
The tag colours for each environment are:

-  Pink for local
-  Green for dev
-  Yellow for staging
-  Blue for user research

Trello card: https://trello.com/c/DFOs5YuI/858-display-which-environment-a-user-is-accessing


#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
