### PR TITLE
Remove unnecessary calls to html_safe

### DIFF
--- a/app/views/question/_address.html.erb
+++ b/app/views/question/_address.html.erb
@@ -1,5 +1,5 @@
 
-<%= form.govuk_fieldset legend: { text: question_text_with_optional_suffix(page, @mode).html_safe, tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-address-hint" : nil do %>
+<%= form.govuk_fieldset legend: { text: question_text_with_optional_suffix(page, @mode), tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-address-hint" : nil do %>
   <% if page.question.is_international_address? %>
     <% if page.hint_text.present? %>
       <p id="govuk-address-hint" class="govuk-hint"><%= page.hint_text %></p>

--- a/app/views/question/_date.html.erb
+++ b/app/views/question/_date.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_date_field :date, date_of_birth: page.question.date_of_birth?, legend: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode).html_safe }, hint: { text: page.hint_text } %>
+<%= form.govuk_date_field :date, date_of_birth: page.question.date_of_birth?, legend: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode) }, hint: { text: page.hint_text } %>

--- a/app/views/question/_name.html.erb
+++ b/app/views/question/_name.html.erb
@@ -1,7 +1,7 @@
 <% if page.question.is_full_name? && !page.question.needs_title? %>
-  <%= form.govuk_text_field :full_name, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode).html_safe }, hint: { text: page.hint_text }, autocomplete: "name" %>
+  <%= form.govuk_text_field :full_name, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode) }, hint: { text: page.hint_text }, autocomplete: "name" %>
 <% else %>
-  <%= form.govuk_fieldset legend: { text: question_text_with_optional_suffix(page, @mode).html_safe, tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-name-hint" : nil do %>
+  <%= form.govuk_fieldset legend: { text: question_text_with_optional_suffix(page, @mode), tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-name-hint" : nil do %>
     <% if page.hint_text.present? %>
       <p id="govuk-name-hint" class="govuk-hint"><%= page.hint_text %></p>
     <% end %>

--- a/app/views/question/_national_insurance_number.html.erb
+++ b/app/views/question/_national_insurance_number.html.erb
@@ -1,1 +1,1 @@
-<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode).html_safe }, hint: { text: page.hint_text }, width: 10, spellcheck: false %>
+<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode) }, hint: { text: page.hint_text }, width: 10, spellcheck: false %>


### PR DESCRIPTION
#### What problem does the pull request solve?
The application helper that called before these `.html_safe` already calls `.html_safe`

https://github.com/alphagov/forms-runner/blob/3575a7b3122d3f327ad2f4d90a936c1e64d15b33/app/helpers/application_helper.rb#L31

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
