### PR TITLE
Parallelize test and lint actions

### DIFF
--- a/.github/workflows/setup_rails/action.yml
+++ b/.github/workflows/setup_rails/action.yml
@@ -1,0 +1,16 @@
+name: "Ruby on Rails setup"
+description: "Installs Ruby, installs frontend and backend dependencies, then runs the frontend build"
+runs:
+  using: "composite"
+  steps:
+    # The ruby version is taken from the .ruby-version file, no need to specify here.
+    - name: Install Ruby and gems
+      uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939
+      with:
+        bundler-cache: true
+    - name: Install frontend dependencies
+      run: npm ci
+      shell: bash
+    - name: Run Frontend build
+      run: bin/vite build
+      shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,19 +21,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      # Add or replace dependency steps here
-      # The ruby version is taken from the .ruby-version file, no need to specify here.
-      - name: Install Ruby and gems
-        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939
-        with:
-          bundler-cache: true
-      - name: Install frontend dependencies
-        run: npm ci
-      - name: Run Frontend build
-        run: bin/vite build
+      - name: Setup Rails
+        uses: ./.github/workflows/setup_rails
       # Add or replace test runners here
       - name: Run tests
         run: bundle exec rspec
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup Rails
+        uses: ./.github/workflows/setup_rails
       # Add or replace any other lints here
       - name: Security audit dependencies
         run: bundler exec bundle audit check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
       # Add or replace test runners here
       - name: Run tests
         run: bundle exec rspec
+      - name: Run Jest tests
+        run: npm test
   lint:
     runs-on: ubuntu-latest
     env:

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/vendor/'],
+  passWithNoTests: true
+}


### PR DESCRIPTION
#### What problem does the pull request solve?
Having the different bits of the `build_and_test` task run in parallel should speed them up (since they're not running in series) and make it clearer which task(s) are failing.

To accomplish that, this PR:
- Moves the linting / static analysis tasks into a new job `lint`
- Adds the jest tests to the `build_and_test` job (we don't have any Jest tests in this repo yet, because we haven't written any custom JS here, so there's no point it having its own action)
- Allows the `build_and_test` and `lint` jobs to run in parallel, which should make them slightly quicker 
- Creates a new [composite workflow](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) `build/action.yml` which allows us to run the common rails setup tasks before jobs rather than write them out every time

If we do this we should also update the branch protection settings to require the new tasks to pass before a PR can be merged.

#### Checklist

- [x] I've used the pull request template
- [n/a] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
