### PR TITLE
Add automated accessibility tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,9 @@ group :test do
   gem "selenium-webdriver"
   gem "simplecov"
   gem "webdrivers"
+
+  # axe-core for running automated accessibility checks
+  gem "axe-core-rspec"
 end
 
 # For security auditing gem vulnerabilities. RUN IN CI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,9 +74,20 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    axe-core-api (4.7.0)
+      dumb_delegator
+      virtus
+    axe-core-rspec (4.7.0)
+      axe-core-api
+      dumb_delegator
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     better_html (2.0.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -92,7 +103,7 @@ GEM
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
-    capybara (3.37.1)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -102,6 +113,8 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.2.2)
     config (4.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -112,6 +125,8 @@ GEM
       irb (>= 1.3.6)
       reline (>= 0.3.1)
     deep_merge (1.2.2)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dotenv (2.7.6)
@@ -151,6 +166,7 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
+    dumb_delegator (1.0.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -189,6 +205,7 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
+    ice_nine (0.11.2)
     io-console (0.5.11)
     irb (1.4.1)
       reline (>= 0.3.0)
@@ -237,7 +254,7 @@ GEM
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
-    public_suffix (4.0.7)
+    public_suffix (5.0.3)
     puma (6.3.0)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -287,7 +304,7 @@ GEM
     redis-session-store (0.11.5)
       actionpack (>= 6, < 8)
       redis (>= 3, < 6)
-    regexp_parser (2.8.0)
+    regexp_parser (2.8.1)
     reline (0.3.1)
       io-console (~> 0.5)
     request_store (1.5.1)
@@ -361,6 +378,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.2)
+    thread_safe (0.3.6)
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -372,6 +390,10 @@ GEM
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     vite_rails (3.0.15)
       railties (>= 5.1, < 8)
       vite_ruby (~> 3.0, >= 3.2.2)
@@ -407,6 +429,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeresource
+  axe-core-rspec
   bootsnap
   brakeman (~> 6.0)
   bundler-audit (~> 0.9.0)

--- a/app/components/main_component/view.rb
+++ b/app/components/main_component/view.rb
@@ -2,14 +2,15 @@
 
 module MainComponent
   class View < ViewComponent::Base
-    def initialize(mode:, is_question: false)
+    def initialize(mode:, is_question: false, is_component_preview: false)
       super
       @mode = mode
       @is_question = is_question
+      @is_component_preview = is_component_preview
     end
 
     def call
-      tag.main(class: "govuk-main-wrapper #{mode_class} #{is_question_class}", id: "main-content", role: "main") do
+      tag.main(class: "govuk-main-wrapper #{mode_class} #{is_question_class}", id: @is_component_preview ? nil : "main-content", role: "main") do
         content
       end
     end

--- a/app/controllers/component_preview_controller.rb
+++ b/app/controllers/component_preview_controller.rb
@@ -1,0 +1,11 @@
+class ComponentPreviewController < ApplicationController
+  include ViewComponent::PreviewActions
+
+  layout :component_layout
+
+private
+
+  def component_layout
+    action_name == "index" ? "application" : "base"
+  end
+end

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -1,6 +1,6 @@
 <% set_page_title(form_title(form_name: @current_context.form.name, page_name: t('form.check_your_answers.title'), mode: @mode)) %>
 
-<% content_for :before_content do %>
+<% content_for :back_link do %>
   <% if @back_link %>
     <%= link_to "Back", @back_link, class: "govuk-back-link" %>
   <% end %>

--- a/app/views/forms/page/show.html.erb
+++ b/app/views/forms/page/show.html.erb
@@ -1,6 +1,6 @@
 <% set_page_title(form_title(form_name: @current_context.form.name, page_name: @step.question_text, mode: @mode, error: @step.question&.errors&.any?)) %>
 
-<% content_for :before_content do %>
+<% content_for :back_link do %>
   <% if @back_link.present? %>
     <%= link_to "Back", @back_link, class: "govuk-back-link" %>
   <% end %>

--- a/app/views/forms/privacy_page/show.html.erb
+++ b/app/views/forms/privacy_page/show.html.erb
@@ -1,6 +1,6 @@
 <% set_page_title(form_title(form_name: @current_context.form.name, page_name: 'Privacy', mode: @mode)) %>
 
-<% content_for :before_content do %>
+<% content_for :back_link do %>
   <% if @back_link.present? %>
     <%= link_to "Back", @back_link, class: "govuk-back-link" %>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,49 +1,18 @@
-<!DOCTYPE html>
-<html lang="en" class="govuk-template ">
-  <head>
-    <meta charset="utf-8">
-    <title><%= page_title %></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="theme-color" content="#0b0c0c">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
 
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+<% content_for :skip_link do %>
+  <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<% end %>
 
-    <link rel="shortcut icon" type="image/x-icon" href="<%= vite_asset_path "#{govuk_assets_path}/images/favicon.ico"%>" sizes="16x16 32x32 48x48" />
-    <link rel="mask-icon" href="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-mask-icon.svg"%>" color="#0b0c0c" />
-    <link rel="apple-touch-icon" href="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-apple-touch-icon-180x180.png"%>" sizes="180x180" />
-    <link rel="apple-touch-icon" href="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-apple-touch-icon-167x167.png"%>" sizes="167x167" />
-    <link rel="apple-touch-icon" href="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-apple-touch-icon-152x152.png"%>" sizes="152x152" />
-    <link rel="apple-touch-icon" href="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-apple-touch-icon.png"%>" />
-    <meta property="og:image" content="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-opengraph-image.png" %>">
+<% content_for :header do %>
+  <%= render(FormHeaderComponent::View.new(current_context: @current_context, mode: @mode)) %>
+<% end %>
 
-    <%= vite_stylesheet_tag 'application.scss' %>
+<% content_for :before_content do %>
+  <%= render(PreviewComponent::View.new(mode: @mode, question_edit_link: @question_edit_link)) %>
+  <%= yield :back_link %>
+<% end %>
 
-  </head>
-
-  <body class="govuk-template__body ">
-    <script>
-      if ('noModule' in HTMLScriptElement.prototype) {
-        document.body.classList
-          .add('js-enabled')
-      }
-    </script>
-
-    <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-
-    <%= render(FormHeaderComponent::View.new(current_context: @current_context, mode: @mode)) %>
-
-    <div class="govuk-width-container ">
-      <%= render(PreviewComponent::View.new(mode: @mode, question_edit_link: @question_edit_link)) %>
-
-      <%= yield(:before_content) %>
-
-      <%= render(MainComponent::View.new(mode: @mode, is_question: @is_question)) do %>
-        <%= yield %>
-      <% end %>
-
-    </div>
+<% content_for :footer do %>
 
     <% meta_links = {t("footer.accessibility_statement") => accessibility_statement_path, t("footer.cookies") => cookies_path} %>
     <% if @current_context.present? %>
@@ -51,8 +20,6 @@
     <% end -%>
 
     <%= govuk_footer meta_items_title: t("footer.helpful_links"), meta_items: meta_links %>
+<% end %>
 
-    <%= vite_client_tag %>
-    <%= vite_javascript_tag 'application' %>
-  </body>
-</html>
+<%= render template: "layouts/base" %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template ">
+  <head>
+    <meta charset="utf-8">
+    <title><%= page_title %></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <link rel="shortcut icon" type="image/x-icon" href="<%= vite_asset_path "#{govuk_assets_path}/images/favicon.ico"%>" sizes="16x16 32x32 48x48" />
+    <link rel="mask-icon" href="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-mask-icon.svg"%>" color="#0b0c0c" />
+    <link rel="apple-touch-icon" href="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-apple-touch-icon-180x180.png"%>" sizes="180x180" />
+    <link rel="apple-touch-icon" href="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-apple-touch-icon-167x167.png"%>" sizes="167x167" />
+    <link rel="apple-touch-icon" href="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-apple-touch-icon-152x152.png"%>" sizes="152x152" />
+    <link rel="apple-touch-icon" href="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-apple-touch-icon.png"%>" />
+    <meta property="og:image" content="<%= vite_asset_path "#{govuk_assets_path}/images/govuk-opengraph-image.png" %>">
+
+    <%= vite_stylesheet_tag 'application.scss' %>
+
+  </head>
+
+  <body class="govuk-template__body ">
+    <script>
+      if ('noModule' in HTMLScriptElement.prototype) {
+        document.body.classList
+          .add('js-enabled')
+      }
+    </script>
+
+    <%= yield :skip_link %>
+
+    <%= yield :header %>
+
+    <div class="govuk-width-container ">
+      <%= yield(:before_content) %>
+
+      <%= render(MainComponent::View.new(mode: @mode, is_question: @is_question)) do %>
+        <%= yield %>
+      <% end %>
+    </div>
+
+    <%= yield :footer %>
+
+    <%= vite_client_tag %>
+    <%= vite_javascript_tag 'application' %>
+  </body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,7 @@ module FormsRunner
     config.exceptions_app = routes
     config.view_component.preview_paths = [Rails.root.join("spec/components")]
     config.view_component.preview_route = "/preview"
+    config.view_component.preview_controller = "ComponentPreviewController"
     # Replace with value which will be true in local dev and PAAS dev
     config.view_component.show_previews = HostingEnvironment.test_environment?
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,4 +59,7 @@ Rails.application.configure do
   # Allow storing session in cookies. This should only be allowed in local
   # development and testing. In production redis should be used
   config.unsafe_session_storage = true
+
+  # Allow previews so we can run feature tests against components
+  config.view_component.show_previews = true
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,3 +27,6 @@ maintenance_mode:
   bypass_ips:
 
 forms_env: local
+
+# When set to true, any capybara tests will run chrome normally rather than in headless mode.
+show_browser_during_tests: false

--- a/spec/components/form_header_component/form_header_component_preview.rb
+++ b/spec/components/form_header_component/form_header_component_preview.rb
@@ -1,19 +1,19 @@
 class FormHeaderComponent::FormHeaderComponentPreview < ViewComponent::Preview
   def default
     mode = Mode.new
-    current_context = OpenStruct.new(form: 1, form_name: "test", form_slug: "test")
+    current_context = OpenStruct.new(form: OpenStruct.new(id: 1, name: "test"), form_slug: "test")
     render(FormHeaderComponent::View.new(current_context:, mode:, service_url_overide: "/form/1/test"))
   end
 
   def preview_draft
     mode = Mode.new("preview-draft")
-    current_context = OpenStruct.new(form: 1, form_name: "test", form_slug: "test")
+    current_context = OpenStruct.new(form: OpenStruct.new(id: 1, name: "test"), form_slug: "test")
     render(FormHeaderComponent::View.new(current_context:, mode:, service_url_overide: "/form/1/test"))
   end
 
   def preview_live
     mode = Mode.new("preview-live")
-    current_context = OpenStruct.new(form: 1, form_name: "test", form_slug: "test")
+    current_context = OpenStruct.new(form: OpenStruct.new(id: 1, name: "test"), form_slug: "test")
     render(FormHeaderComponent::View.new(current_context:, mode:, service_url_overide: "/form/1/test"))
   end
 end

--- a/spec/components/main_component/main_component_preview.rb
+++ b/spec/components/main_component/main_component_preview.rb
@@ -1,28 +1,28 @@
 class MainComponent::MainComponentPreview < ViewComponent::Preview
   def deafult
-    render(MainComponent::View.new(mode: nil))
+    render(MainComponent::View.new(mode: nil, is_component_preview: true))
   end
 
   def draft_preview
-    render(MainComponent::View.new(mode: "preview-draft")) do
+    render(MainComponent::View.new(mode: "preview-draft", is_component_preview: true)) do
       Array.new(10) { content_tag(:p, "This is the draft preview example content.") }.join.html_safe
     end
   end
 
   def live_preview
-    render(MainComponent::View.new(mode: "preview-live")) do
+    render(MainComponent::View.new(mode: "preview-live", is_component_preview: true)) do
       Array.new(10) { content_tag(:p, "This is the live preview example content.") }.join.html_safe
     end
   end
 
   def draft_preview_question
-    render(MainComponent::View.new(mode: "preview-draft", is_question: true)) do
+    render(MainComponent::View.new(mode: "preview-draft", is_question: true, is_component_preview: true)) do
       Array.new(10) { content_tag(:p, "This is the draft preview example content for question pages.") }.join.html_safe
     end
   end
 
   def live_preview_question
-    render(MainComponent::View.new(mode: "preview-live", is_question: true)) do
+    render(MainComponent::View.new(mode: "preview-live", is_question: true, is_component_preview: true)) do
       Array.new(10) { content_tag(:p, "This is the live preview example content for question pages.") }.join.html_safe
     end
   end

--- a/spec/features/components/preview_components_spec.rb
+++ b/spec/features/components/preview_components_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe "Previewing components", type: :feature do
+  it "checks all component previews for axe errors" do
+    visit "/preview/"
+    links = page.all("li > a").map { |a| a["href"] }
+    links.each do |link|
+      visit link
+      expect_component_to_have_no_axe_errors(page)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,7 @@
 require "spec_helper"
 require "view_component/test_helpers"
 require "capybara/rspec"
+require "selenium/webdriver"
 require "axe-rspec"
 
 ENV["RAILS_ENV"] ||= "test"
@@ -13,6 +14,8 @@ Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
+
+require_relative "support/capybara_headless_chrome"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,8 @@
 require "spec_helper"
 require "view_component/test_helpers"
 require "capybara/rspec"
+require "axe-rspec"
+
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 # Prevent database truncation if the environment is production

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require_relative "support/factorybot"
+require_relative "support/axe_feature_helpers"
 require "simplecov"
 
 SimpleCov.formatters = [

--- a/spec/support/axe_feature_helpers.rb
+++ b/spec/support/axe_feature_helpers.rb
@@ -1,0 +1,13 @@
+module AxeFeatureHelpers
+  def expect_page_to_have_no_axe_errors(page)
+    expect(page).to be_axe_clean.according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa)
+  end
+
+  def expect_component_to_have_no_axe_errors(page)
+    expect(page).to be_axe_clean.within("#main-content").according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa)
+  end
+end
+
+RSpec.configure do |config|
+  config.include AxeFeatureHelpers, type: :feature
+end

