### PR TITLE
Log form_id with events

### DIFF
--- a/app/lib/event_logger.rb
+++ b/app/lib/event_logger.rb
@@ -8,6 +8,7 @@ class EventLogger
       url: request&.url,
       method: request&.method,
       form: context.form.name,
+      form_id: context.form.id,
       request_id: request&.request_id,
       event: "form_#{event}",
     })

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe EventLogger do
       url: "http://example.gov.uk",
       method: "GET",
       form: form.name,
+      form_id: form.id,
       request_id: nil,
       event: "form_visit",
     }


### PR DESCRIPTION
### What problem does this pull request solve?

To make it easier to correlate log messages from `event_logger` with other log messages, add the `form_id` to the log message. In our lograge configuration we use the form ID instead of the form name.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?