### PR TITLE
revert text on maintenance page

### DIFF
--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -10,7 +10,7 @@ en:
     title: Sorry, there is a problem with the service
   maintenance:
     body_html: |
-      <p>You will be able to use the service later.</p>
+      <p>You’ll be able to use the service later.</p>
       <p>We have not saved your answers. When the service is available, you’ll have to start again.</p>
     title: Sorry, the service is unavailable
   not_found:

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -10,7 +10,7 @@ en:
     title: Sorry, there is a problem with the service
   maintenance:
     body_html: |
-      <p>You’ll be able to use the service on Wednesday 5 July 2023.</p>
+      <p>You will be able to use the service later.</p>
       <p>We have not saved your answers. When the service is available, you’ll have to start again.</p>
     title: Sorry, the service is unavailable
   not_found:


### PR DESCRIPTION
https://trello.com/c/kdBnaSzQ/84-change-the-content-for-the-maintenance-page-to-be-generic

This PR is to change the content for the maintenance page to be generic.

paired with @alice-carr 