### PR TITLE
Fix browserslist config to prevent unwanted Autoprefixer styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "app",
   "private": "true",
   "browserslist": [
-    ">0.1%",
+    ">0.1% and not dead",
     "last 2 Chrome versions",
     "last 2 Firefox versions",
     "last 2 Edge versions",


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: None

Our current [browserslist](https://browsersl.ist/) query unintentionally includes IE11, which does not support CSS grid but does support a vendor prefixed version with a different API. 

This means that when we use CSS grid syntax, Autoprefixer will automatically generate CSS using IE11's vendor prefixed grid syntax. This can cause broken layouts when we rely on CSS grid's automatic placement, which isn't supported in the IE11 implementation. In this commit we add 'and not dead' to the query to exclude unsupported browsers like IE11.

In forms-admin this change is included in https://github.com/alphagov/forms-admin/pull/663

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
