### PR TITLE
Fix missing optional copy in labels from components

### DIFF
--- a/app/components/question/base.rb
+++ b/app/components/question/base.rb
@@ -10,7 +10,7 @@ module Question
     end
 
     def question_text_with_extra_suffix
-      [CGI.escapeHTML(question.question_text), extra_question_text_suffix].compact_blank.join(" ").html_safe
+      [CGI.escapeHTML(question.question_text_with_optional_suffix), extra_question_text_suffix].compact_blank.join(" ").html_safe
     end
   end
 end

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -18,7 +18,7 @@ module Forms
   private
 
     def page_to_row(page)
-      question_name = helpers.question_text_with_optional_suffix(page, @mode)
+      question_name = helpers.question_text_with_optional_suffix_inc_mode(page, @mode)
       {
         key: { text: question_name },
         value: { text: page.show_answer },

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,9 +23,8 @@ module ApplicationHelper
 
   def question_text_with_optional_suffix_inc_mode(page, mode)
     mode_string = hidden_text_mode(mode)
-    question = page.question.show_optional_suffix ? "#{page.question_text} #{t('page.optional')}" : page.question_text
 
-    [CGI.escapeHTML(question), mode_string].compact_blank.join(" ").html_safe
+    [CGI.escapeHTML(page.question.question_text_with_optional_suffix), mode_string].compact_blank.join(" ").html_safe
   end
 
   def hidden_text_mode(mode)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
     "#{t('page_titles.error_prefix') if error}#{page_name}#{mode_string} - #{form_name}"
   end
 
-  def question_text_with_optional_suffix(page, mode)
+  def question_text_with_optional_suffix_inc_mode(page, mode)
     mode_string = hidden_text_mode(mode)
     question = page.question.show_optional_suffix ? t("page.optional", question_text: page.question_text) : page.question_text
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,7 +23,7 @@ module ApplicationHelper
 
   def question_text_with_optional_suffix_inc_mode(page, mode)
     mode_string = hidden_text_mode(mode)
-    question = page.question.show_optional_suffix ? t("page.optional", question_text: page.question_text) : page.question_text
+    question = page.question.show_optional_suffix ? "#{page.question_text} #{t('page.optional')}" : page.question_text
 
     [CGI.escapeHTML(question), mode_string].compact_blank.join(" ").html_safe
   end

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -40,7 +40,7 @@ module Question
     end
 
     def question_text_with_optional_suffix
-      return question_text unless is_optional?
+      return question_text unless show_optional_suffix
 
       "#{question_text} #{I18n.t('page.optional')}"
     end

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -38,5 +38,11 @@ module Question
     def show_optional_suffix
       is_optional?
     end
+
+    def question_text_with_optional_suffix
+      return question_text unless is_optional?
+
+      "#{question_text} #{I18n.t('page.optional')}"
+    end
   end
 end

--- a/app/views/question/_address.html.erb
+++ b/app/views/question/_address.html.erb
@@ -1,5 +1,5 @@
 
-<%= form.govuk_fieldset legend: { text: question_text_with_optional_suffix(page, @mode), tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-address-hint" : nil do %>
+<%= form.govuk_fieldset legend: { text: question_text_with_optional_suffix_inc_mode(page, @mode), tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-address-hint" : nil do %>
   <% if page.question.is_international_address? %>
     <% if page.hint_text.present? %>
       <p id="govuk-address-hint" class="govuk-hint"><%= page.hint_text %></p>

--- a/app/views/question/_name.html.erb
+++ b/app/views/question/_name.html.erb
@@ -1,7 +1,7 @@
 <% if page.question.is_full_name? && !page.question.needs_title? %>
-  <%= form.govuk_text_field :full_name, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode) }, hint: { text: page.hint_text }, autocomplete: "name" %>
+  <%= form.govuk_text_field :full_name, label: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix_inc_mode(page, @mode) }, hint: { text: page.hint_text }, autocomplete: "name" %>
 <% else %>
