### PR TITLE
Structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ bin/rake run_code_quality_checks
 
 Use the [update_app_versions.sh script in forms-deploy](https://github.com/alphagov/forms-deploy/blob/main/support/update_app_versions.sh)
 
+## Logging
+
+- HTTP access logs are managed using [Lograge](https://github.com/roidrage/lograge) and configured within [the application config](./config/application.rb)
+- Custom app logging should be made via the [LogEventService](./app/services/log_event_service.rb) and [EventLogger](./app/lib/event_logger.rb). This is
+independent to any Lograge configuration.
+- The output format is JSON using the [JsonLogFormatter](./app/lib/json_log_formatter.rb) to enable simpler searching and visbility especially in Splunk.
+- **DO NOT** use [log_tags](https://guides.rubyonrails.org/configuring.html#config-log-tags) since it breaks the JSON formatting produced by Lograge.
+
 ## Support
 
 Raise a Github issue if you need support.

--- a/app/lib/event_logger.rb
+++ b/app/lib/event_logger.rb
@@ -1,16 +1,16 @@
 class EventLogger
-  def self.log(tag, object)
-    Rails.logger.info "[#{tag}] #{object.to_json}"
+  def self.log(object)
+    Rails.logger.info object.to_json
   end
 
   def self.log_form_event(context, request, event)
-    item_to_log = {
+    log({
       url: request&.url,
       method: request&.method,
       form: context.form.name,
-    }
-
-    log("form_#{event}", item_to_log)
+      request_id: request&.request_id,
+      event: "form_#{event}",
+    })
   end
 
   def self.log_page_event(context, page, request, event, skipped_question)
@@ -20,10 +20,12 @@ class EventLogger
       form: context.form.name,
       question_text: page.question.question_text,
       question_number: page.page_number,
+      request_id: request&.request_id,
+      event: event.to_s,
     }
 
     item_to_log.merge!({ skipped_question: skipped_question.to_s }) unless skipped_question.nil?
 
-    log(event.to_s, item_to_log)
+    log(item_to_log)
   end
 end

--- a/app/lib/json_log_formatter.rb
+++ b/app/lib/json_log_formatter.rb
@@ -1,0 +1,23 @@
+class JsonLogFormatter < ActiveSupport::Logger::Formatter
+  def call(severity, timestamp, _progname, message)
+    log_event = {
+      level: severity,
+      time: timestamp,
+    }
+
+    if is_json(message)
+      log_event.merge!(JSON.parse(message))
+    else
+      log_event[:message] = message
+    end
+
+    "#{log_event.to_json}\n"
+  end
+
+  def is_json(message)
+    result = JSON.parse(message)
+    result.is_a?(Hash) || result.is_a?(Array)
+  rescue JSON::ParserError, TypeError
+    false
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ require "action_view/railtie"
 require "action_cable/engine"
 require "rails/test_unit/railtie"
 require "./app/lib/hosting_environment"
+require "./app/lib/json_log_formatter"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -46,5 +47,33 @@ module FormsRunner
     config.view_component.preview_controller = "ComponentPreviewController"
     # Replace with value which will be true in local dev and PAAS dev
     config.view_component.show_previews = HostingEnvironment.test_environment?
+
+    #### LOGGING CONFIGURATION ####
+
+    # Use JSON log formatter for better support in Splunk. To use conventional
+    # logging use the Logger::Formatter.new.
+    config.log_formatter = JsonLogFormatter.new
+
+    if ENV["RAILS_LOG_TO_STDOUT"].present?
+      config.logger = ActiveSupport::Logger.new($stdout)
+      config.logger.formatter = config.log_formatter
+    end
+
+    # Lograge is used to format the standard HTTP request logging
+    config.lograge.enabled = true
+    config.lograge.formatter = Lograge::Formatters::Json.new
+
+    # Lograge suppresses the default Rails request logging. Set this to true to
+    # make lograge output it which includes some extra debugging
+    # information.
+    config.lograge.keep_original_rails_log = false
+
+    config.lograge.custom_options = lambda do |event|
+      {}.tap do |h|
+        h[:host] = event.payload[:host]
+        h[:request_id] = event.payload[:request_id]
+        h[:form_id] = event.payload[:form_id] if event.payload[:form_id]
+      end
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,6 +73,7 @@ module FormsRunner
         h[:host] = event.payload[:host]
         h[:request_id] = event.payload[:request_id]
         h[:form_id] = event.payload[:form_id] if event.payload[:form_id]
+        h[:exception] = event.payload[:exception] if event.payload[:exception]
       end
     end
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,9 +52,6 @@ Rails.application.configure do
   # information to avoid inadvertent exposure of personally identifiable information (PII).
   config.log_level = :info
 
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -74,29 +71,4 @@ Rails.application.configure do
 
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require "syslog/logger"
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
-
-  config.lograge.enabled = true
-
-  config.lograge.custom_options = lambda do |event|
-    {}.tap do |h|
-      h[:host] = event.payload[:host]
-      h[:request_id] = event.payload[:request_id]
-      h[:form_id] = event.payload[:form_id] if event.payload[:form_id]
-    end
-  end
-
-  config.lograge.formatter = Lograge::Formatters::Json.new
 end

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -18,68 +18,65 @@ RSpec.describe EventLogger do
     OpenStruct.new({ url: "http://example.gov.uk", method: "GET" })
   end
 
-  let(:form_log_item) do
-    {
-      url: "http://example.gov.uk",
-      method: "GET",
-      form: form.name,
-    }
-  end
-
-  let(:page_log_item) do
-    {
-      url: "http://example.gov.uk",
-      method: "GET",
-      form: form.name,
-      question_number: page.id,
-      question_text: page.question_text,
-    }
-  end
-
   it "logs an event" do
     allow(Rails.logger).to receive(:info).at_least(:once)
 
-    described_class.log("page_save", { test: true })
+    described_class.log({ event: "page_save", test: true })
 
-    expect(Rails.logger).to have_received(:info).with("[page_save] {\"test\":true}")
+    expect(Rails.logger).to have_received(:info).with("{\"event\":\"page_save\",\"test\":true}")
   end
 
   it "logs a form event" do
     allow(described_class).to receive(:log).at_least(:once)
+    form_event = {
+      url: "http://example.gov.uk",
+      method: "GET",
+      form: form.name,
+      request_id: nil,
+      event: "form_visit",
+    }
 
     described_class.log_form_event(context, request, "visit")
 
-    expect(described_class).to have_received(:log).with("form_visit", form_log_item)
+    expect(described_class).to have_received(:log).with(form_event)
   end
 
   context "when completing a question" do
     it "logs a page event" do
       allow(described_class).to receive(:log).at_least(:once)
+      page_log_event = {
+        url: "http://example.gov.uk",
+        method: "GET",
+        form: form.name,
+        question_number: page.id,
+        question_text: page.question_text,
+        request_id: nil,
+        event: "page_save",
+      }
 
       described_class.log_page_event(context, OpenStruct.new(question: page, page_number: 1), request, "page_save", nil)
 
-      expect(described_class).to have_received(:log).with("page_save", page_log_item)
+      expect(described_class).to have_received(:log).with(page_log_event)
     end
   end
 
   context "when skipping an optional question" do
-    let(:page_log_item) do
-      {
+    it "logs a page event with a question_skipped parameter" do
+      allow(described_class).to receive(:log).at_least(:once)
+      page_log_event_with_skipped_questions = {
         url: "http://example.gov.uk",
         method: "GET",
         form: form.name,
         question_number: page.id,
         question_text: page.question_text,
         skipped_question: "true",
+        request_id: nil,
+        event: "optional_save",
       }
-    end
-
-    it "logs a page event with a question_skipped parameter" do
-      allow(described_class).to receive(:log).at_least(:once)
 
       described_class.log_page_event(context, OpenStruct.new(question: page, page_number: 1), request, "optional_save", true)
 
-      expect(described_class).to have_received(:log).with("optional_save", page_log_item)
+      expect(described_class).to have_received(:log).with(page_log_event_with_skipped_questions)
     end
   end
 end

--- a/spec/lib/json_log_formatter_spec.rb
+++ b/spec/lib/json_log_formatter_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+require_relative "../../app/lib/json_log_formatter"
+
+RSpec.describe JsonLogFormatter do
+  it "merges the JSON if message is JSON" do
+    input_json_message = { one: 1, two: 2 }.to_json
+    expected_output = "{\"level\":\"INFO\",\"time\":\"10:00\",\"one\":1,\"two\":2}\n"
+
+    expect(described_class.new.call("INFO", "10:00", "testing", input_json_message)).to eq(expected_output)
+  end
+
+  it "adds the message as message field if it is a string" do
+    input_message = "just a simple string"
+    expected_output = "{\"level\":\"INFO\",\"time\":\"10:00\",\"message\":\"just a simple string\"}\n"
+
+    expect(described_class.new.call("INFO", "10:00", "testing", input_message)).to eq(expected_output)
+  end
+
+  it "prints an empty message if message is empty" do
+    input_message = ""
+    expected_output = "{\"level\":\"INFO\",\"time\":\"10:00\",\"message\":\"\"}\n"
+
+    expect(described_class.new.call("INFO", "10:00", "testing", input_message)).to eq(expected_output)
+  end
+
+  it "prints a null message if message is nil" do
+    input_message = nil
+    expected_output = "{\"level\":\"INFO\",\"time\":\"10:00\",\"message\":null}\n"
+
+    expect(described_class.new.call("INFO", "10:00", "testing", input_message)).to eq(expected_output)
+  end
+end

--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Forms::BaseController, type: :request do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      allow(EventLogger).to receive(:log).at_least(:once)
+      allow(EventLogger).to receive(:log_form_event).at_least(:once)
       mock.get "/api/v1/forms/2#{api_url_suffix}", req_headers, form_response_data.to_json, 200
       mock.get "/api/v1/forms/9999#{api_url_suffix}", req_headers, no_data_found_response, 404
     end
@@ -80,7 +80,7 @@ RSpec.describe Forms::BaseController, type: :request do
   describe "#error_repeat_submission" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        allow(EventLogger).to receive(:log).at_least(:once)
+        allow(EventLogger).to receive(:log_form_event).at_least(:once)
         mock.get "/api/v1/forms/2/live", req_headers, form_response_data.to_json, 200
       end
 
@@ -110,7 +110,7 @@ RSpec.describe Forms::BaseController, type: :request do
             end
 
             it "does not log the form_visit event" do
-              expect(EventLogger).not_to have_received(:log)
+              expect(EventLogger).not_to have_received(:log_form_event)
             end
           end
 
@@ -186,7 +186,7 @@ RSpec.describe Forms::BaseController, type: :request do
             end
 
             it "does not log the form_visit event" do
-              expect(EventLogger).not_to have_received(:log)
+              expect(EventLogger).not_to have_received(:log_form_event)
             end
           end
 
@@ -262,7 +262,7 @@ RSpec.describe Forms::BaseController, type: :request do
             end
 
             it "Logs the form_visit event" do
-              expect(EventLogger).to have_received(:log).with("form_visit", { form: form_response_data.name, method: "GET", url: "http://www.example.com/form/2/#{form_response_data.form_slug}" })
+              expect(EventLogger).to have_received(:log_form_event).with(an_instance_of(Context), an_instance_of(ActionDispatch::Request), "visit")
             end
           end
 

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         before do
           post save_form_page_path("form", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
           post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "answer text" }, changing_existing_answer: false }
-          allow(EventLogger).to receive(:log).at_least(:once)
+          allow(EventLogger).to receive(:log_form_event).at_least(:once)
           get check_your_answers_path(mode: "form", form_id: 2, form_slug: form_data.form_slug)
         end
 
@@ -137,7 +137,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         end
 
         it "Logs the form_check_answers event" do
-          expect(EventLogger).to have_received(:log).with("form_check_answers", { form: form_data.name, method: "GET", url: "http://www.example.com/form/2/#{form_data.form_slug}/#{CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG}" })
+          expect(EventLogger).to have_received(:log_form_event).with(instance_of(Context), instance_of(ActionDispatch::Request), "check_answers")
         end
       end
 

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -362,36 +362,21 @@ RSpec.describe Forms::PageController, type: :request do
         end
 
         it "Logs the change_answer_page_save event" do
-          expect(EventLogger).to receive(:log).with("change_answer_page_save",
-                                                    { form: form_data.name,
-                                                      method: "POST",
-                                                      question_number: form_data.pages.first.position,
-                                                      question_text: form_data.pages.first.question_text,
-                                                      url: "http://www.example.com/form/2/#{form_data.form_slug}/1?changing_existing_answer=true&question%5Btext%5D=answer+text" })
+          expect(EventLogger).to receive(:log_page_event).with(instance_of(Context), instance_of(Step), instance_of(ActionDispatch::Request), "change_answer_page_save", nil)
           post save_form_page_path("form", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
         end
       end
 
       context "with the first page" do
         it "Logs the first_page_save event" do
-          expect(EventLogger).to receive(:log).with("first_page_save",
-                                                    { form: form_data.name,
-                                                      method: "POST",
-                                                      question_number: form_data.pages.first.position,
-                                                      question_text: form_data.pages.first.question_text,
-                                                      url: "http://www.example.com/form/2/#{form_data.form_slug}/1" })
+          expect(EventLogger).to receive(:log_page_event).with(instance_of(Context), instance_of(Step), instance_of(ActionDispatch::Request), "first_page_save", nil)
           post save_form_page_path("form", 2, form_data.form_slug, 1), params: { question: { text: "answer text" } }
         end
       end
 
       context "with a subsequent page" do
         it "Logs the page_save event" do
-          expect(EventLogger).to receive(:log).with("page_save",
-                                                    { form: form_data.name,
-                                                      method: "POST",
-                                                      question_number: form_data.pages.second.position,
-                                                      question_text: form_data.pages.second.question_text,
-                                                      url: "http://www.example.com/form/2/#{form_data.form_slug}/2" })
+          expect(EventLogger).to receive(:log_page_event).with(instance_of(Context), instance_of(Step), instance_of(ActionDispatch::Request), "page_save", nil)
           post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
         end
       end
@@ -408,27 +393,15 @@ RSpec.describe Forms::PageController, type: :request do
 
         context "when an optional question is completed" do
           it "Logs the optional_save event with skipped_question as true" do
-            expect(EventLogger).to receive(:log).with("optional_save",
-                                                      { form: form_data.name,
-                                                        method: "POST",
-                                                        question_number: form_data.pages.second.position,
-                                                        question_text: form_data.pages.second.question_text,
-                                                        skipped_question: "false",
-                                                        url: "http://www.example.com/form/2/#{form_data.form_slug}/2" })
-            post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+            expect(EventLogger).to receive(:log_page_event).with(instance_of(Context), instance_of(Step), instance_of(ActionDispatch::Request), "optional_save", true)
+            post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "" } }
           end
         end
 
         context "when an optional question is skipped" do
           it "Logs the optional_save event with skipped_question as false" do
-            expect(EventLogger).to receive(:log).with("optional_save",
-                                                      { form: form_data.name,
-                                                        method: "POST",
-                                                        question_number: form_data.pages.second.position,
-                                                        question_text: form_data.pages.second.question_text,
-                                                        skipped_question: "true",
-                                                        url: "http://www.example.com/form/2/#{form_data.form_slug}/2" })
-            post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "" } }
+            expect(EventLogger).to receive(:log_page_event).with(instance_of(Context), instance_of(Step), instance_of(ActionDispatch::Request), "optional_save", false)
+            post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
           end
         end
       end

