### PR TITLE
Toggle page headings depending on if question has guidance

### DIFF
--- a/app/components/question/address_component/view.rb
+++ b/app/components/question/address_component/view.rb
@@ -14,7 +14,7 @@ module Question
       end
 
       def build_fields
-        form_builder.govuk_fieldset legend: { text: question_text_with_extra_suffix, tag: "h1", size: "l" }, described_by: hint_id do
+        form_builder.govuk_fieldset legend: { text: question_text_with_extra_suffix, **question_text_size_and_tag }, described_by: hint_id do
           form_fields = is_international_address? ? fields_for_international_address : fields_for_uk_address
           safe_join([hint_text, form_fields].compact_blank)
         end

--- a/app/components/question/base.rb
+++ b/app/components/question/base.rb
@@ -23,7 +23,9 @@ module Question
     end
 
     def question_text_size_and_tag
-      { tag: "h1", size: "l" }
+      return { tag: "h1", size: "l" } if question.page_heading.nil? && question.guidance_markdown.blank?
+
+      { size: "m" }
     end
   end
 end

--- a/app/components/question/base.rb
+++ b/app/components/question/base.rb
@@ -21,5 +21,9 @@ module Question
         question.hint_text
       end
     end
+
+    def question_text_size_and_tag
+      { tag: "h1", size: "l" }
+    end
   end
 end

--- a/app/components/question/date_component/view.html.erb
+++ b/app/components/question/date_component/view.html.erb
@@ -1,5 +1,5 @@
 <%= form_builder.govuk_date_field :date,
                                   date_of_birth: date_of_birth?,
-                                  legend: { tag: 'h1', size: 'l', text: question_text_with_extra_suffix },
+                                  legend: { text: question_text_with_extra_suffix, **question_text_size_and_tag },
                                   hint: { text: question.hint_text }
 %>

--- a/app/components/question/email_component/view.html.erb
+++ b/app/components/question/email_component/view.html.erb
@@ -1,5 +1,5 @@
 <%= form_builder.govuk_email_field :email,
-                                  label: { tag: 'h1', size: 'l', text: question_text_with_extra_suffix },
+                                  label: { text: question_text_with_extra_suffix, **question_text_size_and_tag },
                                   hint: { text: question.hint_text },
                                   autocomplete: 'email',
                                   spellcheck: false

--- a/app/components/question/name_component/view.rb
+++ b/app/components/question/name_component/view.rb
@@ -33,13 +33,13 @@ module Question
 
       def fields_for_full_name_and_no_title
         form_builder.govuk_text_field :full_name,
-                                      label: { tag: "h1", size: "l", text: question_text_with_extra_suffix },
+                                      label: { text: question_text_with_extra_suffix, **question_text_size_and_tag },
                                       hint: { text: question.hint_text },
                                       autocomplete: "name"
       end
 
       def fields_for_name_with_or_without_title
