### PR TITLE
Prevent question text from injecting custom html tags (Security concern)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,13 +22,25 @@ module ApplicationHelper
   end
 
   def question_text_with_optional_suffix(page, mode)
-    if mode.preview_draft?
-      mode_string = "<span class='govuk-visually-hidden'>&nbsp;#{t('page.draft_preview')}</span>"
-    elsif mode.preview_live?
-      mode_string = "<span class='govuk-visually-hidden'>&nbsp;#{t('page.live_preview')}</span>"
-    end
+    mode_string = hidden_text_mode(mode)
     question = page.question.show_optional_suffix ? t("page.optional", question_text: page.question_text) : page.question_text
-    [question, mode_string].compact.join(" ").html_safe
+
+    if mode_string.blank?
+      question
+    else
+      [question, mode_string].join(" ")
+    end
+  end
+
+  def hidden_text_mode(mode)
+    return "" unless mode.preview?
+
+    mode_name = if mode.preview_draft?
+                  "draft"
+                elsif mode.preview_live?
+                  "live"
+                end
+    "<span class='govuk-visually-hidden'>&nbsp;#{t("page.#{mode_name}_preview".to_s)}</span>".html_safe
   end
 
   def format_paragraphs(text)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -120,6 +120,7 @@ search:
 ignore_unused:
   - 'activemodel.errors.*'
   - 'mode.*'
+  - 'page.*_preview'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -43,6 +43,30 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe "#hidden_text_mode" do
+    let(:mode) { OpenStruct.new(preview?: false) }
+
+    it "returns empty string by default if not in some preview mode" do
+      expect(helper.hidden_text_mode(mode)).to eq ""
+    end
+
+    context "when previewing in draft mode" do
+      let(:mode) { OpenStruct.new(preview?: true, preview_draft?: true, preview_live?: false) }
+
+      it "returns a visually hidden span with the mode name" do
+        expect(helper.hidden_text_mode(mode)).to eq "<span class='govuk-visually-hidden'>&nbsp;draft preview</span>"
+      end
+    end
+
+    context "when previewing in live mode " do
+      let(:mode) { OpenStruct.new(preview?: true, preview_draft?: false, preview_live?: true) }
+
+      it "returns a visually hidden span with the mode name" do
+        expect(helper.hidden_text_mode(mode)).to eq "<span class='govuk-visually-hidden'>&nbsp;live preview</span>"
+      end
+    end
+  end
+
   describe "#form_title" do
     context "when there is no error" do
       context "when in live mode" do


### PR DESCRIPTION
#### What problem does the pull request solve?
This refactor addresses a few concerns.

1. `question_text_with_optional_suffix` application helper, used `html_safe` on both question text (supplied by form creators i.e user input) and mode_string. This meant that form creators could use script tags to create XSS attacks to any user of their form. Instead, we should only use `html_safe` on markup that we completely control and never trust data supplied by users

2. `question_text_with_optional_suffix` was doing a lot of extra work apart from just adding `(optional)` suffix to the question text. It was also responsible for adding what mode the question should read out to screenreaders. It was easier to split out adding mode span which could be useful to other parts of the application and not just this helper.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
