### PR TITLE
Remove 404 link from accessibility_statement.html.erb

### DIFF
--- a/app/views/application/accessibility_statement.html.erb
+++ b/app/views/application/accessibility_statement.html.erb
@@ -4,11 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Accessibility statement for this form</h1>
     <p>
-      This accessibility statement contains information about this online form
-      available at
-      <a href="https://submit.forms.service.gov.uk"
-        >https://submit.forms.service.gov.uk</a
-      >.
+      This accessibility statement applies to online forms with a URL that starts with https://submit.forms.service.gov.uk.
     </p>
 
     <p class="govuk-inset-text">


### PR DESCRIPTION
The link to https://submit.forms.service.gov.uk goes to a 404. 

The purpose of this URL is to make it clear what the accessibility statement applies to, rather than being a link people need to follow.

So this change makes that clearer and removes the active link.

#### What problem does the pull request solve?

Trello card:https://trello.com/c/6sHINqj1/971-fix-broken-link-on-accessibility-statement-for-individual-forms

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
