### PR TITLE
Convert text question partial to view component

### DIFF
--- a/app/components/question/base.rb
+++ b/app/components/question/base.rb
@@ -1,0 +1,18 @@
+module Question
+  class Base < ViewComponent::Base
+    attr_accessor :form_builder, :question, :extra_question_text_suffix
+
+    def initialize(form_builder:, question:, extra_question_text_suffix:)
+      @form_builder = form_builder
+      @question = question
+      @extra_question_text_suffix = extra_question_text_suffix
+      super
+    end
+
+    def question_text_with_extra_suffix
+      return question.question_text if extra_question_text_suffix.blank?
+
+      [question.question_text, extra_question_text_suffix.html_safe].compact.join(" ").html_safe
+    end
+  end
+end

--- a/app/components/question/base.rb
+++ b/app/components/question/base.rb
@@ -10,9 +10,7 @@ module Question
     end
 
     def question_text_with_extra_suffix
-      return question.question_text if extra_question_text_suffix.blank?
-
-      [question.question_text, extra_question_text_suffix.html_safe].compact.join(" ").html_safe
+      [CGI.escapeHTML(question.question_text), extra_question_text_suffix].compact_blank.join(" ").html_safe
     end
   end
 end

--- a/app/components/question/text_component/view.html.erb
+++ b/app/components/question/text_component/view.html.erb
@@ -1,0 +1,17 @@
+<% if question.answer_settings.input_type == "single_line" %>
+  <%= form_builder.govuk_text_field :text,
+                                    label: { tag: 'h1',
+                                             size: 'l',
+                                             text: question_text_with_extra_suffix
+                                    },
+                                    hint: { text: question.hint_text },
+                                    width: 'one-half' %>
+<% else %>
+  <%= form_builder.govuk_text_area :text,
+                                   label: { tag: 'h1',
+                                            size: 'l',
+                                            text:  question_text_with_extra_suffix
+                                   },
+                                   hint: { text: question.hint_text },
+                                   rows: 5 %>
+<% end %>

--- a/app/components/question/text_component/view.rb
+++ b/app/components/question/text_component/view.rb
@@ -1,0 +1,6 @@
+module Question
+  module TextComponent
+    class View < Question::Base
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,11 +25,7 @@ module ApplicationHelper
     mode_string = hidden_text_mode(mode)
     question = page.question.show_optional_suffix ? t("page.optional", question_text: page.question_text) : page.question_text
 
-    if mode_string.blank?
-      question
-    else
-      "#{CGI.escapeHTML(question)} #{mode_string}".html_safe
-    end
+    [CGI.escapeHTML(question), mode_string].compact_blank.join(" ").html_safe
   end
 
   def hidden_text_mode(mode)

--- a/app/views/forms/page/show.html.erb
+++ b/app/views/forms/page/show.html.erb
@@ -12,11 +12,16 @@
       <% if @step.question&.errors&.any? %>
         <%= form.govuk_error_summary %>
       <% end %>
-        <%== render :partial => ActiveSupport::Inflector.underscore(@step.question.model_name.name), :locals => { :page => @step, :form => form } %>
+      <% if @step.question.class.name =="Question::Text" %>
+        <% view_component = Object.const_get("#{@step.question.class.name}Component::View") %>
+        <%= render view_component.new(form_builder: form, question: @step.question, extra_question_text_suffix: hidden_text_mode(@mode).html_safe) %>
+      <% else %>
+        <%= render :partial => ActiveSupport::Inflector.underscore(@step.question.model_name.name), :locals => { :page => @step, :form => form } %>
+      <% end %>
+
       <%= form.govuk_submit %>
     <% end %>
 
     <%= render SupportDetailsComponent::View.new(@support_details) %>
-
   </div>
 </div>

--- a/app/views/question/_long_text.html.erb
+++ b/app/views/question/_long_text.html.erb
@@ -1,1 +1,0 @@
-<%= form.govuk_text_area :text, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode) }, hint: { text: page.hint_text }, rows: 5 %>

--- a/app/views/question/_single_line.html.erb
+++ b/app/views/question/_single_line.html.erb
@@ -1,1 +1,0 @@
-<%= form.govuk_text_field :text, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode) }, hint: { text: page.hint_text }, width: 'one-half' %>

--- a/app/views/question/_text.html.erb
+++ b/app/views/question/_text.html.erb
@@ -1,5 +1,0 @@
-<% if page.answer_settings.input_type == "single_line" %>
-  <%= form.govuk_text_field :text, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode) }, hint: { text: page.hint_text }, width: 'one-half' %>
-<% else %>
-  <%= form.govuk_text_area :text, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode) }, hint: { text: page.hint_text }, rows: 5 %>
-<% end %>

