### PR TITLE
Bump Node Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apk update
 RUN apk upgrade --available
-RUN apk add libc6-compat openssl-dev build-base libpq-dev nodejs=~18.16 npm
+RUN apk add libc6-compat openssl-dev build-base libpq-dev nodejs=~18 npm
 RUN adduser -D ruby
 RUN mkdir /node_modules && chown ruby:ruby -R /node_modules /app
 


### PR DESCRIPTION
Node is used to compile the front end assets in the first stage of the docker build process. Pin to the version 18 major release but allow pulling of the current minor and patch based upon that available in the Alpine package repo.

#### What problem does the pull request solve?
Fixes failing docker build https://github.com/alphagov/forms-runner/actions/runs/5598875560/jobs/10239113773?pr=371#step:3:60

Note that 18.16 is no longer available: https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.18&repo=&arch=&maintainer=

Correctly installs 18.17 https://github.com/alphagov/forms-runner/actions/runs/5598999056/jobs/10239396992?pr=376#step:3:91

It seems appropriate to pin to the major version but flex on minor and patches to the latest available on Alpine.