### PR TITLE
Remove obsolete exception handling for StepFactory

### DIFF
--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -30,9 +30,6 @@ module Forms
       @step = current_context.find_or_create(page_slug)
 
       @support_details = current_context.support_details
-    rescue StepFactory::PageNotFoundError => e
-      Sentry.capture_exception(e)
-      render "errors/not_found", status: :not_found
     end
 
     def setup_instance_vars_for_view


### PR DESCRIPTION
#### What problem does the pull request solve?
This exception handling was created before we had a BaseController which PageController inherits from now.

[BaseController now handles the exception](https://github.com/alphagov/forms-runner/blob/94fcc37b2e924225ea2d3f36a1ef2288bc8749c2/app/controllers/forms/base_controller.rb#L10C5-L12C8) from any controller that inherits from it.

This will stop us randomly raising errors in sentry

Trello card: https://trello.com/c/KXVDn9V9/918-stop-stepfactory-from-raising-sentry-alerts

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