-        form_builder.govuk_fieldset legend: { text: question_text_with_extra_suffix, tag: "h1", size: "l" }, described_by: hint_id do
+        form_builder.govuk_fieldset legend: { text: question_text_with_extra_suffix, **question_text_size_and_tag }, described_by: hint_id do
           form_fields = if is_full_name?
                           [
                             (form_builder.govuk_text_field :full_name, label: { text: t("question/name.label.full_name") }, autocomplete: "name"),

--- a/app/components/question/national_insurance_number_component/view.html.erb
+++ b/app/components/question/national_insurance_number_component/view.html.erb
@@ -1,5 +1,5 @@
 <%= form_builder.govuk_text_field :national_insurance_number,
-                          label: { tag: 'h1', size: 'l', text: question_text_with_extra_suffix },
+                          label: { text: question_text_with_extra_suffix, **question_text_size_and_tag },
                           hint: { text: question.hint_text },
                           width: 10,
                           spellcheck: false

--- a/app/components/question/number_component/view.html.erb
+++ b/app/components/question/number_component/view.html.erb
@@ -3,8 +3,6 @@
   https://design-system.service.gov.uk/components/text-input/#avoid-using-inputs-with-a-type-of-number
 %>
 <%= form_builder.govuk_text_field :number,
-                                  label: { tag: 'h1',
-                                           size: 'l',
-                                           text: question_text_with_extra_suffix },
+                                  label: { text: question_text_with_extra_suffix, **question_text_size_and_tag },
                                   hint: { text: question.hint_text },
                                   spellcheck: false %>

--- a/app/components/question/organisation_name_component/view.html.erb
+++ b/app/components/question/organisation_name_component/view.html.erb
@@ -1,4 +1,4 @@
 <%= form_builder.govuk_text_field :text,
-                                  label: { tag: 'h1', size: 'l', text: question_text_with_extra_suffix },
+                                  label: { text: question_text_with_extra_suffix, **question_text_size_and_tag },
                                   hint: { text: question.hint_text },
                                   autocomplete: "organization" %>

--- a/app/components/question/phone_number_component/view.html.erb
+++ b/app/components/question/phone_number_component/view.html.erb
@@ -1,5 +1,5 @@
 <%= form_builder.govuk_phone_field :phone_number,
-                                   label: { tag: 'h1', size: 'l', text: question_text_with_extra_suffix },
+                                   label: { text: question_text_with_extra_suffix, **question_text_size_and_tag },
                                    hint: { text: question.hint_text },
                                    width: 20,
                                    autocomplete: 'tel'

--- a/app/components/question/selection_component/view.rb
+++ b/app/components/question/selection_component/view.rb
@@ -14,13 +14,13 @@ module Question
       end
 
       def build_single_answer_list_from_a_list
-        form_builder.govuk_radio_buttons_fieldset(:selection, legend: { tag: "h1", size: "l", text: question_text_with_extra_suffix }, hint: { text: question.hint_text }) do
+        form_builder.govuk_radio_buttons_fieldset(:selection, legend: { text: question_text_with_extra_suffix, **question_text_size_and_tag }, hint: { text: question.hint_text }) do
           safe_join([hidden_field, radio_button_options, none_of_the_above_radio_button].compact_blank)
         end
       end
 
       def build_multiple_answers_from_a_list
-        form_builder.govuk_check_boxes_fieldset(:selection, legend: { tag: "h1", size: "l", text: question_text_with_extra_suffix }, hint: { text: question.hint_text }) do
+        form_builder.govuk_check_boxes_fieldset(:selection, legend: { text: question_text_with_extra_suffix, **question_text_size_and_tag }, hint: { text: question.hint_text }) do
           safe_join([checkbox_options, none_of_the_above_checkbox].compact_blank)
         end
       end

--- a/app/components/question/text_component/view.html.erb
+++ b/app/components/question/text_component/view.html.erb
@@ -1,17 +1,11 @@
 <% if question.answer_settings.input_type == "single_line" %>
   <%= form_builder.govuk_text_field :text,
-                                    label: { tag: 'h1',
-                                             size: 'l',
-                                             text: question_text_with_extra_suffix
-                                    },
+                                    label: { text: question_text_with_extra_suffix, **question_text_size_and_tag },
                                     hint: { text: question.hint_text },
                                     width: 'one-half' %>
 <% else %>
   <%= form_builder.govuk_text_area :text,
-                                   label: { tag: 'h1',
-                                            size: 'l',
-                                            text:  question_text_with_extra_suffix
-                                   },
+                                   label: { text:  question_text_with_extra_suffix, **question_text_size_and_tag },
                                    hint: { text: question.hint_text },
                                    rows: 5 %>
 <% end %>

--- a/app/lib/question_register.rb
+++ b/app/lib/question_register.rb
@@ -25,6 +25,13 @@ class QuestionRegister
               raise ArgumentError, "Unexpected answer_type for page #{page.id}: #{page.answer_type}"
             end
     hint_text = page.respond_to?(:hint_text) ? page.hint_text : nil
-    klass.new({}, { question_text: page.question_text, hint_text:, is_optional: page.is_optional, answer_settings: page.answer_settings })
+    page_heading = page.respond_to?(:page_heading) ? page.page_heading : nil
+    guidance_markdown = page.respond_to?(:additional_guidance_markdown) ? page.additional_guidance_markdown : nil
+    klass.new({}, { question_text: page.question_text,
+                    hint_text:,
+                    is_optional: page.is_optional,
+                    answer_settings: page.answer_settings,
+                    page_heading:,
+                    guidance_markdown: })
   end
 end

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -5,7 +5,7 @@ module Question
     include ActiveModel::Serialization
     include ActiveModel::Attributes
 
-    attr_accessor :question_text, :hint_text, :answer_settings, :is_optional
+    attr_accessor :question_text, :hint_text, :answer_settings, :is_optional, :page_heading, :guidance_markdown
 
     def initialize(attributes = {}, options = {})
       super(attributes)
@@ -13,6 +13,8 @@ module Question
       @hint_text = options[:hint_text]
       @is_optional = options[:is_optional]
       @answer_settings = options[:answer_settings]
+      @page_heading = options[:page_heading]
+      @guidance_markdown = options[:guidance_markdown]
     end
 
     def attributes

--- a/spec/components/question/address_component/view_spec.rb
+++ b/spec/components/question/address_component/view_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Question::AddressComponent::View, type: :component do
     let(:question) { build :uk_address_question }
 
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text)
+      expect(page.find("legend h1")).to have_text(question.question_text)
     end
 
     it "renders 5 text fields (Address line 1, Address line 2, Town or city, County, Postcode) and include autocomplete" do
