### PR TITLE
Rename additional_guidance_markdown to guidance_markdown

### DIFF
--- a/app/lib/question_register.rb
+++ b/app/lib/question_register.rb
@@ -26,7 +26,7 @@ class QuestionRegister
             end
     hint_text = page.respond_to?(:hint_text) ? page.hint_text : nil
     page_heading = page.respond_to?(:page_heading) ? page.page_heading : nil
-    guidance_markdown = page.respond_to?(:additional_guidance_markdown) ? page.additional_guidance_markdown : nil
+    guidance_markdown = page.respond_to?(:guidance_markdown) ? page.guidance_markdown : nil
     klass.new({}, { question_text: page.question_text,
                     hint_text:,
                     is_optional: page.is_optional,

--- a/spec/components/question/date_component/view_spec.rb
+++ b/spec/components/question/date_component/view_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Question::DateComponent::View, type: :component do
                    hint_text: question_page.hint_text,
                    answer_settings:,
                    page_heading: question_page.page_heading,
-                   guidance_markdown: question_page.additional_guidance_markdown)
+                   guidance_markdown: question_page.guidance_markdown)
   end
   let(:answer_settings) { question_page.answer_settings }
   let(:extra_question_text_suffix) { nil }

--- a/spec/components/question/email_component/view_spec.rb
+++ b/spec/components/question/email_component/view_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Question::EmailComponent::View, type: :component do
                    hint_text: question_page.hint_text,
                    answer_settings: nil,
                    page_heading: question_page.page_heading,
-                   guidance_markdown: question_page.additional_guidance_markdown)
+                   guidance_markdown: question_page.guidance_markdown)
   end
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do

--- a/spec/components/question/national_insurance_number_component/view_spec.rb
+++ b/spec/components/question/national_insurance_number_component/view_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Question::NationalInsuranceNumberComponent::View, type: :componen
                    hint_text: question_page.hint_text,
                    answer_settings: nil,
                    page_heading: question_page.page_heading,
-                   guidance_markdown: question_page.additional_guidance_markdown)
+                   guidance_markdown: question_page.guidance_markdown)
   end
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do

--- a/spec/components/question/number_component/view_spec.rb
+++ b/spec/components/question/number_component/view_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Question::NumberComponent::View, type: :component do
                    hint_text: question_page.hint_text,
                    answer_settings: nil,
                    page_heading: question_page.page_heading,
-                   guidance_markdown: question_page.additional_guidance_markdown)
+                   guidance_markdown: question_page.guidance_markdown)
   end
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do

--- a/spec/components/question/organisation_name_component/view_spec.rb
+++ b/spec/components/question/organisation_name_component/view_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Question::OrganisationNameComponent::View, type: :component do
                    hint_text: question_page.hint_text,
                    answer_settings: nil,
                    page_heading: question_page.page_heading,
-                   guidance_markdown: question_page.additional_guidance_markdown)
+                   guidance_markdown: question_page.guidance_markdown)
   end
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do

--- a/spec/components/question/phone_number_component/view_spec.rb
+++ b/spec/components/question/phone_number_component/view_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Question::PhoneNumberComponent::View, type: :component do
                    hint_text: question_page.hint_text,
                    answer_settings: nil,
                    page_heading: question_page.page_heading,
-                   guidance_markdown: question_page.additional_guidance_markdown)
+                   guidance_markdown: question_page.guidance_markdown)
   end
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do

--- a/spec/components/question/text_component/view_spec.rb
+++ b/spec/components/question/text_component/view_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Question::TextComponent::View, type: :component do
                    hint_text: question_page.hint_text,
                    answer_settings: question_page.answer_settings,
                    page_heading: question_page.page_heading,
-                   guidance_markdown: question_page.additional_guidance_markdown)
+                   guidance_markdown: question_page.guidance_markdown)
   end
   let(:extra_question_text_suffix) { nil }
   let(:form_builder) do

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     is_optional { nil }
     answer_settings { nil }
     page_heading { nil }
-    additional_guidance_markdown { nil }
+    guidance_markdown { nil }
     hint_text { nil }
     routing_conditions { [] }
     sequence(:position) { |n| n }
@@ -27,7 +27,7 @@ FactoryBot.define do
 
     trait :with_guidance do
       page_heading { Faker::Quote.yoda }
-      additional_guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
+      guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
     end
 
     trait :with_simple_answer_type do

--- a/spec/lib/question_register_spec.rb
+++ b/spec/lib/question_register_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe QuestionRegister do
   context "when a question has guidance" do
     it "creates a question class with the page_heading and guidance_markdown" do
       %i[date address email national_insurance_number phone_number number organisation_name text].each do |type|
-        page = OpenStruct.new(answer_type: type, page_heading: "New page heading", additional_guidance_markdown: "## Heading level 2")
+        page = OpenStruct.new(answer_type: type, page_heading: "New page heading", guidance_markdown: "## Heading level 2")
         result = described_class.from_page(page)
         expect(result.page_heading).to eq page.page_heading
-        expect(result.guidance_markdown).to eq page.additional_guidance_markdown
+        expect(result.guidance_markdown).to eq page.guidance_markdown
       end
     end
   end


### PR DESCRIPTION
This change is being made to shorten the field name, in line with changes in admin and the API

https://github.com/alphagov/forms-api/pull/316
https://github.com/alphagov/forms-admin/pull/602
