### PR TITLE
Use npm ci and remove devDependencies after build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,12 @@ COPY --chown=ruby:ruby Gemfile* ./
 RUN gem install bundler -v 2.4.10
 
 RUN bundle config set --local without development:test \
-  && bundle config set --local jobs "$(nproc)"
+    && bundle config set --local jobs "$(nproc)"
 
 RUN bundle install
 
-COPY --chown=ruby:ruby package.json ./
-RUN npm install --ignore-scripts
+COPY --chown=ruby:ruby package.json package-lock.json ./
+RUN npm ci --ignore-scripts
 
 ENV RAILS_ENV="${RAILS_ENV:-production}" \
     NODE_ENV="${NODE_ENV:-production}" \
@@ -32,6 +32,9 @@ COPY --chown=ruby:ruby . .
 # you can't run rails commands like assets:precompile without a secret key set
 # even though the command doesn't use the value itself
 RUN SECRET_KEY_BASE=dummyvalue rails assets:precompile
+
+# Remove devDependencies once assets have been built
+RUN npm ci --ignore-scripts --only=production
 
 CMD ["bash"]
 


### PR DESCRIPTION
#### What problem does the pull request solve?
We have two sets of node dependencies in our package.json - `dependencies` which are packages we need to ship with our app, and `devDependencies` which we need to build our app (or develop locally) but don't need to ship with our app at run time. We have many more `devDependencies` than we do `dependencies`.

In our Docker builds we install our devDependencies so that we can run the frontend asset build. We then copy the entire `app` folder into our runtime environment. Shipping these extra dependencies at run time increases our app's attack surface, so we should remove them once we no longer need them. 

In this PR, I'm running `npm ci --only=production` at the end of the build stage, which will clear out our node_modules file and install only our production dependencies. This means none of our devDependencies will get copied over during the run stage.

I've also changed the build stage to use `npm ci` instead of `npm install` during the initial build stage. This will do a clean install based on the `package-lock.json` file, so our build will be more deterministic.

#### Checklist

- [x] I've used the pull request template
- [n/a] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