@@ -52,13 +52,21 @@ RSpec.describe Question::AddressComponent::View, type: :component do
         expect(page.find("h1").native.inner_html).to eq(expected_output)
       end
     end
+
+    context "when question has guidance" do
+      let(:question) { build :uk_address_question, :with_guidance }
+
+      it "renders the question text as a legend" do
+        expect(page.find("legend.govuk-fieldset__legend--m")).to have_text(question.question_text)
+      end
+    end
   end
 
   describe "when component is international address field" do
     let(:question) { build :international_address_question }
 
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text)
+      expect(page.find("legend h1")).to have_text(question.question_text)
     end
 
     it "renders 1 textarea (Street Address and 1 input(Country) and includes autocomplete" do
@@ -91,6 +99,14 @@ RSpec.describe Question::AddressComponent::View, type: :component do
       it "returns the escaped title with the optional suffix" do
         expected_output = "What is your name? &lt;script&gt;alert(\"Hi\")&lt;/script&gt; <span>Some trusted html</span>"
         expect(page.find("h1").native.inner_html).to eq(expected_output)
+      end
+    end
+
+    context "when question has guidance" do
+      let(:question) { build :international_address_question, :with_guidance }
+
+      it "renders the question text as a legend" do
+        expect(page.find("legend.govuk-fieldset__legend--m")).to have_text(question.question_text)
       end
     end
   end
@@ -126,12 +142,20 @@ RSpec.describe Question::AddressComponent::View, type: :component do
     end
 
     context "with unsafe question text" do
-      let(:question) { build :international_address_question, question_text: "What is your name? <script>alert(\"Hi\")</script>" }
+      let(:question) { build :address, question_text: "What is your name? <script>alert(\"Hi\")</script>" }
       let(:extra_question_text_suffix) { "<span>Some trusted html</span>" }
 
       it "returns the escaped title with the optional suffix" do
         expected_output = "What is your name? &lt;script&gt;alert(\"Hi\")&lt;/script&gt; <span>Some trusted html</span>"
         expect(page.find("h1").native.inner_html).to eq(expected_output)
+      end
+    end
+
+    context "when question has guidance" do
+      let(:question) { build :address, :with_guidance }
+
+      it "renders the question text as a legend" do
+        expect(page.find("legend.govuk-fieldset__legend--m")).to have_text(question.question_text)
       end
     end
   end

--- a/spec/components/question/date_component/view_spec.rb
+++ b/spec/components/question/date_component/view_spec.rb
@@ -4,7 +4,14 @@ RSpec.describe Question::DateComponent::View, type: :component do
   let(:question_page) { build :page, :with_date_settings, input_type: }
   let(:input_type) { "other_date" }
   let(:answer_text) { nil }
