### PR TITLE
Add guidance component

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apk update
 RUN apk upgrade --available
-RUN apk add libc6-compat openssl-dev build-base libpq-dev nodejs=~18 npm
+RUN apk add libc6-compat openssl-dev build-base libpq-dev nodejs=~18 npm git
 RUN adduser -D ruby
 RUN mkdir /node_modules && chown ruby:ruby -R /node_modules /app
 

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem "activeresource"
 gem "govuk-components", "~> 4.1.0"
 gem "govuk_design_system_formbuilder", "~> 4.1.1"
 
+# Our own custom markdown renderer
+gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.2.1"
+
 # For compiling our frontend assets
 gem "vite_rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/alphagov/govuk-forms-markdown.git
+  revision: c1d9b83d7510b0f8d259238901de2bb9a5c2041c
+  tag: 0.2.1
+  specs:
+    govuk-forms-markdown (0.2.1)
+      redcarpet (~> 3.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -299,6 +307,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redcarpet (3.6.0)
     redis (4.8.1)
     redis-session-store (0.11.5)
       actionpack (>= 6, < 8)
@@ -434,6 +443,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   govuk-components (~> 4.1.0)
+  govuk-forms-markdown!
   govuk_design_system_formbuilder (~> 4.1.1)
   govuk_notify_rails
   i18n-tasks (~> 1.0.12)

--- a/app/components/guidance_component/view.html.erb
+++ b/app/components/guidance_component/view.html.erb
@@ -1,0 +1,3 @@
+<h1 class="govuk-heading-l"><%= question.page_heading %></h1>
+
+<%= guidance_html %>

--- a/app/components/guidance_component/view.rb
+++ b/app/components/guidance_component/view.rb
@@ -1,0 +1,20 @@
+require "govuk_forms_markdown"
+
+module GuidanceComponent
+  class View < ViewComponent::Base
+    attr_accessor :question
+
+    def initialize(question)
+      super
+      @question = question
+    end
+
+    def render?
+      question.page_heading.present? && question.guidance_markdown.present?
+    end
+
+    def guidance_html
+      ActionController::Base.helpers.sanitize(GovukFormsMarkdown.render(question.guidance_markdown), scrubber: MarkdownScrubber.new)
+    end
+  end
+end

--- a/app/lib/markdown_scrubber.rb
+++ b/app/lib/markdown_scrubber.rb
@@ -1,0 +1,7 @@
+class MarkdownScrubber < Rails::Html::PermitScrubber
+  def initialize
+    super
+    self.tags = %w[a h2 h3 ol ul li p]
+    self.attributes = %w[href class rel target title]
+  end
+end

--- a/app/views/forms/page/show.html.erb
+++ b/app/views/forms/page/show.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(form_title(form_name: @current_context.form.name, page_name: @step.question_text, mode: @mode, error: @step.question&.errors&.any?)) %>
+<% set_page_title(form_title(form_name: @current_context.form.name, page_name: (@step.question.page_heading.present? ? @step.question.page_heading : @step.question.question_text), mode: @mode, error: @step.question&.errors&.any?)) %>
 
 <% content_for :back_link do %>
   <% if @back_link.present? %>

--- a/app/views/forms/page/show.html.erb
+++ b/app/views/forms/page/show.html.erb
@@ -13,6 +13,8 @@
         <%= form.govuk_error_summary %>
       <% end %>
 
+      <%= render GuidanceComponent::View.new(@step.question) %>
+
       <% view_component = Object.const_get("#{@step.question.class.name}Component::View") %>
       <%= render view_component.new(form_builder: form, question: @step.question, extra_question_text_suffix: hidden_text_mode(@mode).html_safe) %>
 

--- a/spec/components/guidance_component/guidance_component_preview.rb
+++ b/spec/components/guidance_component/guidance_component_preview.rb
@@ -1,0 +1,37 @@
+class GuidanceComponent::GuidanceComponentPreview < ViewComponent::Preview
+  def default
+    question = OpenStruct.new(
+      page_heading: nil,
+      guidance_markdown: nil,
+    )
+
+    render(GuidanceComponent::View.new(question))
+  end
+
+  def with_paragraph_content
+    question = OpenStruct.new(
+      page_heading: "Interview needs",
+      guidance_markdown: "Providers do not usually have much flexibility when setting a date and time for interview unless you need adjustments due to a [health condition or disability](#).\n\nHowever, if you need flexibility for other reasons you can tell us about it here.\n\nFor example, you have commitments like caring responsibilites or employment.\n\nContact your provider if you’re concerned about the interview process.",
+    )
+
+    render(GuidanceComponent::View.new(question))
+  end
+
+  def with_bulleted_list
+    question = OpenStruct.new(
+      page_heading: "10 figure grid reference of the proposed location of the building",
+      guidance_markdown: "## How to find your 10 figure grid reference\n\nIn order to find the relevant grid reference you should do the following: \n\n* Go to the [Grid Reference Finder](https://gridreferencefinder.com/) website\n* Search for your location by postcode or using the other search fields\n* Click on the location",
+    )
+
+    render(GuidanceComponent::View.new(question))
+  end
+
+  def with_numbered_list
+    question = OpenStruct.new(
+      page_heading: "National Grid field number for the proposed location of the building",
+      guidance_markdown: "## How to find National Grid field numbers for your land or building\n\nUse the [multi-agency geographic information for the countryside (MAGIC) map](https://magic.defra.gov.uk/).\n\n### Instructions:\n\n1. Select ‘Get Started’.\n2. Search for a county, place or postcode.\n3. Using the map, locate the land or building. Use the +/-icons to zoom in and out.\n4. Select the ‘Where am I’ function on the toolbar and then click on the land or building.\n5. A pop-up box will appear showing the land details for this location. This includes the National Grid field number.",
+    )
+
+    render(GuidanceComponent::View.new(question))
+  end
+end

--- a/spec/components/guidance_component/view_spec.rb
+++ b/spec/components/guidance_component/view_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe GuidanceComponent::View, type: :component do
+  let(:answer_text) { nil }
+  let(:page_heading) { "10 figure grid reference of the proposed location of the building" }
+  let(:subheading) { "How to find your 10 figure grid reference" }
+  let(:guidance_markdown) { "## #{subheading}" }
+  let(:question) { OpenStruct.new(page_heading:, guidance_markdown:) }
+
+  before do
+    render_inline(described_class.new(question))
+  end
+
+  context "when page_heading is blank" do
+    let(:page_heading) { nil }
+
+    it "does not render" do
+      expect(page).not_to have_css("*")
+    end
+  end
+
+  context "when guidance_markdown is blank" do
+    let(:guidance_markdown) { nil }
+
+    it "does not render" do
+      expect(page).not_to have_css("*")
+    end
+  end
+
+  describe "when component has a page heading and guidance markdown" do
+    it "renders the page_heading as a h1" do
+      expect(page.find("h1.govuk-heading-l")).to have_text(question.page_heading)
+    end
+
+    it "renders the markdown correctly" do
+      # just test that markdown is rendered on the page - we test the markdown rendering in more detail within the govuk-forms-markdown gem itself
+      expect(page.find("h2")).to have_text(subheading)
+    end
+
+    context "with unsafe question text" do
+      let(:page_heading) { "10 figure grid reference of the proposed location of the building<script>alert(\"Hi\")</script>" }
+      let(:guidance_markdown) { "<script>alert(\"Hi\")</script>" }
+
+      it "does not render the script element" do
+        expect(page).not_to have_css("script")
+      end
+    end
+  end
+end

--- a/spec/lib/markdown_scrubber_spec.rb
+++ b/spec/lib/markdown_scrubber_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe MarkdownScrubber do
+  let(:markdown_scrubber) { described_class.new }
+
+  it "returns an array of html tags allowed" do
+    expect(markdown_scrubber.tags).to eq %w[a h2 h3 ol ul li p]
+  end
+
+  it "returns an array of html attributes allowed" do
+    expect(markdown_scrubber.attributes).to eq %w[href class rel target title]
+  end
+
+  context "when used with sanitize" do
+    context "when the string contains only allowed markup" do
+      let(:input) { "<a href=\"#\">A perfectly innocent link</a>" }
+
+      it "returns the allowed markup unchanged" do
+        sanitized_string = ActionController::Base.helpers.sanitize(input, scrubber: markdown_scrubber)
+        expect(sanitized_string).to eq "<a href=\"#\">A perfectly innocent link</a>"
+      end
+    end
+
+    context "when the string contains an allowed tag with a disallowed attribute" do
+      let(:input) { "<a href=\"#\" class=\"govuk-link\" target=\"blank\" rel=\"noopener noreferrer\" style=\"color: rebeccapurple\" onClick=\"alert('some malicious js!')\">A link with some dodgy styling and JS attached</a>" }
+
+      it "returns the tag with the disallowed attributes removed" do
+        sanitized_string = ActionController::Base.helpers.sanitize(input, scrubber: markdown_scrubber)
+        expect(sanitized_string).to eq "<a href=\"#\" class=\"govuk-link\" target=\"blank\" rel=\"noopener noreferrer\">A link with some dodgy styling and JS attached</a>"
+      end
+    end
+
+    context "when the string contains disallowed markup" do
+      let(:input) { "<a href=\"#\"><em>A</em> <strong class=\"bold\">perfectly</strong> <b style=\"font-weight: 700;\">innocent</b> <i>link</i></a><script>alert(\"malicious code!\")</script>" }
+
+      it "sanitises the disallowed markup" do
+        sanitized_string = ActionController::Base.helpers.sanitize(input, scrubber: markdown_scrubber)
+        expect(sanitized_string).to eq "<a href=\"#\">A perfectly innocent link</a>alert(\"malicious code!\")"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/bfw5T1Ny/975-create-guidance-component-in-forms-runner

Adds a new component for displaying the page heading and rendering the markdown guidance.

As part of that I've installed the [govuk-forms-markdown](https://github.com/alphagov/govuk-forms-markdown) gem and added git to our Docker build.

Note that this doesn't actually add the new component to the view - that'll be done either as part of https://trello.com/c/R5aZ0LWX/950-update-forms-runner-to-display-additional-guidance-to-form-fillers or in a separate PR once that one's merged.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
