### PR TITLE
Fix escaping of html in the question page heading

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,7 +28,7 @@ module ApplicationHelper
     if mode_string.blank?
       question
     else
-      [question, mode_string].join(" ")
+      "#{CGI.escapeHTML(question)} #{mode_string}".html_safe
     end
   end
 

--- a/app/views/forms/page/show.html.erb
+++ b/app/views/forms/page/show.html.erb
@@ -12,7 +12,7 @@
       <% if @step.question&.errors&.any? %>
         <%= form.govuk_error_summary %>
       <% end %>
-        <%= render :partial => ActiveSupport::Inflector.underscore(@step.question.model_name.name), :locals => { :page => @step, :form => form } %>
+        <%== render :partial => ActiveSupport::Inflector.underscore(@step.question.model_name.name), :locals => { :page => @step, :form => form } %>
       <%= form.govuk_submit %>
     <% end %>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
 
+    context "with unsafe question text" do
+      it "returns the escaped title with the optional suffix" do
+        page = OpenStruct.new(question_text: "What is your name? <script>alert(\"Hi\")</script>", question: OpenStruct.new(show_optional_suffix: false))
+        mode = OpenStruct.new(preview?: true, preview_draft?: true)
+        expected_output = "What is your name? &lt;script&gt;alert(&quot;Hi&quot;)&lt;/script&gt; <span class='govuk-visually-hidden'>&nbsp;draft preview</span>"
+        expect(helper.question_text_with_optional_suffix(page, mode)).to eq(expected_output)
+      end
+    end
+
     context "with a required question" do
       it "returns the title with the optional suffix" do
         page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(show_optional_suffix: false))


### PR DESCRIPTION
#### What problem does the pull request solve?
Preview draft/live were outputing escaped html for the mode which should have been visually hidden.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
