### PR TITLE
Remove web-console gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,17 +76,6 @@ group :development, :test do
   gem "brakeman", "~> 6.0"
 end
 
-group :development do
-  # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem "web-console"
-
-  # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
-  # gem "rack-mini-profiler"
-
-  # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
-  # gem "spring"
-end
-
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,6 @@ GEM
       erubi (~> 1.4)
       parser (>= 2.4)
       smart_properties
-    bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     brakeman (6.0.1)
@@ -408,11 +407,6 @@ GEM
       dry-cli (>= 0.7, < 2)
       rack-proxy (~> 0.6, >= 0.6.1)
       zeitwerk (~> 2.2)
-    web-console (4.2.0)
-      actionview (>= 6.0.0)
-      activemodel (>= 6.0.0)
-      bindex (>= 0.4.0)
-      railties (>= 6.0.0)
     websocket (1.2.9)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -463,7 +457,6 @@ DEPENDENCIES
   tzinfo-data
   uk_postcode
   vite_rails
-  web-console
 
 RUBY VERSION
    ruby 3.2.2p53


### PR DESCRIPTION
### What problem does this pull request solve?

The web-console gem is never used. It simply provides a Rails console in the browser. It also seems to be throwing an error:

```
Web Console is activated in the test environment. This is
usually a mistake. To ensure it's only activated in development
mode, move it to the development group of your Gemfile:

    gem 'web-console', group: :development

If you still want to run it in the test environment (and know
what you are doing), put this in your Rails application
configuration:

    config.web_console.development_only = false
```

since we put everything into the [default rake task](https://github.com/alphagov/forms-runner/pull/386) but can't work out why so removing for now rather than wasting more time on debugging. 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