--- a/spec/components/question/text_component/text_component_preview.rb
+++ b/spec/components/question/text_component/text_component_preview.rb
@@ -1,0 +1,47 @@
+class Question::TextComponent::TextComponentPreview < ViewComponent::Preview
+  def short_text_field
+    question = OpenStruct.new(text: "This is a short answer text field",
+                              answer_type: "text",
+                              question_text: "Summary of your request",
+                              answer_settings: OpenStruct.new(input_type: "single_line"))
+    form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                                 ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+
+    render(Question::TextComponent::View.new(form_builder:, question:, extra_question_text_suffix: ""))
+  end
+
+  def short_text_field_with_hint
+    question = OpenStruct.new(text: "This is a short answer text field",
+                              answer_type: "text",
+                              question_text: "Summary of your request",
+                              hint_text: "Please be specific",
+                              answer_settings: OpenStruct.new(input_type: "single_line"))
+    form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                                 ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+
+    render(Question::TextComponent::View.new(form_builder:, question:, extra_question_text_suffix: ""))
+  end
+
+  def multiline_text_field
+    question = OpenStruct.new(text: "This is a multi-line answer text area. \n\n With examples",
+                              answer_type: "text",
+                              question_text: "Details of your request",
+                              answer_settings: OpenStruct.new)
+    form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                                 ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+
+    render(Question::TextComponent::View.new(form_builder:, question:, extra_question_text_suffix: nil))
+  end
+
+  def multiline_text_field_with_hints
+    question = OpenStruct.new(text: "This is a multi-line answer text area. \n\n With examples",
+                              answer_type: "text",
+                              question_text: "Details of your request",
+                              hint_text: "Add as much details are you like",
+                              answer_settings: OpenStruct.new)
+    form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                                 ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+
+    render(Question::TextComponent::View.new(form_builder:, question:, extra_question_text_suffix: nil))
+  end
+end

--- a/spec/components/question/text_component/view_spec.rb
+++ b/spec/components/question/text_component/view_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe Question::TextComponent::View, type: :component do
+  let(:question_page) { build :page, :with_text_settings, input_type: }
+  let(:input_type) { "single_line" }
+  let(:answer_text) { nil }
+  let(:question) { DataStruct.new(text: answer_text, question_text: question_page.question_text, hint_text: question_page.hint_text, answer_settings: question_page.answer_settings) }
+  let(:extra_question_text_suffix) { nil }
+  let(:form_builder) do
+    GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+  end
+
+  before do
+    render_inline(described_class.new(form_builder:, question:, extra_question_text_suffix:))
+  end
+
+  describe "when component is short answer text field" do
+    it "renders the question text as a heading" do
+      expect(page.find("h1")).to have_text(question.question_text)
+    end
+
+    it "renders a text input field" do
+      expect(page).to have_css("input[type='text'][name='form[text]']")
+    end
+
+    it "renders at one half the width of the parent container" do
+      expect(page.native.to_html).to include('class="govuk-input govuk-!-width-one-half"')
+    end
+
+    context "when the user has provided an answer" do
+      let(:answer_text) { Faker::Quote.yoda }
+
+      it "sets the field value" do
+        expect(page.find("input[type='text'][name='form[text]']").value).to eq answer_text
+      end
+    end
+
+    context "when the question has hint text" do
+      let(:question_page) { build :page, :with_hints, :with_text_settings, input_type: }
+
+      it "outputs the hint text" do
+        expect(page.find(".govuk-hint")).to have_text(question.hint_text)
+      end
+    end
+
+    context "when there is extra suffix to be added to heading" do
+      let(:extra_question_text_suffix) { "Some extra text to add to the question text" }
+
+      it "renders the question text and extra suffix as a heading" do
+        expect(page.find("h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+      end
+    end
+  end
+
+  describe "when component is multi-line answer" do
+    let(:input_type) { "long_text" }
+
+    it "renders the question text as a heading" do
+      expect(page.find("h1")).to have_text(question.question_text)
+    end
+
+    it "renders a textarea field" do
+      expect(page).to have_css("textarea[name='form[text]']")
+    end
+
+    it "renders textarea with 5 rows" do
+      expect(page).to have_css("textarea[rows='5']")
+    end
+
+    context "when the user has provided an answer" do
+      let(:answer_text) { Faker::Quote.yoda }
+
+      it "sets the field value" do
+        expect(page.find("textarea[name='form[text]']").value).to eq answer_text
+      end
+    end
+
+    context "when the question has hint text" do
+      let(:question_page) { build :page, :with_hints, :with_text_settings, input_type: }
+
+      it "outputs the hint text" do
+        expect(page.find(".govuk-hint")).to have_text(question.hint_text)
+      end
+    end
+
+    context "when there is extra suffix to be added to heading" do
+      let(:extra_question_text_suffix) { "Some extra text to add to the question text" }
+
+      it "renders the question text and extra suffix as a heading" do
+        expect(page.find("h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?
As part of this refactor it will mean that this answer type can now be easily ported to other apps because it doesn't rely on specific application specific code. There is only one dependency for it which is the govuk form builder gem.

Trello card: https://trello.com/c/mGqPIFkV/237-switch-the-runner-to-use-components-rather-than-partials

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
