### PR TITLE
refactor form_submission_service to have a main method to called

### DIFF
--- a/app/controllers/forms/submit_answers_controller.rb
+++ b/app/controllers/forms/submit_answers_controller.rb
@@ -10,7 +10,7 @@ module Forms
 
         FormSubmissionService.call(current_context:,
                                    reference: params[:notify_reference],
-                                   preview_mode: mode.preview?).submit_form_to_processing_team
+                                   preview_mode: mode.preview?).submit
         redirect_to :form_submitted
       end
     rescue StandardError => e

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -10,6 +10,7 @@ class FormSubmissionService
     @form = current_context.form
     @reference = reference
     @preview_mode = preview_mode
+    @timestamp = submission_timestamp
   end
 
   def submit
@@ -23,15 +24,13 @@ class FormSubmissionService
       raise StandardError, "Form id(#{@form.id}) is missing a submission email address"
     end
 
-    timestamp = submission_timestamp
-
     unless @form.submission_email.blank? && @preview_mode
       FormSubmissionMailer
         .email_completed_form(title: form_title,
                               text_input: email_body,
                               preview_mode: @preview_mode,
                               reference: @reference,
-                              timestamp:,
+                              timestamp: @timestamp,
                               submission_email: @form.submission_email).deliver_now
     end
   end

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -12,6 +12,10 @@ class FormSubmissionService
     @preview_mode = preview_mode
   end
 
+  def submit
+    submit_form_to_processing_team
+  end
+
   def submit_form_to_processing_team
     raise StandardError, "Form id(#{@form.id}) has no completed steps i.e questions/answers to include in submission email" if @current_context.completed_steps.blank?
 

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe FormSubmissionService do
   let(:step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer_in_email: "42" }) }
   let(:preview_mode) { false }
 
+  describe "#submit" do
+    it "calls submit_form_to_processing_team method" do
+      expect(service).to receive(:submit_form_to_processing_team).once
+      service.submit
+    end
+  end
+
   describe "#submit_form_to_processing_team" do
     it "calls FormSubmissionMailer" do
       freeze_time do


### PR DESCRIPTION
### What problem does this pull request solve?
We have one method which we call to email form submissions but we
want to add other functionality to form_submission_service. eg
once form has been submitted then send confirmation email to form
filler. This PR is the groundwork for these enhancements

Trello card: https://trello.com/c/A7YmTtGq/1104-send-confirmation-email-to-form-filler

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