--- a/spec/requests/forms/submit_answers_controller_spec.rb
+++ b/spec/requests/forms/submit_answers_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Forms::SubmitAnswersController, type: :request do
       mock.get "/api/v1/forms/2/live", req_headers, form_response_data.to_json, 200
     end
 
-    allow(EventLogger).to receive(:log).at_least(:once)
+    allow(EventLogger).to receive(:log_form_event).at_least(:once)
 
     allow(Context).to receive(:new).and_wrap_original do |original_method, *args|
       context_spy = original_method.call(form: args[0][:form], store:)
@@ -97,7 +97,7 @@ RSpec.describe Forms::SubmitAnswersController, type: :request do
       end
 
       it "does not log the form_submission event" do
-        expect(EventLogger).not_to have_received(:log)
+        expect(EventLogger).not_to have_received(:log_form_event)
       end
 
       it "emails the form submission" do
@@ -132,7 +132,7 @@ RSpec.describe Forms::SubmitAnswersController, type: :request do
       end
 
       it "Logs the form_submission event" do
-        expect(EventLogger).to have_received(:log).with("form_submission", { form: "Form name", method: "POST", url: "http://www.example.com/form/2/form-name/submit-answers.1" })
+        expect(EventLogger).to have_received(:log_form_event).with(instance_of(Context), instance_of(ActionDispatch::Request), "submission")
       end
 
       it "emails the form submission" do