--- a/spec/support/capybara_headless_chrome.rb
+++ b/spec/support/capybara_headless_chrome.rb
@@ -1,0 +1,43 @@
+require "selenium/webdriver"
+
+options = Selenium::WebDriver::Chrome::Options.new
+options.add_preference(:download, prompt_for_download: false,
+                                  default_directory: "/tmp/downloads")
+
+options.add_preference(:browser, set_download_behavior: { behavior: "allow" })
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
+end
+
+Capybara.register_driver :headless_chrome do |app|
+  options.add_argument("--headless")
+  options.add_argument("--disable-gpu")
+  options.add_argument("--window-size=1280,1024")
+  options.add_argument("--no-sandbox")
+  options.add_argument("--disable-dev-shm-usage")
+
+  driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
+
+  ### Allow file downloads in Google Chrome when headless!!!
+  ### https://bugs.chromium.org/p/chromium/issues/detail?id=696481#c89
+  bridge = driver.browser.send(:bridge)
+
+  path = "/session/:session_id/chromium/send_command"
+  path[":session_id"] = bridge.session_id
+
+  bridge.http.call(:post, path, cmd: "Page.setDownloadBehavior",
+                                params: {
+                                  behavior: "allow",
+                                  downloadPath: "/tmp/downloads",
+                                })
+  ###
+
+  driver
+end
+
+Capybara.default_driver = Settings.show_browser_during_tests ? :chrome : :headless_chrome
+
+Capybara.configure do |config|
+  config.automatic_label_click = true
+end