-  let(:question) { OpenStruct.new(date: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings:) }
+  let(:question) do
+    OpenStruct.new(date: answer_text,
+                   question_text_with_optional_suffix: question_page.question_text,
+                   hint_text: question_page.hint_text,
+                   answer_settings:,
+                   page_heading: question_page.page_heading,
+                   guidance_markdown: question_page.additional_guidance_markdown)
+  end
   let(:answer_settings) { question_page.answer_settings }
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
@@ -18,7 +25,7 @@ RSpec.describe Question::DateComponent::View, type: :component do
 
   describe "when component is other date field" do
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
+      expect(page.find("legend h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders 3 text fields (day, month, year)" do
@@ -55,7 +62,7 @@ RSpec.describe Question::DateComponent::View, type: :component do
       let(:extra_question_text_suffix) { "Some extra text to add to the question text" }
 
       it "renders the question text and extra suffix as a heading" do
-        expect(page.find("h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+        expect(page.find("legend h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
       end
     end
 
@@ -68,13 +75,21 @@ RSpec.describe Question::DateComponent::View, type: :component do
         expect(page.find("h1").native.inner_html).to eq(expected_output)
       end
     end
+
+    context "when question has guidance" do
+      let(:question_page) { build :page, :with_guidance, :with_date_settings }
+
+      it "renders the question text as a legend" do
+        expect(page.find("legend.govuk-fieldset__legend--m")).to have_text(question_page.question_text)
+      end
+    end
   end
 
   describe "when component is date of birth field" do
     let(:input_type) { "date_of_birth" }
 
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
+      expect(page.find("legend h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders 3 text fields (day, month, year)" do
@@ -121,7 +136,15 @@ RSpec.describe Question::DateComponent::View, type: :component do
 
       it "returns the escaped title with the optional suffix" do
         expected_output = "What is your name? &lt;script&gt;alert(\"Hi\")&lt;/script&gt; <span>Some trusted html</span>"
-        expect(page.find("h1").native.inner_html).to eq(expected_output)
+        expect(page.find("legend h1").native.inner_html).to eq(expected_output)
+      end
+    end
+
+    context "when question has guidance" do
+      let(:question_page) { build :page, :with_guidance, :with_date_settings }
+
+      it "renders the question text as a legend" do
+        expect(page.find("legend.govuk-fieldset__legend--m")).to have_text(question_page.question_text)
       end
     end
   end
@@ -130,7 +153,7 @@ RSpec.describe Question::DateComponent::View, type: :component do
     let(:answer_settings) { nil }
 
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
+      expect(page.find("legend h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders 3 text fields (day, month, year)" do
@@ -143,6 +166,14 @@ RSpec.describe Question::DateComponent::View, type: :component do
       expect(page).not_to have_css("input[type='text'][autocomplete='bday-day']")
       expect(page).not_to have_css("input[type='text'][autocomplete='bday-month']")
       expect(page).not_to have_css("input[type='text'][autocomplete='bday-year']")
+    end
+
+    context "when question has guidance" do
+      let(:question_page) { build :page, :with_guidance, answer_type: "date", answer_settings: }
+
+      it "renders the question text as a legend" do
+        expect(page.find("legend.govuk-fieldset__legend--m")).to have_text(question_page.question_text)
+      end
     end
   end
 end

--- a/spec/components/question/email_component/view_spec.rb
+++ b/spec/components/question/email_component/view_spec.rb
@@ -3,7 +3,14 @@ require "rails_helper"
 RSpec.describe Question::EmailComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "email" }
   let(:answer_text) { nil }
-  let(:question) { OpenStruct.new(email: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) do
+    OpenStruct.new(email: answer_text,
+                   question_text_with_optional_suffix: question_page.question_text,
+                   hint_text: question_page.hint_text,
+                   answer_settings: nil,
+                   page_heading: question_page.page_heading,
+                   guidance_markdown: question_page.additional_guidance_markdown)
+  end
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
@@ -47,17 +54,25 @@ RSpec.describe Question::EmailComponent::View, type: :component do
       let(:extra_question_text_suffix) { "Some extra text to add to the question text" }
 
       it "renders the question text and extra suffix as a heading" do
-        expect(page.find("h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+        expect(page.find("h1 label")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
       end
     end
 
     context "with unsafe question text" do
-      let(:question_page) { build :page, answer_type: "number", question_text: "What is your name? <script>alert(\"Hi\")</script>" }
+      let(:question_page) { build :page, answer_type: "email", question_text: "What is your name? <script>alert(\"Hi\")</script>" }
       let(:extra_question_text_suffix) { "<span>Some trusted html</span>" }
 
       it "returns the escaped title with the optional suffix" do
         expected_output = "What is your name? &lt;script&gt;alert(\"Hi\")&lt;/script&gt; <span>Some trusted html</span>"
         expect(page.find("h1 .govuk-label").native.inner_html).to eq(expected_output)
+      end
+    end
+
+    context "when question has guidance" do
+      let(:question_page) { build :page, :with_guidance, answer_type: "email" }
+
+      it "renders the question text as a label" do
+        expect(page.find("label.govuk-label--m")).to have_text(question_page.question_text)
       end
     end
   end

--- a/spec/components/question/national_insurance_number_component/view_spec.rb
+++ b/spec/components/question/national_insurance_number_component/view_spec.rb
@@ -3,7 +3,14 @@ require "rails_helper"
 RSpec.describe Question::NationalInsuranceNumberComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "national_insurance_number" }
   let(:answer_text) { nil }
-  let(:question) { OpenStruct.new(national_insurance_number: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) do
+    OpenStruct.new(national_insurance_number: answer_text,
+                   question_text_with_optional_suffix: question_page.question_text,
+                   hint_text: question_page.hint_text,
+                   answer_settings: nil,
+                   page_heading: question_page.page_heading,
+                   guidance_markdown: question_page.additional_guidance_markdown)
+  end
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
@@ -47,17 +54,25 @@ RSpec.describe Question::NationalInsuranceNumberComponent::View, type: :componen
       let(:extra_question_text_suffix) { "Some extra text to add to the question text" }
 
       it "renders the question text and extra suffix as a heading" do
-        expect(page.find("h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+        expect(page.find("h1 label")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
       end
     end
 
     context "with unsafe question text" do
-      let(:question_page) { build :page, answer_type: "number", question_text: "What is your name? <script>alert(\"Hi\")</script>" }
+      let(:question_page) { build :page, answer_type: "national_insurance_number", question_text: "What is your name? <script>alert(\"Hi\")</script>" }
       let(:extra_question_text_suffix) { "<span>Some trusted html</span>" }
 
       it "returns the escaped title with the optional suffix" do
         expected_output = "What is your name? &lt;script&gt;alert(\"Hi\")&lt;/script&gt; <span>Some trusted html</span>"
         expect(page.find("h1 .govuk-label").native.inner_html).to eq(expected_output)
+      end
+    end
+
+    context "when question has guidance" do
+      let(:question_page) { build :page, :with_guidance, answer_type: "national_insurance_number" }
+
+      it "renders the question text as a label" do
+        expect(page.find("label.govuk-label--m")).to have_text(question_page.question_text)
       end
     end
   end

--- a/spec/components/question/number_component/view_spec.rb
+++ b/spec/components/question/number_component/view_spec.rb
@@ -3,7 +3,14 @@ require "rails_helper"
 RSpec.describe Question::NumberComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "number" }
   let(:answer_text) { nil }
-  let(:question) { OpenStruct.new(number: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) do
+    OpenStruct.new(number: answer_text,
+                   question_text_with_optional_suffix: question_page.question_text,
+                   hint_text: question_page.hint_text,
+                   answer_settings: nil,
+                   page_heading: question_page.page_heading,
+                   guidance_markdown: question_page.additional_guidance_markdown)
+  end
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
@@ -43,7 +50,7 @@ RSpec.describe Question::NumberComponent::View, type: :component do
       let(:extra_question_text_suffix) { "Some extra text to add to the question text" }
 
       it "renders the question text and extra suffix as a heading" do
-        expect(page.find("h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+        expect(page.find("h1 label")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
       end
     end
 
@@ -54,6 +61,14 @@ RSpec.describe Question::NumberComponent::View, type: :component do
       it "returns the escaped title with the optional suffix" do
         expected_output = "What is your name? &lt;script&gt;alert(\"Hi\")&lt;/script&gt; <span>Some trusted html</span>"
         expect(page.find("h1 .govuk-label").native.inner_html).to eq(expected_output)
+      end
+    end
+
+    context "when question has guidance" do
+      let(:question_page) { build :page, :with_guidance, answer_type: "number" }
+
+      it "renders the question text as a label" do
+        expect(page.find("label.govuk-label--m")).to have_text(question_page.question_text)
       end
     end
   end

--- a/spec/components/question/organisation_name_component/view_spec.rb
+++ b/spec/components/question/organisation_name_component/view_spec.rb
@@ -3,7 +3,14 @@ require "rails_helper"
 RSpec.describe Question::OrganisationNameComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "organisation_name" }
   let(:answer_text) { nil }
-  let(:question) { OpenStruct.new(text: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) do
+    OpenStruct.new(text: answer_text,
+                   question_text_with_optional_suffix: question_page.question_text,
+                   hint_text: question_page.hint_text,
+                   answer_settings: nil,
+                   page_heading: question_page.page_heading,
+                   guidance_markdown: question_page.additional_guidance_markdown)
+  end
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
@@ -16,7 +23,7 @@ RSpec.describe Question::OrganisationNameComponent::View, type: :component do
 
   describe "when component is organisation name field" do
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
+      expect(page.find("h1 label")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders a text input field" do
@@ -58,6 +65,14 @@ RSpec.describe Question::OrganisationNameComponent::View, type: :component do
       it "returns the escaped title with the optional suffix" do
         expected_output = "What is your name? &lt;script&gt;alert(\"Hi\")&lt;/script&gt; <span>Some trusted html</span>"
         expect(page.find("h1 .govuk-label").native.inner_html).to eq(expected_output)
+      end
+    end
+
+    context "when question has guidance" do
+      let(:question_page) { build :page, :with_guidance, answer_type: "organisation_name" }
+
+      it "renders the question text as a label" do
+        expect(page.find("label.govuk-label--m")).to have_text(question_page.question_text)
       end
     end
   end

--- a/spec/components/question/phone_number_component/view_spec.rb
+++ b/spec/components/question/phone_number_component/view_spec.rb
@@ -3,7 +3,14 @@ require "rails_helper"
 RSpec.describe Question::PhoneNumberComponent::View, type: :component do
   let(:question_page) { build :page, answer_type: "phone_number" }
   let(:answer_text) { nil }
-  let(:question) { OpenStruct.new(phone_number: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: nil) }
+  let(:question) do
+    OpenStruct.new(phone_number: answer_text,
+                   question_text_with_optional_suffix: question_page.question_text,
+                   hint_text: question_page.hint_text,
+                   answer_settings: nil,
+                   page_heading: question_page.page_heading,
+                   guidance_markdown: question_page.additional_guidance_markdown)
+  end
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
@@ -16,7 +23,7 @@ RSpec.describe Question::PhoneNumberComponent::View, type: :component do
 
   describe "when component is phone number field" do
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
+      expect(page.find("h1 label")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders a telephone input field" do
@@ -51,7 +58,7 @@ RSpec.describe Question::PhoneNumberComponent::View, type: :component do
       let(:extra_question_text_suffix) { "Some extra text to add to the question text" }
 
       it "renders the question text and extra suffix as a heading" do
-        expect(page.find("h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+        expect(page.find("h1 label")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
       end
     end
 
@@ -62,6 +69,14 @@ RSpec.describe Question::PhoneNumberComponent::View, type: :component do
       it "returns the escaped title with the optional suffix" do
         expected_output = "What is your phone number? &lt;script&gt;alert(\"Hi\")&lt;/script&gt; <span>Some trusted html</span>"
         expect(page.find("h1 .govuk-label").native.inner_html).to eq(expected_output)
+      end
+    end
+
+    context "when question has guidance" do
+      let(:question_page) { build :page, :with_guidance, answer_type: "phone_number" }
+
+      it "renders the question text as a label" do
+        expect(page.find("label.govuk-label--m")).to have_text(question_page.question_text)
       end
     end
   end

--- a/spec/components/question/selection_component/view_spec.rb
+++ b/spec/components/question/selection_component/view_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Question::SelectionComponent::View, type: :component do
     let(:question) { build :single_selection_question, is_optional: }
 
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text)
+      expect(page.find("legend h1")).to have_text(question.question_text)
     end
 
     it "contains the options" do
@@ -38,7 +38,7 @@ RSpec.describe Question::SelectionComponent::View, type: :component do
       let(:extra_question_text_suffix) { "Some extra text to add to the question text" }
 
       it "renders the question text and extra suffix as a heading" do
-        expect(page.find("h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+        expect(page.find("legend h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
       end
     end
 
@@ -61,6 +61,14 @@ RSpec.describe Question::SelectionComponent::View, type: :component do
 
       it "contains the 'None of the above' option" do
         expect(page).to have_css("input[type='radio'] + label", text: "None of the above")
+      end
+    end
+
+    context "when question has guidance" do
+      let(:question) { build :single_selection_question, :with_guidance }
+
+      it "renders the question text as a legend" do
+        expect(page.find("legend.govuk-fieldset__legend--m")).to have_text(question.question_text)
       end
     end
   end
@@ -112,6 +120,14 @@ RSpec.describe Question::SelectionComponent::View, type: :component do
 
       it "contains the 'None of the above' option" do
         expect(page).to have_css("input[type='checkbox'] + label", text: "None of the above")
+      end
+    end
+
+    context "when question has guidance" do
+      let(:question) { build :multiple_selection_question, :with_guidance }
+
+      it "renders the question text as a legend" do
+        expect(page.find("legend.govuk-fieldset__legend--m")).to have_text(question.question_text)
       end
     end
   end

--- a/spec/components/question/text_component/view_spec.rb
+++ b/spec/components/question/text_component/view_spec.rb
@@ -4,7 +4,14 @@ RSpec.describe Question::TextComponent::View, type: :component do
   let(:question_page) { build :page, :with_text_settings, input_type: }
   let(:input_type) { "single_line" }
   let(:answer_text) { nil }
-  let(:question) { OpenStruct.new(text: answer_text, question_text_with_optional_suffix: question_page.question_text, hint_text: question_page.hint_text, answer_settings: question_page.answer_settings) }
+  let(:question) do
+    OpenStruct.new(text: answer_text,
+                   question_text_with_optional_suffix: question_page.question_text,
+                   hint_text: question_page.hint_text,
+                   answer_settings: question_page.answer_settings,
+                   page_heading: question_page.page_heading,
+                   guidance_markdown: question_page.additional_guidance_markdown)
+  end
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
@@ -17,7 +24,7 @@ RSpec.describe Question::TextComponent::View, type: :component do
 
   describe "when component is short answer text field" do
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
+      expect(page.find("h1 label")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders a text input field" do
@@ -48,7 +55,25 @@ RSpec.describe Question::TextComponent::View, type: :component do
       let(:extra_question_text_suffix) { "Some extra text to add to the question text" }
 
       it "renders the question text and extra suffix as a heading" do
-        expect(page.find("h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+        expect(page.find("h1 label")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+      end
+    end
+
+    context "with unsafe question text" do
+      let(:question_page) { build :page, :with_text_settings, input_type:, question_text: "What is your name? <script>alert(\"Hi\")</script>" }
+      let(:extra_question_text_suffix) { "<span>Some trusted html</span>" }
+
+      it "returns the escaped title with the optional suffix" do
+        expected_output = "What is your name? &lt;script&gt;alert(\"Hi\")&lt;/script&gt; <span>Some trusted html</span>"
+        expect(page.find("h1 .govuk-label").native.inner_html).to eq(expected_output)
+      end
+    end
+
+    context "when question has guidance" do
+      let(:question_page) { build :page, :with_text_settings, :with_guidance, input_type: }
+
+      it "renders the question text as a label" do
+        expect(page.find("label.govuk-label--m")).to have_text(question_page.question_text)
       end
     end
   end
@@ -57,7 +82,7 @@ RSpec.describe Question::TextComponent::View, type: :component do
     let(:input_type) { "long_text" }
 
     it "renders the question text as a heading" do
-      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
+      expect(page.find("h1 label")).to have_text(question.question_text_with_optional_suffix)
     end
 
     it "renders a textarea field" do
@@ -84,11 +109,29 @@ RSpec.describe Question::TextComponent::View, type: :component do
       end
     end
 
+    context "with unsafe question text" do
+      let(:question_page) { build :page, :with_text_settings, input_type:, question_text: "What is your name? <script>alert(\"Hi\")</script>" }
+      let(:extra_question_text_suffix) { "<span>Some trusted html</span>" }
+
+      it "returns the escaped title with the optional suffix" do
+        expected_output = "What is your name? &lt;script&gt;alert(\"Hi\")&lt;/script&gt; <span>Some trusted html</span>"
+        expect(page.find("h1 .govuk-label").native.inner_html).to eq(expected_output)
+      end
+    end
+
     context "when there is extra suffix to be added to heading" do
       let(:extra_question_text_suffix) { "Some extra text to add to the question text" }
 
       it "renders the question text and extra suffix as a heading" do
-        expect(page.find("h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+        expect(page.find("h1 label")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+      end
+    end
+
+    context "when question has guidance" do
+      let(:question_page) { build :page, :with_text_settings, :with_guidance, input_type: }
+
+      it "renders the question text as a label" do
+        expect(page.find("label.govuk-label--m")).to have_text(question_page.question_text)
       end
     end
   end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -15,12 +15,19 @@ FactoryBot.define do
     answer_type { Page::ANSWER_TYPES.reject { |item| Page::ANSWER_TYPES_WITH_SETTINGS.include? item }.sample }
     is_optional { nil }
     answer_settings { nil }
+    page_heading { nil }
+    additional_guidance_markdown { nil }
     hint_text { nil }
     routing_conditions { [] }
     sequence(:position) { |n| n }
 
     trait :with_hints do
       hint_text { Faker::Quote.yoda }
+    end
+
+    trait :with_guidance do
+      page_heading { Faker::Quote.yoda }
+      additional_guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
     end
 
     trait :with_simple_answer_type do

--- a/spec/factories/models/question/address.rb
+++ b/spec/factories/models/question/address.rb
@@ -3,6 +3,9 @@ FactoryBot.define do
     question_text { Faker::Lorem.question }
     hint_text { nil }
     is_optional { false }
+    page_heading { nil }
+    guidance_markdown { nil }
+
     address1 { nil }
     address2 { nil }
     town_or_city { nil }
@@ -14,6 +17,11 @@ FactoryBot.define do
 
     trait :with_hints do
       hint_text { Faker::Quote.yoda }
+    end
+
+    trait :with_guidance do
+      page_heading { Faker::Quote.yoda }
+      guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
     end
 
     factory :uk_address_question do

--- a/spec/factories/models/question/selection.rb
+++ b/spec/factories/models/question/selection.rb
@@ -8,6 +8,11 @@ FactoryBot.define do
       hint_text { Faker::Quote.yoda }
     end
 
+    trait :with_guidance do
+      page_heading { Faker::Quote.yoda }
+      guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
+    end
+
     factory :single_selection_question do
       transient do
         selection_options { [DataStruct.new(name: "Option 1"),  DataStruct.new(name: "Option 2")] }

--- a/spec/lib/question_register_spec.rb
+++ b/spec/lib/question_register_spec.rb
@@ -27,4 +27,15 @@ RSpec.describe QuestionRegister do
       end
     end
   end
+
+  context "when a question has guidance" do
+    it "creates a question class with the page_heading and guidance_markdown" do
+      %i[date address email national_insurance_number phone_number number organisation_name text].each do |type|
+        page = OpenStruct.new(answer_type: type, page_heading: "New page heading", additional_guidance_markdown: "## Heading level 2")
+        result = described_class.from_page(page)
+        expect(result.page_heading).to eq page.page_heading
+        expect(result.guidance_markdown).to eq page.additional_guidance_markdown
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?
- refactors how we set answer type view components tag and font size
- passes page_heading/additional_guidance_markdown to the QuestionRegister so we can use it on the page and components.
- adjust all the answer type view components to toggle between using heading and native legend/labels

Trello card: https://trello.com/c/R5aZ0LWX/950-update-forms-runner-to-display-additional-guidance-to-form-fillers

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
