### PR TITLE
Convert National Insurance Number to component

### DIFF
--- a/app/components/question/national_insurance_number_component/view.html.erb
+++ b/app/components/question/national_insurance_number_component/view.html.erb
@@ -1,0 +1,6 @@
+<%= form_builder.govuk_text_field :national_insurance_number,
+                          label: { tag: 'h1', size: 'l', text: question_text_with_extra_suffix },
+                          hint: { text: question.hint_text },
+                          width: 10,
+                          spellcheck: false
+%>

--- a/app/components/question/national_insurance_number_component/view.rb
+++ b/app/components/question/national_insurance_number_component/view.rb
@@ -1,0 +1,6 @@
+module Question
+  module NationalInsuranceNumberComponent
+    class View < Question::Base
+    end
+  end
+end

--- a/app/views/forms/page/show.html.erb
+++ b/app/views/forms/page/show.html.erb
@@ -12,7 +12,7 @@
       <% if @step.question&.errors&.any? %>
         <%= form.govuk_error_summary %>
       <% end %>
-      <% if @step.question.class.name.in?(%w[Question::Text Question::Number]) %>
+      <% if @step.question.class.name.in?(%w[Question::Text Question::Number Question::NationalInsuranceNumber]) %>
         <% view_component = Object.const_get("#{@step.question.class.name}Component::View") %>
         <%= render view_component.new(form_builder: form, question: @step.question, extra_question_text_suffix: hidden_text_mode(@mode).html_safe) %>
       <% else %>

--- a/app/views/question/_national_insurance_number.html.erb
+++ b/app/views/question/_national_insurance_number.html.erb
@@ -1,1 +1,0 @@
-<%= form.govuk_text_field :national_insurance_number, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode) }, hint: { text: page.hint_text }, width: 10, spellcheck: false %>

--- a/spec/components/question/national_insurance_number_component/national_insurance_number_component_preview.rb
+++ b/spec/components/question/national_insurance_number_component/national_insurance_number_component_preview.rb
@@ -1,0 +1,24 @@
+class Question::NationalInsuranceNumberComponent::NationalInsuranceNumberComponentPreview < ViewComponent::Preview
+  def national_insurance_number_field
+    question = OpenStruct.new(national_insurance_number: "AB 123456 C",
+                              answer_type: "national_insurance_number",
+                              question_text: "What is your NI number?",
+                              answer_settings: nil)
+    form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                                 ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+
+    render(Question::NationalInsuranceNumberComponent::View.new(form_builder:, question:, extra_question_text_suffix: ""))
+  end
+
+  def national_insurance_number_field_with_hint
+    question = OpenStruct.new(national_insurance_number: "AB 123456 C",
+                              answer_type: "national_insurance_number",
+                              question_text: "What is your NI number?",
+                              hint_text: "eg. AB 12 34 56 C",
+                              answer_settings: nil)
+    form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                                 ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+
+    render(Question::NationalInsuranceNumberComponent::View.new(form_builder:, question:, extra_question_text_suffix: ""))
+  end
+end

--- a/spec/components/question/national_insurance_number_component/view_spec.rb
+++ b/spec/components/question/national_insurance_number_component/view_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe Question::NationalInsuranceNumberComponent::View, type: :component do
+  let(:question_page) { build :page, answer_type: "national_insurance_number" }
+  let(:answer_text) { nil }
+  let(:question) { DataStruct.new(national_insurance_number: answer_text, question_text: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:extra_question_text_suffix) { nil }
+  let(:form_builder) do
+    GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+  end
+
+  before do
+    render_inline(described_class.new(form_builder:, question:, extra_question_text_suffix:))
+  end
+
+  describe "when component is national insurance number field" do
+    it "renders the question text as a heading" do
+      expect(page.find("h1")).to have_text(question.question_text)
+    end
+
+    it "renders a text input field" do
+      expect(page).to have_css("input[type='text'][name='form[national_insurance_number]']")
+    end
+
+    it "renders at 10-character width (https://design-system.service.gov.uk/components/text-input/#fixed-width-inputs)" do
+      expect(page.native.to_html).to include('class="govuk-input govuk-input--width-10"')
+    end
+
+    context "when the user has provided an answer" do
+      let(:answer_text) { 8 }
+
+      it "sets the field value" do
+        expect(page.find("input[type='text'][name='form[national_insurance_number]']").value).to eq answer_text.to_s
+      end
+    end
+
+    context "when the question has hint text" do
+      let(:question_page) { build :page, :with_hints, answer_type: "national_insurance_number" }
+
+      it "outputs the hint text" do
+        expect(page.find(".govuk-hint")).to have_text(question.hint_text)
+      end
+    end
+
+    context "when there is extra suffix to be added to heading" do
+      let(:extra_question_text_suffix) { "Some extra text to add to the question text" }
+
+      it "renders the question text and extra suffix as a heading" do
+        expect(page.find("h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+      end
+    end
+
+    context "with unsafe question text" do
+      let(:question_page) { build :page, answer_type: "number", question_text: "What is your name? <script>alert(\"Hi\")</script>" }
+      let(:extra_question_text_suffix) { "<span>Some trusted html</span>" }
+
+      it "returns the escaped title with the optional suffix" do
+        expected_output = "What is your name? &lt;script&gt;alert(\"Hi\")&lt;/script&gt; <span>Some trusted html</span>"
+        expect(page.find("h1 .govuk-label").native.inner_html).to eq(expected_output)
+      end
+    end
+  end
+end

--- a/spec/components/question/number_component/number_component_preview.rb
+++ b/spec/components/question/number_component/number_component_preview.rb
@@ -14,6 +14,7 @@ class Question::NumberComponent::NumberComponentPreview < ViewComponent::Preview
     question = OpenStruct.new(number: "7",
                               answer_type: "number",
                               question_text: "Number of days in a week",
+                              hint_text: "Number after 6",
                               answer_settings: nil)
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})


### PR DESCRIPTION
#### What problem does the pull request solve?
As part of this refactor it will mean that this answer type can now be easily ported to other apps because it doesn't rely on specific application specific code. There is only one dependency for it which is the govuk form builder gem.

Trello card:  https://trello.com/c/mGqPIFkV/237-switch-the-runner-to-use-components-rather-than-partials

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
