### PR TITLE
Remove webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,6 @@ group :test do
   gem "rails-controller-testing"
   gem "selenium-webdriver"
   gem "simplecov"
-  gem "webdrivers"
 
   # axe-core for running automated accessibility checks
   gem "axe-core-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    childprocess (4.1.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.2.2)
@@ -309,7 +308,7 @@ GEM
       io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
     rspec-expectations (3.11.0)
@@ -358,8 +357,7 @@ GEM
       rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    selenium-webdriver (4.3.0)
-      childprocess (>= 0.5, < 5.0)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -406,10 +404,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.0.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -460,7 +454,6 @@ DEPENDENCIES
   uk_postcode
   vite_rails
   web-console
-  webdrivers
 
 RUBY VERSION
    ruby 3.2.2p53


### PR DESCRIPTION
Webdrivers isn't necessary with selenium-webdrivers of version 4.10 and higher. Webdrivers cannot currently install and manage v115 of Chromedriver.

#### What problem does the pull request solve?
Gets CI running again

There is more information about the webdrivers issues and their recommendation to remove webdrivers and use selenium-webdrivers + 4.10 https://github.com/titusfortner/webdrivers/issues/247
