### PR TITLE
Only Bundle Install Production Scope Only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,11 @@ USER ruby
 
 COPY --chown=ruby:ruby Gemfile* ./
 RUN gem install bundler -v 2.4.10
-RUN bundle install --jobs "$(nproc)"
+
+RUN bundle config set --local without development:test \
+  && bundle config set --local jobs "$(nproc)"
+
+RUN bundle install
 
 COPY --chown=ruby:ruby package.json ./
 RUN npm install --ignore-scripts


### PR DESCRIPTION
We do not need to install the development and test scoped dependencies into our docker image.

#### What problem does the pull request solve?
See similar PR for forms-admin: https://github.com/alphagov/forms-admin/pull/561