-  <%= form.govuk_fieldset legend: { text: question_text_with_optional_suffix(page, @mode), tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-name-hint" : nil do %>
+  <%= form.govuk_fieldset legend: { text: question_text_with_optional_suffix_inc_mode(page, @mode), tag: 'h1', size: 'l' }, "aria-describedby": page.hint_text.present? ? "govuk-name-hint" : nil do %>
     <% if page.hint_text.present? %>
       <p id="govuk-name-hint" class="govuk-hint"><%= page.hint_text %></p>
     <% end %>

--- a/app/views/question/_selection.html.erb
+++ b/app/views/question/_selection.html.erb
@@ -1,5 +1,5 @@
 <% if page.question.allow_multiple_answers? %>
-  <%= form.govuk_check_boxes_fieldset(:selection, legend: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode) }, hint: { text: page.hint_text }) do %>
+  <%= form.govuk_check_boxes_fieldset(:selection, legend: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix_inc_mode(page, @mode) }, hint: { text: page.hint_text }) do %>
     <% page.answer_settings.selection_options.each_with_index do |option, index| %>
       <%= form.govuk_check_box :selection, option.name, label: { text: option.name }, link_errors: index == 0  %>
     <% end %>
@@ -9,7 +9,7 @@
     <% end %>
   <% end %>
 <% else %>
-  <%= form.govuk_radio_buttons_fieldset(:selection, legend: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix(page, @mode) }, hint: { text: page.hint_text }) do %>
+  <%= form.govuk_radio_buttons_fieldset(:selection, legend: { tag: 'h1', size: 'l', text: question_text_with_optional_suffix_inc_mode(page, @mode) }, hint: { text: page.hint_text }) do %>
     <%= form.hidden_field :selection %>
     <% page.answer_settings.selection_options.each_with_index do |option, index| %>
       <%= form.govuk_radio_button :selection, option.name, label: { text: option.name }, link_errors: index == 0  %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,7 +103,7 @@ en:
     draft_preview: draft preview
     live_preview: live preview
     none_of_the_above: None of the above
-    optional: "%{question_text} (optional)"
+    optional: "(optional)"
   page_titles:
     error_prefix: 'Error: '
   question/name:

--- a/spec/components/question/date_component/date_component_preview.rb
+++ b/spec/components/question/date_component/date_component_preview.rb
@@ -2,7 +2,7 @@ class Question::DateComponent::DateComponentPreview < ViewComponent::Preview
   def other_date_field
     question = OpenStruct.new(date: Date.new(2023, 1, 31),
                               answer_type: "date",
-                              question_text: "When did you purchase the vehicle?",
+                              question_text_with_optional_suffix: "When did you purchase the vehicle?",
                               answer_settings: OpenStruct.new(input_type: "other_date"))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -13,7 +13,7 @@ class Question::DateComponent::DateComponentPreview < ViewComponent::Preview
   def other_date_field_with_hint
     question = OpenStruct.new(date: Date.new(2023, 1, 31),
                               answer_type: "date",
-                              question_text: "When did you purchase the vehicle?",
+                              question_text_with_optional_suffix: "When did you purchase the vehicle?",
                               hint_text: "For example, 27 3 2007",
                               answer_settings: OpenStruct.new(input_type: "other_date"))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
@@ -25,7 +25,7 @@ class Question::DateComponent::DateComponentPreview < ViewComponent::Preview
   def date_of_birth_field
     question = OpenStruct.new(date: Date.new(1984, 1, 31),
                               answer_type: "date",
-                              question_text: "When were you born?",
+                              question_text_with_optional_suffix: "When were you born?",
                               answer_settings: OpenStruct.new(input_type: "date_of_birth"))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -36,7 +36,7 @@ class Question::DateComponent::DateComponentPreview < ViewComponent::Preview
   def date_of_birth_field_with_hint
     question = OpenStruct.new(date: Date.new(1984, 1, 31),
                               answer_type: "date",
-                              question_text: "When were you born?",
+                              question_text_with_optional_suffix: "When were you born?",
                               hint_text: "For example, 27 3 1908",
                               answer_settings: OpenStruct.new(input_type: "date_of_birth"))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/date_component/view_spec.rb
+++ b/spec/components/question/date_component/view_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Question::DateComponent::View, type: :component do
   let(:question_page) { build :page, :with_date_settings, input_type: }
   let(:input_type) { "other_date" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(date: answer_text, question_text: question_page.question_text, hint_text: question_page.hint_text, answer_settings:) }
+  let(:question) { DataStruct.new(date: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings:) }
   let(:answer_settings) { question_page.answer_settings }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do