### PR DESCRIPTION
#### What problem does the pull request solve?
Changes the log format to be entirely JSON format. This aids searching and reporting in Splunk since it is able to understand the structured log format and automatically extract each key for use. It also formats the log event with syntax highlighting making it simpler to understand.

Before the change:
![image](https://github.com/alphagov/forms-runner/assets/31340341/ca0a2445-8f09-41cf-a30c-39f10fb4f82a)


After the change in dev:
![image](https://github.com/alphagov/forms-runner/assets/31340341/b09ea27b-30b6-4182-bf02-de824e69f3df)

This also permits simpler splunk queries that make direct reference to any key without needing to first `rex` out content from the log event. E.g. 
```
index="*forms*" source="*forms-runner-dev*" event=form_submission
| stats count by form
```

### Notes on commits ###
- The first commit refactors the specs so that the request specs expect on the higher level logging functions without making direct reference to the output format which is an implementation detail from their concern.
-  The second commit introduces the JSON logging format.
- The third commit adds the exception field to the Lograge event if there is one, useful for tracing exceptions with user activity.

### Other things to Note ###
- Ideally I'd rather not rely on `rescue` from an exception in conditional logic but the `JsonLogFormatter#is_json` seems to be the idiomatic way of doing this from the various Rails solutions I've found.
- I have updated the README.md with details about the logging which should be read and understood as part of this review.

- The Lograge and common logging configuration has been moved into `config/application.rb` since we favour keeping environments common, it also makes it simpler to develop on the log format without needing to make changes (previously Lograge wasn't enabled for non-production environments). It would be possible to toggle between JSON and positional logging formats for local dev if there's preference based upon ENV vars. If that's something people want then it can be added in a later PR.
- **Limitation** the initial start up logs from Puma are not in JSON format since they do not seemingly use the logger configured in the application config. e.g. 
```
Puma starting in single mode...
```
- From some experimentation exceptions are logged thus, seen in development environment. This seems a benefit since the exception message appears in a single event under the `message` key with `level: FATAL` making them easier to find. Note there is a ticket to make this happen: https://trello.com/c/ZGYPzwJP/80-prevent-splunk-from-splitting-logs
```
{ [-]
   level: FATAL
   message:   
ActionView::Template::Error (undefined method `name' for 1:Integer):
    1: <% if @render_args[:component] %>
    2:   <% if ViewComponent::Base.config.render_monkey_patch_enabled || Rails.version.to_f >= 6.1 %>
    3:     <%= render(@render_args[:component], @render_args[:args], &@render_args[:block]) %>
    4:   <% else %>
    5:     <%= render_component(@render_args[:component], &@render_args[:block]) %>
    6:   <% end %>
  
app/components/form_header_component/view.rb:13:in `call'
   time: 2023-07-14T15:33:13.834+00:00
}
```
- This change does not appear to change the Sentry behaviour, the corresponding Sentry event for the exception log above can be viewed here: https://govuk-forms.sentry.io/issues/4315463747/?project=6576261&query=is%3Aunresolved&referrer=issue-stream&stream_index=0
- Lograge is configured to include the exception message if one occurs. This message includes the usual lograge fields and makes it simple to link the exception to the client activity via the request_id
```
{ [-]
   action: save
   controller: Forms::PageController
   duration: 0.59
   exception: [ [-]
     ActionController::InvalidAuthenticityToken
     Can't verify CSRF token authenticity.
   ]
   form_id: 119
   format: html
   host: submit.dev.forms.service.gov.uk
   level: INFO
   method: POST
   path: /preview-draft/119/a-test-form/182
   request_id: 58b528ed-779f-4011-830a-0348ead25137
   status: 422
   time: 2023-07-17T15:07:45.635+00:00
   view: 0
}
```

### How to Test ###
- You can run this locally and see the logs in JSON format.
- **This is currently deployed in dev environment.** You can search for [runner logs in dev in Splunk](https://gds.splunkcloud.com/en-GB/app/gds-543-forms/search?q=search%20index%3D%22*forms*%22%20source%3D%22*forms-runner-dev*%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=%40d&latest=now&display.page.search.tab=events&display.general.type=events&sid=1689590083.560392)

### Implications on existing Reporting ###
Before I merge I'll speak with @AnneCarr to make sure any reports are updated accordingly.


#### Checklist
Trello card: https://trello.com/c/VSdLnRsI/130-firebreak-convert-logs-to-json-structured

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [x] I've updated the documentation in (If any documentation requires updating)
  - [x] README.md
  - [ ] Elsewhere (please link)
