### PR TITLE
Replace DataStruct with OpenStruct

### DIFF
--- a/spec/components/question/date_component/view_spec.rb
+++ b/spec/components/question/date_component/view_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Question::DateComponent::View, type: :component do
   let(:question_page) { build :page, :with_date_settings, input_type: }
   let(:input_type) { "other_date" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(date: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings:) }
+  let(:question) { OpenStruct.new(date: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings:) }
   let(:answer_settings) { question_page.answer_settings }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do

--- a/spec/components/question/email_component/view_spec.rb
+++ b/spec/components/question/email_component/view_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Question::EmailComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "email" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(email: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) { OpenStruct.new(email: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/national_insurance_number_component/view_spec.rb
+++ b/spec/components/question/national_insurance_number_component/view_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Question::NationalInsuranceNumberComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "national_insurance_number" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(national_insurance_number: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) { OpenStruct.new(national_insurance_number: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/number_component/view_spec.rb
+++ b/spec/components/question/number_component/view_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Question::NumberComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "number" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(number: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) { OpenStruct.new(number: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/organisation_name_component/view_spec.rb
+++ b/spec/components/question/organisation_name_component/view_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Question::OrganisationNameComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "organisation_name" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(text: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) { OpenStruct.new(text: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/phone_number_component/view_spec.rb
+++ b/spec/components/question/phone_number_component/view_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Question::PhoneNumberComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "phone_number" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(phone_number: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) { OpenStruct.new(phone_number: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,

--- a/spec/components/question/selection_component/selection_component_preview.rb
+++ b/spec/components/question/selection_component/selection_component_preview.rb
@@ -4,12 +4,12 @@ class Question::SelectionComponent::SelectionComponentPreview < ViewComponent::P
                               answer_type: "selection",
                               is_optional?: false,
                               question_text_with_optional_suffix: "Which countries are part of United Kingdom?",
-                              answer_settings: DataStruct.new(only_one_option: "true",
+                              answer_settings: OpenStruct.new(only_one_option: "true",
                                                               selection_options: [
-                                                                DataStruct.new(name: "England"),
-                                                                DataStruct.new(name: "Scotland"),
-                                                                DataStruct.new(name: "Wales"),
-                                                                DataStruct.new(name: "Northern Ireland"),
+                                                                OpenStruct.new(name: "England"),
+                                                                OpenStruct.new(name: "Scotland"),
+                                                                OpenStruct.new(name: "Wales"),
+                                                                OpenStruct.new(name: "Northern Ireland"),
                                                               ]))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -23,12 +23,12 @@ class Question::SelectionComponent::SelectionComponentPreview < ViewComponent::P
                               is_optional?: false,
                               question_text_with_optional_suffix: "Which countries are part of United Kingdom?",
                               hint_text: "Select one or more options",
-                              answer_settings: DataStruct.new(only_one_option: "true",
+                              answer_settings: OpenStruct.new(only_one_option: "true",
                                                               selection_options: [
-                                                                DataStruct.new(name: "England"),
-                                                                DataStruct.new(name: "Scotland"),
-                                                                DataStruct.new(name: "Wales"),
-                                                                DataStruct.new(name: "Northern Ireland"),
+                                                                OpenStruct.new(name: "England"),
+                                                                OpenStruct.new(name: "Scotland"),
+                                                                OpenStruct.new(name: "Wales"),
+                                                                OpenStruct.new(name: "Northern Ireland"),
                                                               ]))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -41,12 +41,12 @@ class Question::SelectionComponent::SelectionComponentPreview < ViewComponent::P
                               answer_type: "selection",
                               is_optional?: true,
                               question_text_with_optional_suffix: "Which countries are part of United Kingdom?",
-                              answer_settings: DataStruct.new(only_one_option: "true",
+                              answer_settings: OpenStruct.new(only_one_option: "true",
                                                               selection_options: [
-                                                                DataStruct.new(name: "England"),
-                                                                DataStruct.new(name: "Scotland"),
-                                                                DataStruct.new(name: "Wales"),
-                                                                DataStruct.new(name: "Northern Ireland"),
+                                                                OpenStruct.new(name: "England"),
+                                                                OpenStruct.new(name: "Scotland"),
+                                                                OpenStruct.new(name: "Wales"),
+                                                                OpenStruct.new(name: "Northern Ireland"),
                                                               ]))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -60,12 +60,12 @@ class Question::SelectionComponent::SelectionComponentPreview < ViewComponent::P
                               is_optional?: true,
                               question_text_with_optional_suffix: "Which countries are part of United Kingdom?",
                               hint_text: "This is a trick question...",
-                              answer_settings: DataStruct.new(only_one_option: "true",
+                              answer_settings: OpenStruct.new(only_one_option: "true",
                                                               selection_options: [
-                                                                DataStruct.new(name: "England"),
-                                                                DataStruct.new(name: "Scotland"),
-                                                                DataStruct.new(name: "Wales"),
-                                                                DataStruct.new(name: "Northern Ireland"),
+                                                                OpenStruct.new(name: "England"),
+                                                                OpenStruct.new(name: "Scotland"),
+                                                                OpenStruct.new(name: "Wales"),
+                                                                OpenStruct.new(name: "Northern Ireland"),
                                                               ]))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -78,10 +78,10 @@ class Question::SelectionComponent::SelectionComponentPreview < ViewComponent::P
                               answer_type: "selection",
                               is_optional?: false,
                               question_text_with_optional_suffix: "Are you sure?",
-                              answer_settings: DataStruct.new(only_one_option: false,
+                              answer_settings: OpenStruct.new(only_one_option: false,
                                                               selection_options: [
-                                                                DataStruct.new(name: "Yes"),
-                                                                DataStruct.new(name: "No"),
+                                                                OpenStruct.new(name: "Yes"),
+                                                                OpenStruct.new(name: "No"),
                                                               ]))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -95,10 +95,10 @@ class Question::SelectionComponent::SelectionComponentPreview < ViewComponent::P
                               is_optional?: false,
                               question_text_with_optional_suffix: "Have you recently been involved in a car accident?",
                               hint_text: "Anytime within the last 12 months",
-                              answer_settings: DataStruct.new(only_one_option: false,
+                              answer_settings: OpenStruct.new(only_one_option: false,
                                                               selection_options: [
-                                                                DataStruct.new(name: "Yes"),
-                                                                DataStruct.new(name: "No"),
+                                                                OpenStruct.new(name: "Yes"),
+                                                                OpenStruct.new(name: "No"),
                                                               ]))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -111,12 +111,12 @@ class Question::SelectionComponent::SelectionComponentPreview < ViewComponent::P
                               answer_type: "selection",
                               is_optional?: true,
                               question_text_with_optional_suffix: "Which country is part of United Kingdom?",
-                              answer_settings: DataStruct.new(only_one_option: false,
+                              answer_settings: OpenStruct.new(only_one_option: false,
                                                               selection_options: [
-                                                                DataStruct.new(name: "England"),
-                                                                DataStruct.new(name: "France"),
-                                                                DataStruct.new(name: "Spain"),
-                                                                DataStruct.new(name: "Ireland"),
+                                                                OpenStruct.new(name: "England"),
+                                                                OpenStruct.new(name: "France"),
+                                                                OpenStruct.new(name: "Spain"),
+                                                                OpenStruct.new(name: "Ireland"),
                                                               ]))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
@@ -130,12 +130,12 @@ class Question::SelectionComponent::SelectionComponentPreview < ViewComponent::P
                               is_optional?: true,
                               question_text_with_optional_suffix: "Which country is part of United Kingdom?",
                               hint_text: "This is a trick question...",
-                              answer_settings: DataStruct.new(only_one_option: false,
+                              answer_settings: OpenStruct.new(only_one_option: false,
                                                               selection_options: [
-                                                                DataStruct.new(name: "England"),
-                                                                DataStruct.new(name: "France"),
-                                                                DataStruct.new(name: "Spain"),
-                                                                DataStruct.new(name: "Ireland"),
+                                                                OpenStruct.new(name: "England"),
+                                                                OpenStruct.new(name: "France"),
+                                                                OpenStruct.new(name: "Spain"),
+                                                                OpenStruct.new(name: "Ireland"),
                                                               ]))
     form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
                                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})

--- a/spec/components/question/text_component/view_spec.rb
+++ b/spec/components/question/text_component/view_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Question::TextComponent::View, type: :component do
   let(:question_page) { build :page, :with_text_settings, input_type: }
   let(:input_type) { "single_line" }
   let(:answer_text) { nil }
-  let(:question) { DataStruct.new(text: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: question_page.answer_settings) }
+  let(:question) { OpenStruct.new(text: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: question_page.answer_settings) }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,


### PR DESCRIPTION
### What problem does this pull request solve?

Preview components were failing in dev but not on localhost

NameError
uninitialized constant Question::SelectionComponent::SelectionComponentPreview::DataStruct (NameError)

ref: https://govuk-forms.sentry.io/issues/4355784060/?project=6576261&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=0

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
