### PR TITLE
Increase width of single line of text input

### DIFF
--- a/app/components/question/text_component/view.html.erb
+++ b/app/components/question/text_component/view.html.erb
@@ -1,8 +1,7 @@
 <% if question.answer_settings.input_type == "single_line" %>
   <%= form_builder.govuk_text_field :text,
                                     label: { text: question_text_with_extra_suffix, **question_text_size_and_tag },
-                                    hint: { text: question.hint_text },
-                                    width: 'one-half' %>
+                                    hint: { text: question.hint_text } %>
 <% else %>
   <%= form_builder.govuk_text_area :text,
                                    label: { text:  question_text_with_extra_suffix, **question_text_size_and_tag },

--- a/spec/components/question/text_component/view_spec.rb
+++ b/spec/components/question/text_component/view_spec.rb
@@ -31,10 +31,6 @@ RSpec.describe Question::TextComponent::View, type: :component do
       expect(page).to have_css("input[type='text'][name='form[text]']")
     end
 
-    it "renders at one half the width of the parent container" do
-      expect(page.native.to_html).to include('class="govuk-input govuk-!-width-one-half"')
-    end
-
     context "when the user has provided an answer" do
       let(:answer_text) { Faker::Quote.yoda }
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/yzKobeRo/977-single-line-text-inputs-should-be-wider

We want the width of the input to be at least two-thirds the width of the page. This commit just removes the `one-half` width qualifier, so the input fluidly fills the space available. As the form group is in a two-thirds grid column, this fulfils the requirement.

<details>
<summary><h3>Screenshots of changes</h3></summary>

#### Before

![Screenshot of single line of text input before changes](https://github.com/alphagov/forms-runner/assets/503614/8571fe62-f6a0-42a8-9470-a9fbf802b957)

#### After

![Screenshot of single line of text input after changes](https://github.com/alphagov/forms-runner/assets/503614/cf18c830-ba68-4381-9384-4ee99fac7949)


</details>

I went through the all question types form by hand and checked that only the single line of text question was affected.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?