--- a/spec/components/question/email_component/email_component_preview.rb
+++ b/spec/components/question/email_component/email_component_preview.rb
@@ -2,7 +2,7 @@ class Question::EmailComponent::EmailComponentPreview < ViewComponent::Preview
   def email_field
     question = OpenStruct.new(email: "example@gov.uk",
                               answer_type: "email",
-                              question_text: "What is your email?",
+                              question_text_with_optional_suffix: "What is your email?",
                               answer_settings: nil)
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -13,7 +13,7 @@ class Question::EmailComponent::EmailComponentPreview < ViewComponent::Preview
   def email_field_with_hint
     question = OpenStruct.new(email: "example@gov.uk",
                               answer_type: "email",
-                              question_text: "What is your email?",
+                              question_text_with_optional_suffix: "What is your email?",
                               hint_text: "eg: Joe.Bloggs@example.com",
                               answer_settings: nil)
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/email_component/view_spec.rb
+++ b/spec/components/question/email_component/view_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Question::EmailComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "email" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(email: answer_text, question_text: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) { DataStruct.new(email: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/national_insurance_number_component/national_insurance_number_component_preview.rb
+++ b/spec/components/question/national_insurance_number_component/national_insurance_number_component_preview.rb
@@ -2,7 +2,7 @@ class Question::NationalInsuranceNumberComponent::NationalInsuranceNumberCompone
   def national_insurance_number_field
     question = OpenStruct.new(national_insurance_number: "AB 123456 C",
                               answer_type: "national_insurance_number",
-                              question_text: "What is your NI number?",
+                              question_text_with_optional_suffix: "What is your NI number?",
                               answer_settings: nil)
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -13,7 +13,7 @@ class Question::NationalInsuranceNumberComponent::NationalInsuranceNumberCompone
   def national_insurance_number_field_with_hint
     question = OpenStruct.new(national_insurance_number: "AB 123456 C",
                               answer_type: "national_insurance_number",
-                              question_text: "What is your NI number?",
+                              question_text_with_optional_suffix: "What is your NI number?",
                               hint_text: "eg. AB 12 34 56 C",
                               answer_settings: nil)
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/national_insurance_number_component/view_spec.rb
+++ b/spec/components/question/national_insurance_number_component/view_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Question::NationalInsuranceNumberComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "national_insurance_number" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(national_insurance_number: answer_text, question_text: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) { DataStruct.new(national_insurance_number: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/number_component/number_component_preview.rb
+++ b/spec/components/question/number_component/number_component_preview.rb
@@ -2,7 +2,7 @@ class Question::NumberComponent::NumberComponentPreview < ViewComponent::Preview
   def number_field
     question = OpenStruct.new(number: "7",
                               answer_type: "number",
-                              question_text: "Number of days in a week",
+                              question_text_with_optional_suffix: "Number of days in a week",
                               answer_settings: nil)
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -13,7 +13,7 @@ class Question::NumberComponent::NumberComponentPreview < ViewComponent::Preview
   def number_field_with_hint
     question = OpenStruct.new(number: "7",
                               answer_type: "number",
-                              question_text: "Number of days in a week",
+                              question_text_with_optional_suffix: "Number of days in a week",
                               hint_text: "Number after 6",
                               answer_settings: nil)
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/number_component/view_spec.rb
+++ b/spec/components/question/number_component/view_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Question::NumberComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "number" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(number: answer_text, question_text: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) { DataStruct.new(number: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/organisation_name_component/organisation_name_component_preview.rb
+++ b/spec/components/question/organisation_name_component/organisation_name_component_preview.rb
@@ -2,7 +2,7 @@ class Question::OrganisationNameComponent::OrganisationNameComponentPreview < Vi
   def organisation_name_field
     question = OpenStruct.new(text: "Organisations R Us",
                               answer_type: "organisation_name",
-                              question_text: "What is your company name?",
+                              question_text_with_optional_suffix: "What is your company name?",
                               answer_settings: nil)
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -13,7 +13,7 @@ class Question::OrganisationNameComponent::OrganisationNameComponentPreview < Vi
   def organisation_name_field_with_hint
     question = OpenStruct.new(text: "Organisations R Us",
                               answer_type: "organisation_name",
-                              question_text: "What is your company name?",
+                              question_text_with_optional_suffix: "What is your company name?",
                               hint_text: "As registered with Companies House",
                               answer_settings: nil)
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/organisation_name_component/view_spec.rb
+++ b/spec/components/question/organisation_name_component/view_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Question::OrganisationNameComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "organisation_name" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(text: answer_text, question_text: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) { DataStruct.new(text: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/phone_number_component/phone_number_component_preview.rb
+++ b/spec/components/question/phone_number_component/phone_number_component_preview.rb
@@ -2,7 +2,7 @@ class Question::PhoneNumberComponent::PhoneNumberComponentPreview < ViewComponen
   def phone_number_field
     question = OpenStruct.new(phone_number: "0207 555 4444",
                               answer_type: "phone_number",
-                              question_text: "What is your home phone number?",
+                              question_text_with_optional_suffix: "What is your home phone number?",
                               answer_settings: nil)
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -13,7 +13,7 @@ class Question::PhoneNumberComponent::PhoneNumberComponentPreview < ViewComponen
   def phone_number_field_with_hint
     question = OpenStruct.new(phone_number: "0207 555 4444",
                               answer_type: "phone_number",
-                              question_text: "What is your home phone number?",
+                              question_text_with_optional_suffix: "What is your home phone number?",
                               hint_text: "Do not include international dialing code",
                               answer_settings: nil)
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/phone_number_component/view_spec.rb
+++ b/spec/components/question/phone_number_component/view_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Question::PhoneNumberComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "phone_number" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(phone_number: answer_text, question_text: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) { DataStruct.new(phone_number: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/text_component/text_component_preview.rb
+++ b/spec/components/question/text_component/text_component_preview.rb
@@ -2,7 +2,7 @@ class Question::TextComponent::TextComponentPreview < ViewComponent::Preview
   def short_text_field
     question = OpenStruct.new(text: "This is a short answer text field",
                               answer_type: "text",
-                              question_text: "Summary of your request",
+                              question_text_with_optional_suffix: "Summary of your request",
                               answer_settings: OpenStruct.new(input_type: "single_line"))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -13,7 +13,7 @@ class Question::TextComponent::TextComponentPreview < ViewComponent::Preview
   def short_text_field_with_hint
     question = OpenStruct.new(text: "This is a short answer text field",
                               answer_type: "text",
-                              question_text: "Summary of your request",
+                              question_text_with_optional_suffix: "Summary of your request",
                               hint_text: "Please be specific",
                               answer_settings: OpenStruct.new(input_type: "single_line"))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
@@ -25,7 +25,7 @@ class Question::TextComponent::TextComponentPreview < ViewComponent::Preview
   def multiline_text_field
     question = OpenStruct.new(text: "This is a multi-line answer text area. \n\n With examples",
                               answer_type: "text",
-                              question_text: "Details of your request",
+                              question_text_with_optional_suffix: "Details of your request",
                               answer_settings: OpenStruct.new)
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -36,7 +36,7 @@ class Question::TextComponent::TextComponentPreview < ViewComponent::Preview
   def multiline_text_field_with_hints
     question = OpenStruct.new(text: "This is a multi-line answer text area. \n\n With examples",
                               answer_type: "text",
-                              question_text: "Details of your request",
+                              question_text_with_optional_suffix: "Details of your request (optional)",
                               hint_text: "Add as much details are you like",
                               answer_settings: OpenStruct.new)
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/text_component/view_spec.rb
+++ b/spec/components/question/text_component/view_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Question::TextComponent::View, type: :component do
   let(:question_page) { build :page, :with_text_settings, input_type: }
   let(:input_type) { "single_line" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(text: answer_text, question_text: question_page.question_text, hint_text: question_page.hint_text, answer_settings: question_page.answer_settings) }
+  let(:question) { DataStruct.new(text: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: question_page.answer_settings) }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "returns the title with the optional suffix" do
         page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(show_optional_suffix: true))
         mode = OpenStruct.new(preview?: false)
-        expect(helper.question_text_with_optional_suffix_inc_mode(page, mode)).to eq(I18n.t("page.optional", question_text: "What is your name?"))
+        expect(helper.question_text_with_optional_suffix_inc_mode(page, mode)).to eq("What is your name? #{I18n.t("page.optional")}")
       end
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "returns the title with the optional suffix" do
         page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(show_optional_suffix: true))
         mode = OpenStruct.new(preview?: false)
-        expect(helper.question_text_with_optional_suffix(page, mode)).to eq(I18n.t("page.optional", question_text: "What is your name?"))
+        expect(helper.question_text_with_optional_suffix_inc_mode(page, mode)).to eq(I18n.t("page.optional", question_text: "What is your name?"))
       end
     end
 
@@ -23,7 +23,7 @@ RSpec.describe ApplicationHelper, type: :helper do
         page = OpenStruct.new(question_text: "What is your name? <script>alert(\"Hi\")</script>", question: OpenStruct.new(show_optional_suffix: false))
         mode = OpenStruct.new(preview?: true, preview_draft?: true)
         expected_output = "What is your name? &lt;script&gt;alert(&quot;Hi&quot;)&lt;/script&gt; <span class='govuk-visually-hidden'>&nbsp;draft preview</span>"
-        expect(helper.question_text_with_optional_suffix(page, mode)).to eq(expected_output)
+        expect(helper.question_text_with_optional_suffix_inc_mode(page, mode)).to eq(expected_output)
       end
     end
 
@@ -31,7 +31,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "returns the title with the optional suffix" do
         page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(show_optional_suffix: false))
         mode = OpenStruct.new(preview?: false)
-        expect(helper.question_text_with_optional_suffix(page, mode)).to eq("What is your name?")
+        expect(helper.question_text_with_optional_suffix_inc_mode(page, mode)).to eq("What is your name?")
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "returns the title with the optional suffix with visually hidden text" do
         page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(show_optional_suffix: false))
         mode = OpenStruct.new(preview?: true, preview_draft?: true)
-        expect(helper.question_text_with_optional_suffix(page, mode)).to eq("What is your name? <span class='govuk-visually-hidden'>&nbsp;draft preview</span>")
+        expect(helper.question_text_with_optional_suffix_inc_mode(page, mode)).to eq("What is your name? <span class='govuk-visually-hidden'>&nbsp;draft preview</span>")
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "returns the title with the optional suffix with visually hidden text" do
         page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(show_optional_suffix: false))
         mode = OpenStruct.new(preview?: true, preview_live?: true)
-        expect(helper.question_text_with_optional_suffix(page, mode)).to eq("What is your name? <span class='govuk-visually-hidden'>&nbsp;live preview</span>")
+        expect(helper.question_text_with_optional_suffix_inc_mode(page, mode)).to eq("What is your name? <span class='govuk-visually-hidden'>&nbsp;live preview</span>")
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -9,45 +9,19 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "#question_text_with_optional_suffix" do
-    context "with an optional question" do
-      it "returns the title with the optional suffix" do
-        page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(show_optional_suffix: true))
-        mode = OpenStruct.new(preview?: false)
-        expect(helper.question_text_with_optional_suffix_inc_mode(page, mode)).to eq("What is your name? #{I18n.t("page.optional")}")
-      end
+  describe "#question_text_with_optional_suffix_inc_mode" do
+    it "renders the question text followed by the mode the page is viewed in" do
+      page = OpenStruct.new(question: OpenStruct.new(question_text_with_optional_suffix: "What is your name?"))
+      allow(helper).to receive(:hidden_text_mode).and_return("<span>PREVIEWING MODE</span>")
+      expect(helper.question_text_with_optional_suffix_inc_mode(page, "mode")).to eq("What is your name? <span>PREVIEWING MODE</span>")
     end
 
     context "with unsafe question text" do
-      it "returns the escaped title with the optional suffix" do
-        page = OpenStruct.new(question_text: "What is your name? <script>alert(\"Hi\")</script>", question: OpenStruct.new(show_optional_suffix: false))
-        mode = OpenStruct.new(preview?: true, preview_draft?: true)
-        expected_output = "What is your name? &lt;script&gt;alert(&quot;Hi&quot;)&lt;/script&gt; <span class='govuk-visually-hidden'>&nbsp;draft preview</span>"
-        expect(helper.question_text_with_optional_suffix_inc_mode(page, mode)).to eq(expected_output)
-      end
-    end
-
-    context "with a required question" do
-      it "returns the title with the optional suffix" do
-        page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(show_optional_suffix: false))
-        mode = OpenStruct.new(preview?: false)
-        expect(helper.question_text_with_optional_suffix_inc_mode(page, mode)).to eq("What is your name?")
-      end
-    end
-
-    context "with preview draft mode" do
-      it "returns the title with the optional suffix with visually hidden text" do
-        page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(show_optional_suffix: false))
-        mode = OpenStruct.new(preview?: true, preview_draft?: true)
-        expect(helper.question_text_with_optional_suffix_inc_mode(page, mode)).to eq("What is your name? <span class='govuk-visually-hidden'>&nbsp;draft preview</span>")
-      end
-    end
-
-    context "with live preview live mode" do
-      it "returns the title with the optional suffix with visually hidden text" do
-        page = OpenStruct.new(question_text: "What is your name?", question: OpenStruct.new(show_optional_suffix: false))
-        mode = OpenStruct.new(preview?: true, preview_live?: true)
-        expect(helper.question_text_with_optional_suffix_inc_mode(page, mode)).to eq("What is your name? <span class='govuk-visually-hidden'>&nbsp;live preview</span>")
+      it "returns the escaped title but doesn't escape the trusted suffix" do
+        page = OpenStruct.new(question: OpenStruct.new(question_text_with_optional_suffix: "What is your name? <script>alert(\"Hi\")</script>"))
+        allow(helper).to receive(:hidden_text_mode).and_return("<span>not escaped</span>")
+        expected_output = "What is your name? &lt;script&gt;alert(&quot;Hi&quot;)&lt;/script&gt; <span>not escaped</span>"
+        expect(helper.question_text_with_optional_suffix_inc_mode(page, "")).to eq(expected_output)
       end
     end
   end

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -57,6 +57,10 @@ RSpec.describe Question::Selection, type: :model do
         expect(question).not_to be_valid
         expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.both_none_and_value_selected"))
       end
+
+      it "does not include '(optional)' in the question text" do
+        expect(question.question_text_with_optional_suffix).to eq(question.question_text)
+      end
     end
   end
 

--- a/spec/support/shared_examples/question_models.rb
+++ b/spec/support/shared_examples/question_models.rb
@@ -38,10 +38,13 @@ RSpec.shared_examples "a question model" do |_parameter|
     context "when question is optional" do
       let(:is_optional?) { true }
 
-      it "responds to question_text_with_optional_suffix and includes optional suffix" do
-        expect(question.question_text_with_optional_suffix).to eq("#{question.question_text} #{I18n.t('page.optional')}")
+      it "responds to question_text_with_optional_suffix" do
+        if question.is_a?(Question::Selection)
+          expect(question.question_text_with_optional_suffix).to eq(question.question_text)
+        else
+          expect(question.question_text_with_optional_suffix).to eq("#{question.question_text} #{I18n.t('page.optional')}")
+        end
       end
     end
   end
-
 end

--- a/spec/support/shared_examples/question_models.rb
+++ b/spec/support/shared_examples/question_models.rb
@@ -22,4 +22,26 @@ RSpec.shared_examples "a question model" do |_parameter|
   it "responds to has_long_answer?" do
     expect(question.has_long_answer?).to be(true).or be(false)
   end
+
+  describe "#question_text_with_optional_suffix" do
+    let(:is_optional?) { false }
+
+    before do
+      question.question_text = "What is the meaning of life?"
+      allow(question).to receive(:is_optional?).and_return(is_optional?)
+    end
+
+    it "responds to question_text_with_optional_suffix" do
+      expect(question.question_text_with_optional_suffix).to eq(question.question_text)
+    end
+
+    context "when question is optional" do
+      let(:is_optional?) { true }
+
+      it "responds to question_text_with_optional_suffix and includes optional suffix" do
+        expect(question.question_text_with_optional_suffix).to eq("#{question.question_text} #{I18n.t('page.optional')}")
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
As part of the refactoring of the components we forgot to add "(optional)" to the question label if the question is optional. This is because before  partials were responsible for calling a helper method which worked out whether or not to add "(optional)" suffix and view mode. This is a lot for a helper method. The components are "dumb" and just handle simple presentation. Manipulating data or business logic is best controlled outside a component.

This moves the business logic of whether or not to add "(optional)" from the helper method to the question model instead. It makes testing this code a lot easier for both the helper method and the new model method.

Trello card: https://trello.com/c/mGqPIFkV/237-switch-the-runner-to-use-components-rather-than-partials

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
