### PR TITLE
Component view spec not using correct attributes in test

### DIFF
--- a/spec/components/question/date_component/view_spec.rb
+++ b/spec/components/question/date_component/view_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Question::DateComponent::View, type: :component do
 
   describe "when component is other date field" do
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text)
+      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders 3 text fields (day, month, year)" do
@@ -74,7 +74,7 @@ RSpec.describe Question::DateComponent::View, type: :component do
     let(:input_type) { "date_of_birth" }
 
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text)
+      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders 3 text fields (day, month, year)" do
@@ -130,7 +130,7 @@ RSpec.describe Question::DateComponent::View, type: :component do
     let(:answer_settings) { nil }
 
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text)
+      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders 3 text fields (day, month, year)" do

--- a/spec/components/question/email_component/view_spec.rb
+++ b/spec/components/question/email_component/view_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Question::EmailComponent::View, type: :component do
 
   describe "when component is email field" do
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text)
+      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders an email input field" do

--- a/spec/components/question/national_insurance_number_component/view_spec.rb
+++ b/spec/components/question/national_insurance_number_component/view_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Question::NationalInsuranceNumberComponent::View, type: :componen
 
   describe "when component is national insurance number field" do
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text)
+      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders a text input field" do

--- a/spec/components/question/number_component/view_spec.rb
+++ b/spec/components/question/number_component/view_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Question::NumberComponent::View, type: :component do
 
   describe "when component is number field" do
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text)
+      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders a text input field" do

--- a/spec/components/question/organisation_name_component/view_spec.rb
+++ b/spec/components/question/organisation_name_component/view_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Question::OrganisationNameComponent::View, type: :component do
 
   describe "when component is organisation name field" do
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text)
+      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders a text input field" do

--- a/spec/components/question/phone_number_component/view_spec.rb
+++ b/spec/components/question/phone_number_component/view_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Question::PhoneNumberComponent::View, type: :component do
 
   describe "when component is phone number field" do
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text)
+      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders a telephone input field" do

--- a/spec/components/question/text_component/view_spec.rb
+++ b/spec/components/question/text_component/view_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Question::TextComponent::View, type: :component do
 
   describe "when component is short answer text field" do
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text)
+      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders a text input field" do
@@ -57,7 +57,7 @@ RSpec.describe Question::TextComponent::View, type: :component do
     let(:input_type) { "long_text" }
 
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text)
+      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders a textarea field" do


### PR DESCRIPTION
### What problem does this pull request solve?

Rspec was alerting the following warning:

`Checking for expected text of nil is confusing and/or pointless since it will always match. Please specify a string or regexp instead.`

This was result of refactoring we did in https://github.com/alphagov/forms-runner/pull/385 to move the logic of adding (optional) to the question text to be part of the question model.

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
