### PR TITLE
Run linting tasks sequentially

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   ],
   "scripts": {
     "test": "jest",
-    "lint": "standard | snazzy & stylelint 'app/**/*.scss'",
-    "format": "standard --fix & stylelint 'app/**/*.scss' --fix",
+    "lint": "standard | snazzy && stylelint 'app/**/*.scss'",
+    "format": "standard --fix && stylelint 'app/**/*.scss' --fix",
     "ci": "bin/setup && bin/rails server",
     "dev": "vite dev"
   },


### PR DESCRIPTION
### What problem does this pull request solve?
Runs the JS and style linting sequentially instead of in parallel. Running them in parallel meant that the linting tasks wouldn't break the build unless _both_ lints failed, so we saw issues being missed in forms-admin (see https://github.com/alphagov/forms-admin/pull/605).

The time saving from running them in parallel is negligible, so there shouldn't be any noticeable drawbacks to changing this.
