### PR TITLE
1059 increment metric in cloudwatch when a form is submitted

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,5 @@ group :test do
   # axe-core for running automated accessibility checks
   gem "axe-core-rspec"
 end
+
+gem "aws-sdk-cloudwatch"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,18 @@ GEM
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.828.0)
+    aws-sdk-cloudwatch (1.80.0)
+      aws-sdk-core (~> 3, >= 3.177.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-core (3.183.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sigv4 (1.6.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     axe-core-api (4.7.0)
       dumb_delegator
       virtus
@@ -215,6 +227,7 @@ GEM
     io-console (0.5.11)
     irb (1.4.1)
       reline (>= 0.3.0)
+    jmespath (1.6.2)
     json (2.6.3)
     jwt (2.5.0)
     lograge (0.13.0)
@@ -426,6 +439,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeresource
+  aws-sdk-cloudwatch
   axe-core-rspec
   bootsnap
   brakeman (~> 6.0)

--- a/app/controllers/forms/submit_answers_controller.rb
+++ b/app/controllers/forms/submit_answers_controller.rb
@@ -5,7 +5,7 @@ module Forms
         redirect_to error_repeat_submission_path(current_form.id)
       else
         unless mode.preview?
-          EventLogger.log_form_event(current_context, request, "submission")
+          LogEventService.log_submit(current_context, request)
         end
 
         FormSubmissionService.call(current_context:,

--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -1,0 +1,26 @@
+class CloudWatchService
+  def self.log_form_submission(form_id:)
+    region = "eu-west-2"
+    cloudwatch_client = Aws::CloudWatch::Client.new(region:)
+    cloudwatch_client.put_metric_data(
+      namespace: metric_namespace,
+      metric_data: [
+        {
+          metric_name: "submitted",
+          dimensions: [
+            {
+              name: "form_id",
+              value: form_id.to_s,
+            },
+          ],
+          value: 1,
+          unit: "Count",
+        },
+      ],
+    )
+  end
+
+  def self.metric_namespace
+    "forms/#{Settings.forms_env}".downcase
+  end
+end

--- a/app/services/log_event_service.rb
+++ b/app/services/log_event_service.rb
@@ -13,7 +13,11 @@ class LogEventService
 
   def self.log_submit(context, request)
     EventLogger.log_form_event(context, request, "submission") # Logging to Splunk
-    CloudWatchService.log_form_submission(form_id: context.form.id) # Logging to Cloudwatch
+    begin
+      CloudWatchService.log_form_submission(form_id: context.form.id) # Logging to Cloudwatch
+    rescue StandardError => e
+      Sentry.capture_exception(e)
+    end
   end
 
 private

--- a/app/services/log_event_service.rb
+++ b/app/services/log_event_service.rb
@@ -12,7 +12,8 @@ class LogEventService
   end
 
   def self.log_submit(context, request)
-    EventLogger.log_form_event(context, request, "submission")
+    EventLogger.log_form_event(context, request, "submission") # Logging to Splunk
+    CloudWatchService.log_form_submission(form_id: context.form.id) # Logging to Cloudwatch
   end
 
 private

--- a/app/services/log_event_service.rb
+++ b/app/services/log_event_service.rb
@@ -11,6 +11,10 @@ class LogEventService
     EventLogger.log_page_event(@current_context, @step, @request, log_event, skipped_question?)
   end
 
+  def self.log_submit(context, request)
+    EventLogger.log_form_event(context, request, "submission")
+  end
+
 private
 
   def log_event

--- a/spec/requests/forms/submit_answers_controller_spec.rb
+++ b/spec/requests/forms/submit_answers_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Forms::SubmitAnswersController, type: :request do
       mock.get "/api/v1/forms/2/live", req_headers, form_response_data.to_json, 200
     end
 
-    allow(EventLogger).to receive(:log_form_event).at_least(:once)
+    allow(LogEventService).to receive(:log_submit).at_least(:once)
 
     allow(Context).to receive(:new).and_wrap_original do |original_method, *args|
       context_spy = original_method.call(form: args[0][:form], store:)
@@ -97,7 +97,7 @@ RSpec.describe Forms::SubmitAnswersController, type: :request do
       end
 
       it "does not log the form_submission event" do
-        expect(EventLogger).not_to have_received(:log_form_event)
+        expect(LogEventService).not_to have_received(:log_submit)
       end
 
       it "emails the form submission" do
@@ -131,8 +131,8 @@ RSpec.describe Forms::SubmitAnswersController, type: :request do
         expect(response).to redirect_to(form_submitted_path)
       end
 
-      it "Logs the form_submission event" do
-        expect(EventLogger).to have_received(:log_form_event).with(instance_of(Context), instance_of(ActionDispatch::Request), "submission")
+      it "Logs the submit event with service logger" do
+        expect(LogEventService).to have_received(:log_submit).with(instance_of(Context), instance_of(ActionDispatch::Request))
       end
 
       it "emails the form submission" do

--- a/spec/services/cloud_watch_service_spec.rb
+++ b/spec/services/cloud_watch_service_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+require "aws-sdk-cloudwatch"
+
+RSpec.describe CloudWatchService do
+  describe ".submitted" do
+    let(:form_id) { 3 }
+    let(:forms_env) { "test" }
+
+    before do
+      allow(Settings).to receive(:forms_env).and_return(forms_env)
+    end
+
+    it "calls the cloudwatch client with put_metric_data" do
+      # Stub the CloudWatch client and put_metric_data method
+      cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
+      allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+
+      expect(cloudwatch_client).to receive(:put_metric_data).with(
+        namespace: "forms/#{forms_env}",
+        metric_data: [
+          {
+            metric_name: "submitted",
+            dimensions: [
+              {
+                name: "form_id",
+                value: form_id.to_s,
+              },
+            ],
+            value: 1,
+            unit: "Count",
+          },
+        ],
+      )
+
+      described_class.log_form_submission(form_id:)
+    end
+  end
+end

--- a/spec/services/log_event_service_spec.rb
+++ b/spec/services/log_event_service_spec.rb
@@ -1,12 +1,13 @@
 require "rails_helper"
 
 RSpec.describe LogEventService do
+  let(:request) { "request" }
+  let(:current_context) { "current_context" }
+
   describe "#log_page_save" do
     let(:changing_answers) { true }
     let(:step) { OpenStruct.new(question:) }
     let(:question) { OpenStruct.new(is_optional?: true) }
-    let(:request) { "request" }
-    let(:current_context) { "current_context" }
     let(:answers) { { "name": "John" } }
 
     it "calls the event logger with log_page_event" do
@@ -21,6 +22,20 @@ RSpec.describe LogEventService do
         request,
         "change_answer_optional_save",
         false,
+      )
+    end
+  end
+
+  describe ".log_form_submit" do
+    it "calls the event logger with the log_form_event" do
+      allow(EventLogger).to receive(:log_form_event).and_return(true)
+
+      described_class.log_submit(current_context, request)
+
+      expect(EventLogger).to have_received(:log_form_event).with(
+        current_context,
+        request,
+        "submission",
       )
     end
   end

--- a/spec/services/log_event_service_spec.rb
+++ b/spec/services/log_event_service_spec.rb
@@ -30,10 +30,12 @@ RSpec.describe LogEventService do
     let(:current_context) { OpenStruct.new(form:) }
     let(:form) { OpenStruct.new(id: 1) }
 
-    it "calls the event logger with .log_form_event" do
-      allow(CloudWatchService).to receive(:log_form_submission).and_return(true)
+    before do
       allow(EventLogger).to receive(:log_form_event).and_return(true)
+      allow(CloudWatchService).to receive(:log_form_submission).and_return(true)
+    end
 
+    it "calls the event logger with .log_form_event" do
       described_class.log_submit(current_context, request)
 
       expect(EventLogger).to have_received(:log_form_event).with(
@@ -44,12 +46,20 @@ RSpec.describe LogEventService do
     end
 
     it "calls the cloud watch service with .log_form_submission" do
-      allow(CloudWatchService).to receive(:log_form_submission).and_return(true)
-      allow(EventLogger).to receive(:log_form_event).and_return(true)
-
       described_class.log_submit(current_context, request)
 
       expect(CloudWatchService).to have_received(:log_form_submission).with(form_id: current_context.form.id)
+    end
+
+    context "when CloudWatchService returns an error" do
+      it "raises the error to Sentry" do
+        allow(CloudWatchService).to receive(:log_form_submission).and_raise(StandardError)
+        allow(Sentry).to receive(:capture_exception)
+
+        described_class.log_submit(current_context, request)
+
+        expect(Sentry).to have_received(:capture_exception)
+      end
     end
   end
 end

--- a/spec/services/log_event_service_spec.rb
+++ b/spec/services/log_event_service_spec.rb
@@ -27,7 +27,11 @@ RSpec.describe LogEventService do
   end
 
   describe ".log_form_submit" do
-    it "calls the event logger with the log_form_event" do
+    let(:current_context) { OpenStruct.new(form:) }
+    let(:form) { OpenStruct.new(id: 1) }
+
+    it "calls the event logger with .log_form_event" do
+      allow(CloudWatchService).to receive(:log_form_submission).and_return(true)
       allow(EventLogger).to receive(:log_form_event).and_return(true)
 
       described_class.log_submit(current_context, request)
@@ -37,6 +41,15 @@ RSpec.describe LogEventService do
         request,
         "submission",
       )
+    end
+
+    it "calls the cloud watch service with .log_form_submission" do
+      allow(CloudWatchService).to receive(:log_form_submission).and_return(true)
+      allow(EventLogger).to receive(:log_form_event).and_return(true)
+
+      described_class.log_submit(current_context, request)
+
+      expect(CloudWatchService).to have_received(:log_form_submission).with(form_id: current_context.form.id)
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/sSoCpSfL/1059-save-as-a-metric-in-cloudwatch-when-a-form-is-submitted

This PR contains a couple of changes:
* Refactoring the LogEventService to incorporate the EventLogger for for submissions. This involved moving the EventLogger call into here. 
* Adding a call to cloudwatch event logging. This is triggered when a form is submitted, and sends an event to Cloudwatch. 

### Things to consider when reviewing

This is a bit of a pain to test locally, but it can be done. You'll need to run the app with AWS credentials, which is doable from the command line with something like `$ gds-cli aws forms-dev-admin -- bundle exec rails s`. This will start the app up with the appropriate credentials to enable Cloudwatch logs. When you submit a form, it will send the form_id as part of a metric to Cloudwatch. You can find this Cloudwatch event by going on to the AWS Cloudwatch interface, and looking for your form ID in the appropriate namespace. I can demo this to anyone interested!

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
