### PR TITLE
Log page ID and slug with requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,8 @@ class ApplicationController < ActionController::Base
     payload[:host] = request.host
     payload[:request_id] = request.request_id
     payload[:form_id] = params[:form_id] if params[:form_id].present?
+    payload[:page_id] = params[:page_slug] if params[:page_slug].present? && params[:page_slug].match(Page::PAGE_ID_REGEX)
+    payload[:page_slug] = params[:page_slug] if params[:page_slug].present?
   end
 
 private

--- a/app/lib/step_factory.rb
+++ b/app/lib/step_factory.rb
@@ -1,6 +1,6 @@
 class StepFactory
   START_PAGE = "_start".freeze
-  PAGE_SLUG_REGEX = Regexp.union([/\d+/, Regexp.new(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)])
+  PAGE_SLUG_REGEX = Regexp.union([Page::PAGE_ID_REGEX, Regexp.new(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)])
 
   class PageNotFoundError < StandardError
     def initialize(msg = "Page not found.")

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,4 +1,6 @@
 class Page < ActiveResource::Base
+  PAGE_ID_REGEX = /\d+/
+
   self.site = Settings.forms_api.base_url
   self.prefix = "/api/v1/forms/:form_id/"
   self.include_format_in_path = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,6 +73,8 @@ module FormsRunner
         h[:host] = event.payload[:host]
         h[:request_id] = event.payload[:request_id]
         h[:form_id] = event.payload[:form_id] if event.payload[:form_id]
+        h[:page_id] = event.payload[:page_id] if event.payload[:page_id]
+        h[:page_slug] = event.payload[:page_slug] if event.payload[:page_slug]
         h[:exception] = event.payload[:exception] if event.payload[:exception]
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When searching Splunk for requests related to a particular page of a form it would be nice to be able to construct a query with `page_id=n`.

This PR adds the page ID to the log event JSON payload so that this will be possible in future.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?