### PR DESCRIPTION
### What problem does the pull request solve?
- Adds axe-core-rspec for running automated accessibilty checks in our tests (see gem info below)
- Adds a feature tests to our existing components, which runs against the component previews and checks for accessibility issues. 
- Adds a couple of convenience methods:
  - Inside an `it "..." do` block within a feature test, you can use the methods `expect_page_to_have_no_axe_errors(page)` and `expect_component_to_have_no_axe_errors(page)` to assert that the page or component the browser is currently on doesn't have any errors.
- Adds a `base` layout which all component previews now use by default. The `application.html.erb` layout now inherits from this base layout

Trello card: https://trello.com/c/BARdutlj/916-explore-adding-automated-accessibility-tests

### New gem assessment
This PR adds a new gem, [axe-core-rspec](https://rubygems.org/gems/axe-core-rspec). To review the gem I looked at its stats on [ruby-toolbox.com](https://ruby-toolbox.com/), and also checked security issues using GitHub Security Advisories and the [snyk.io vulnerability database](https://security.snyk.io/).

The gem is maintained by Deque Systems, a major accessibility organisation which also develops the underlying axe-core library that this gem uses.

#### Does it solve a specific problem we have?
Yes, it lets us run automated accessibility tests within our Capybara feature tests. 
#### Is it updated regularly?
Yes, 16 releases so far this year
#### Is it widely used?
Somewhat - 2,973,244 downloads
#### Is it well documented?
The documentation is good, given the limited API of the gem.
#### Does it have any major security issues?
None that I could see.
#### Would writing the code ourselves have a better outcome?
Unlikely - we'd almost certainly still end up using Deque's underlying axe-core library, so we'd still have a dependency on Deque's code and wouldn't gain much. 
#### How much hassle would it be if this gem stopped being maintained?
Some, but not a lot. We would have to rewrite our accessibility tests in another framework (e.g. using jest-axe or a similar library) and we'd likely lose the convenience of having our accessibility tests integrated with our other rspec tests, but that doesn't feel like a major disadavantage.

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
