### PR TITLE
1072 save as a metric in cloudwatch when a form is started

### DIFF
--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -4,7 +4,7 @@ module Forms
 
     def redirect_to_friendly_url_start
       redirect_to form_page_path(params.require(:form_id), current_form.form_slug, current_form.start_page)
-      EventLogger.log_form_event(Context.new(form: current_form, store: session), request, "visit") unless mode.preview?
+      LogEventService.log_form_start(Context.new(form: current_form, store: session), request) unless mode.preview?
     end
 
     rescue_from ActiveResource::ResourceNotFound, StepFactory::PageNotFoundError do

--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -20,6 +20,27 @@ class CloudWatchService
     )
   end
 
+  def self.log_form_start(form_id:)
+    region = "eu-west-2"
+    cloudwatch_client = Aws::CloudWatch::Client.new(region:)
+    cloudwatch_client.put_metric_data(
+      namespace: metric_namespace,
+      metric_data: [
+        {
+          metric_name: "started",
+          dimensions: [
+            {
+              name: "form_id",
+              value: form_id.to_s,
+            },
+          ],
+          value: 1,
+          unit: "Count",
+        },
+      ],
+    )
+  end
+
   def self.metric_namespace
     "forms/#{Settings.forms_env}".downcase
   end

--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -1,7 +1,7 @@
 class CloudWatchService
+  REGION = "eu-west-2".freeze
+
   def self.log_form_submission(form_id:)
-    region = "eu-west-2"
-    cloudwatch_client = Aws::CloudWatch::Client.new(region:)
     cloudwatch_client.put_metric_data(
       namespace: metric_namespace,
       metric_data: [
@@ -21,8 +21,6 @@ class CloudWatchService
   end
 
   def self.log_form_start(form_id:)
-    region = "eu-west-2"
-    cloudwatch_client = Aws::CloudWatch::Client.new(region:)
     cloudwatch_client.put_metric_data(
       namespace: metric_namespace,
       metric_data: [
@@ -43,5 +41,9 @@ class CloudWatchService
 
   def self.metric_namespace
     "forms/#{Settings.forms_env}".downcase
+  end
+
+  def self.cloudwatch_client
+    Aws::CloudWatch::Client.new(region: REGION)
   end
 end

--- a/app/services/log_event_service.rb
+++ b/app/services/log_event_service.rb
@@ -7,6 +7,10 @@ class LogEventService
     @answers = answers
   end
 
+  def self.log_form_start(context, request)
+    EventLogger.log_form_event(context, request, "visit")
+  end
+
   def log_page_save
     EventLogger.log_page_event(@current_context, @step, @request, log_event, skipped_question?)
   end

--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Forms::BaseController, type: :request do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      allow(EventLogger).to receive(:log_form_event).at_least(:once)
+      allow(LogEventService).to receive(:log_form_start).at_least(:once)
       mock.get "/api/v1/forms/2#{api_url_suffix}", req_headers, form_response_data.to_json, 200
       mock.get "/api/v1/forms/9999#{api_url_suffix}", req_headers, no_data_found_response, 404
     end
@@ -80,7 +80,7 @@ RSpec.describe Forms::BaseController, type: :request do
   describe "#error_repeat_submission" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        allow(EventLogger).to receive(:log_form_event).at_least(:once)
+        allow(LogEventService).to receive(:log_form_start).at_least(:once)
         mock.get "/api/v1/forms/2/live", req_headers, form_response_data.to_json, 200
       end
 
@@ -110,7 +110,7 @@ RSpec.describe Forms::BaseController, type: :request do
             end
 
             it "does not log the form_visit event" do
-              expect(EventLogger).not_to have_received(:log_form_event)
+              expect(LogEventService).not_to have_received(:log_form_start)
             end
           end
 
@@ -186,7 +186,7 @@ RSpec.describe Forms::BaseController, type: :request do
             end
 
             it "does not log the form_visit event" do
-              expect(EventLogger).not_to have_received(:log_form_event)
+              expect(LogEventService).not_to have_received(:log_form_start)
             end
           end
 
@@ -262,7 +262,7 @@ RSpec.describe Forms::BaseController, type: :request do
             end
 
             it "Logs the form_visit event" do
-              expect(EventLogger).to have_received(:log_form_event).with(an_instance_of(Context), an_instance_of(ActionDispatch::Request), "visit")
+              expect(LogEventService).to have_received(:log_form_start).with(an_instance_of(Context), an_instance_of(ActionDispatch::Request))
             end
           end
 

--- a/spec/services/cloud_watch_service_spec.rb
+++ b/spec/services/cloud_watch_service_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "aws-sdk-cloudwatch"
 
 RSpec.describe CloudWatchService do
-  describe ".submitted" do
+  describe ".log_form_submission" do
     let(:form_id) { 3 }
     let(:forms_env) { "test" }
 
@@ -33,6 +33,40 @@ RSpec.describe CloudWatchService do
       )
 
       described_class.log_form_submission(form_id:)
+    end
+  end
+
+  describe ".log_form_start" do
+    let(:form_id) { 3 }
+    let(:forms_env) { "test" }
+
+    before do
+      allow(Settings).to receive(:forms_env).and_return(forms_env)
+    end
+
+    it "calls the cloudwatch client with put_metric_data" do
+      # Stub the CloudWatch client and put_metric_data method
+      cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
+      allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+
+      expect(cloudwatch_client).to receive(:put_metric_data).with(
+        namespace: "forms/#{forms_env}",
+        metric_data: [
+          {
+            metric_name: "started",
+            dimensions: [
+              {
+                name: "form_id",
+                value: form_id.to_s,
+              },
+            ],
+            value: 1,
+            unit: "Count",
+          },
+        ],
+      )
+
+      described_class.log_form_start(form_id:)
     end
   end
 end

--- a/spec/services/log_event_service_spec.rb
+++ b/spec/services/log_event_service_spec.rb
@@ -62,4 +62,20 @@ RSpec.describe LogEventService do
       end
     end
   end
+
+  describe ".log_form_start" do
+    before do
+      allow(EventLogger).to receive(:log_form_event).and_return(true)
+    end
+
+    it "calls the event logger with .log_form_event" do
+      described_class.log_form_start(current_context, request)
+
+      expect(EventLogger).to have_received(:log_form_event).with(
+        current_context,
+        request,
+        "visit",
+      )
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: [1072-save-as-a-metric-in-cloudwatch-when-a-form-is-started](https://trello.com/c/W2bh0Wgq/1072-save-as-a-metric-in-cloudwatch-when-a-form-is-started)

This introduces logging in CloudWatch for forms getting started. It's piggybacking on what used to be the existing EventLogger trigger, which has now been refactored into the LogEventService.

### Things to consider when reviewing

Very similar to the form submission logging. 

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
