### PR TITLE
Move linting gems to development, test groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,12 @@ group :development, :test do
 
   gem "rspec-rails"
   gem "rubocop-govuk", require: false
+
+  # For security auditing gem vulnerabilities. RUN IN CI
+  gem "bundler-audit", "~> 0.9.0"
+
+  # For detecting security vulnerabilities in Ruby on Rails applications via static analysis.
+  gem "brakeman", "~> 6.0"
 end
 
 group :development do
@@ -88,9 +94,3 @@ group :test do
   # axe-core for running automated accessibility checks
   gem "axe-core-rspec"
 end
-
-# For security auditing gem vulnerabilities. RUN IN CI
-gem "bundler-audit", "~> 0.9.0"
-
-# For detecting security vulnerabilities in Ruby on Rails applications via static analysis.
-gem "brakeman", "~> 6.0"


### PR DESCRIPTION
We don't need these gems installed when running apps in production.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?