### PR TITLE
Bump govuk-forms-markdown gem from 0.2.1 to 0.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "govuk-components", "~> 4.1.0"
 gem "govuk_design_system_formbuilder", "~> 4.1.1"
 
 # Our own custom markdown renderer
-gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.2.1"
+gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.3.0"
 
 # For compiling our frontend assets
 gem "vite_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/alphagov/govuk-forms-markdown.git
-  revision: c1d9b83d7510b0f8d259238901de2bb9a5c2041c
-  tag: 0.2.1
+  revision: 673d4f1aea5328af7ed855dac75c156ebce92182
+  tag: 0.3.0
   specs:
-    govuk-forms-markdown (0.2.1)
+    govuk-forms-markdown (0.3.0)
       redcarpet (~> 3.6)
 
 GEM


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/16f0EohC/984-add-validations-warnings-to-govuk-forms-markdown-gem

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
