### PR TITLE
Send confirmation email to form fillers

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -20,7 +20,7 @@ module Forms
           end
 
           FormSubmissionService.call(current_context:,
-                                     reference: email_confirmation_form.notify_reference,
+                                     email_confirmation_form:,
                                      preview_mode: mode.preview?).submit
           redirect_to :form_submitted
         end

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -6,7 +6,7 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
       title:,
       what_happens_next_text:,
       support_contact_details:,
-      submission_time: submission_timestamp.strftime("%H:%M:%S"),
+      submission_time: submission_timestamp.strftime("%l:%M%P").strip,
       submission_date: submission_timestamp.strftime("%-d %B %Y"),
       # GOV.UK Notify's templates have conditionals, but only positive
       # conditionals, so to simulate negative conditionals we add two boolean

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -1,0 +1,27 @@
+class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
+  def send_confirmation_email(title:, what_happens_next_text:, support_contact_details:, submission_timestamp:, preview_mode:, confirmation_email_address:)
+    set_template(Settings.govuk_notify.form_filler_confirmation_email_template_id)
+
+    set_personalisation(
+      title:,
+      what_happens_next_text:,
+      support_contact_details:,
+      submission_time: submission_timestamp.strftime("%H:%M:%S"),
+      submission_date: submission_timestamp.strftime("%-d %B %Y"),
+      # GOV.UK Notify's templates have conditionals, but only positive
+      # conditionals, so to simulate negative conditionals we add two boolean
+      # flags; but they must always have opposite values!
+      test: make_notify_boolean(preview_mode),
+    )
+
+    set_email_reply_to(Settings.govuk_notify.form_submission_email_reply_to_id)
+
+    mail(to: confirmation_email_address)
+  end
+
+private
+
+  def make_notify_boolean(bool)
+    bool ? "yes" : "no"
+  end
+end

--- a/app/mailers/form_submission_mailer.rb
+++ b/app/mailers/form_submission_mailer.rb
@@ -5,7 +5,7 @@ class FormSubmissionMailer < GovukNotifyRails::Mailer
     set_personalisation(
       title:,
       text_input:,
-      submission_time: timestamp.strftime("%H:%M:%S"),
+      submission_time: timestamp.strftime("%l:%M%P").strip,
       submission_date: timestamp.strftime("%-d %B %Y"),
       # GOV.UK Notify's templates have conditionals, but only positive
       # conditionals, so to simulate negative conditionals we add two boolean

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -5,10 +5,11 @@ class FormSubmissionService
     end
   end
 
-  def initialize(current_context:, reference:, preview_mode:)
+  def initialize(current_context:, email_confirmation_form:, preview_mode:)
     @current_context = current_context
     @form = current_context.form
-    @reference = reference
+    @email_confirmation_form = email_confirmation_form
+    @reference = @email_confirmation_form.notify_reference
     @preview_mode = preview_mode
     @timestamp = submission_timestamp
   end

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -16,6 +16,7 @@ class FormSubmissionService
 
   def submit
     submit_form_to_processing_team
+    submit_confirmation_email_to_user if FeatureService.enabled?(:email_confirmations_enabled)
   end
 
   def submit_form_to_processing_team
@@ -34,6 +35,19 @@ class FormSubmissionService
                               timestamp: @timestamp,
                               submission_email: @form.submission_email).deliver_now
     end
+  end
+
+  def submit_confirmation_email_to_user
+    return nil unless @email_confirmation_form.send_confirmation == "send_email"
+
+    FormSubmissionConfirmationMailer.send_confirmation_email(
+      title: form_title,
+      what_happens_next_text: @form.what_happens_next_text,
+      support_contact_details: @form.support_email,
+      submission_timestamp: @timestamp,
+      preview_mode: @preview_mode,
+      confirmation_email_address: @email_confirmation_form.confirmation_email_address,
+    ).deliver_now
   end
 
   class NotifyTemplateBodyFilter

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,6 +16,7 @@ govuk_notify:
   api_key: changeme
   form_submission_email_reply_to_id: fab9373b-fb7c-483f-ae25-5a9852bfcc04
   form_submission_email_template_id: 427eb8bc-ce0d-40a3-bf54-d76e8c3ec916
+  form_filler_confirmation_email_template_id: 2d1f36dc-9799-43dd-8673-b631f9e0b4a5
 
 # Configuration for Sentry
 # Sentry will only initialise if dsn is set to some other value

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -37,6 +37,7 @@ describe "Settings" do
     include_examples expected_value_test, :api_key, govuk_notify, "changeme"
     include_examples expected_value_test, :form_submission_email_reply_to_id, govuk_notify, "fab9373b-fb7c-483f-ae25-5a9852bfcc04"
     include_examples expected_value_test, :form_submission_email_template_id, govuk_notify, "427eb8bc-ce0d-40a3-bf54-d76e8c3ec916"
+    include_examples expected_value_test, :form_filler_confirmation_email_template_id, govuk_notify, "2d1f36dc-9799-43dd-8673-b631f9e0b4a5"
   end
 
   describe "sentry" do

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
     org { "test-org" }
     live_at { nil }
+    what_happens_next_text { nil }
     support_email { nil }
     support_phone { nil }
     support_url { nil }

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -1,20 +1,28 @@
 require "rails_helper"
 
-describe FormSubmissionMailer, type: :mailer do
-  let(:mail) { described_class.email_completed_form(title:, text_input:, reference: "for-my-ref", preview_mode:, timestamp: submission_timestamp, submission_email:) }
+describe FormSubmissionConfirmationMailer, type: :mailer do
+  let(:mail) do
+    described_class.send_confirmation_email(title:,
+                                            what_happens_next_text:,
+                                            support_contact_details:,
+                                            submission_timestamp:,
+                                            preview_mode:,
+                                            confirmation_email_address:)
+  end
   let(:title) { "Form 1" }
-  let(:text_input) { "My question: My answer" }
+  let(:what_happens_next_text) { "Please wait for a response" }
+  let(:support_contact_details) { "Call: 0203 222 2222" }
   let(:preview_mode) { false }
-  let(:submission_email) { "testing@gov.uk" }
+  let(:confirmation_email_address) { "testing@gov.uk" }
   let(:submission_timestamp) { Time.zone.now }
 
-  context "when form filler submits a completed form" do
+  context "when form filler wants an form submission confirmation email" do
     it "sends an email with the correct template" do
-      Settings.govuk_notify.form_submission_email_template_id = "123456"
+      Settings.govuk_notify.form_filler_confirmation_email_template_id = "123456"
       expect(mail.govuk_notify_template).to eq("123456")
     end
 
-    it "sends an email to the form's submission email address" do
+    it "sends an email to the form filler's email address" do
       expect(mail.to).to eq(["testing@gov.uk"])
     end
 
@@ -22,17 +30,12 @@ describe FormSubmissionMailer, type: :mailer do
       expect(mail.govuk_notify_personalisation[:title]).to eq("Form 1")
     end
 
-    it "includes the form question and answers from the user" do
-      expect(mail.govuk_notify_personalisation[:text_input]).to eq("My question: My answer")
+    it "includes the forms what happens next" do
+      expect(mail.govuk_notify_personalisation[:what_happens_next_text]).to eq("Please wait for a response")
     end
 
-    it "includes the an email reference (mostly used to retrieve specific email in notify for e2e tests)" do
-      expect(mail.govuk_notify_reference).to eq("for-my-ref")
-    end
-
-    it "does not use the preview personalisation" do
-      expect(mail.govuk_notify_personalisation[:test]).to eq("no")
-      expect(mail.govuk_notify_personalisation[:not_test]).to eq("yes")
+    it "includes the forms support contact details" do
+      expect(mail.govuk_notify_personalisation[:support_contact_details]).to eq("Call: 0203 222 2222")
     end
 
     it "does include an email-reply-to" do
@@ -79,7 +82,6 @@ describe FormSubmissionMailer, type: :mailer do
 
       it "uses the preview personalisation" do
         expect(mail.govuk_notify_personalisation[:test]).to eq("yes")
-        expect(mail.govuk_notify_personalisation[:not_test]).to eq("no")
       end
     end
   end

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -45,11 +45,11 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
 
     describe "submission date/time" do
       context "with a time in BST" do
-        let(:timestamp) { Time.utc(2022, 9, 14, 10, 0o0, 0o0) }
+        let(:timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0) }
 
         it "includes the time user submitted the form" do
           travel_to timestamp do
-            expect(mail.govuk_notify_personalisation[:submission_time]).to eq("11:00:00")
+            expect(mail.govuk_notify_personalisation[:submission_time]).to eq("9:00am")
           end
         end
 
@@ -61,11 +61,11 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
       end
 
       context "with a time in GMT" do
-        let(:timestamp) { Time.utc(2022, 12, 14, 10, 0o0, 0o0) }
+        let(:timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
 
         it "includes the time user submitted the form" do
           travel_to timestamp do
-            expect(mail.govuk_notify_personalisation[:submission_time]).to eq("10:00:00")
+            expect(mail.govuk_notify_personalisation[:submission_time]).to eq("1:00pm")
           end
         end
 

--- a/spec/mailers/form_submission_mailer_spec.rb
+++ b/spec/mailers/form_submission_mailer_spec.rb
@@ -42,11 +42,11 @@ describe FormSubmissionMailer, type: :mailer do
 
     describe "submission date/time" do
       context "with a time in BST" do
-        let(:timestamp) { Time.utc(2022, 9, 14, 10, 0o0, 0o0) }
+        let(:timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0) }
 
         it "includes the time user submitted the form" do
           travel_to timestamp do
-            expect(mail.govuk_notify_personalisation[:submission_time]).to eq("11:00:00")
+            expect(mail.govuk_notify_personalisation[:submission_time]).to eq("9:00am")
           end
         end
 
@@ -58,11 +58,11 @@ describe FormSubmissionMailer, type: :mailer do
       end
 
       context "with a time in GMT" do
-        let(:timestamp) { Time.utc(2022, 12, 14, 10, 0o0, 0o0) }
+        let(:timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
 
         it "includes the time user submitted the form" do
           travel_to timestamp do
-            expect(mail.govuk_notify_personalisation[:submission_time]).to eq("10:00:00")
+            expect(mail.govuk_notify_personalisation[:submission_time]).to eq("1:00pm")
           end
         end
 

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -14,7 +14,11 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           pages: pages_data)
   end
 
-  let(:email_confirmation_form) { { send_confirmation: "send_email", confirmation_email_address: Faker::Internet.email } }
+  let(:email_confirmation_form) do
+    { send_confirmation: "send_email",
+      confirmation_email_address: Faker::Internet.email,
+      notify_reference: "for-my-ref" }
+  end
 
   let(:store) do
     {
@@ -320,7 +324,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       end
 
       context "when user has not requested a confirmation email" do
-        let(:email_confirmation_form) { { send_confirmation: "skip_confirmation", confirmation_email_address: nil } }
+        let(:email_confirmation_form) { { send_confirmation: "skip_confirmation", confirmation_email_address: nil, notify_reference: "for-my-ref" } }
 
         before do
           post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_form: }
@@ -332,7 +336,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       end
 
       context "when user has requested a confirmation email" do
-        let(:email_confirmation_form) { { send_confirmation: "skip_confirmation", confirmation_email_address: Faker::Internet.email } }
+        let(:email_confirmation_form) { { send_confirmation: "skip_confirmation", confirmation_email_address: Faker::Internet.email, notify_reference: "for-my-ref" } }
 
         before do
           post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_form: }

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expected_personalisation = {
           title: form_data.name,
           text_input: ".*",
-          submission_time: "09:47:57",
+          submission_time: "9:47am",
           submission_date: "13 March 2023",
           test: "yes",
           not_test: "no",
@@ -268,7 +268,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expected_personalisation = {
           title: form_data.name,
           text_input: ".*",
-          submission_time: "09:47:57",
+          submission_time: "9:47am",
           submission_date: "13 March 2023",
           test: "no",
           not_test: "yes",

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -2,16 +2,35 @@ require "rails_helper"
 
 RSpec.describe FormSubmissionService do
   let(:service) { described_class.call(current_context:, email_confirmation_form:, preview_mode:) }
-  let(:form) { OpenStruct.new(id: 1, name: "Form 1", submission_email: "testing@gov.uk") }
+  let(:form) do
+    build(:form,
+          :with_support,
+          id: 1,
+          name: "Form 1",
+          what_happens_next_text: "We usually respond to applications within 10 working days.",
+          submission_email: "testing@gov.uk")
+  end
   let(:current_context) { OpenStruct.new(form:, completed_steps: [step]) }
   let(:step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer_in_email: "42" }) }
   let(:preview_mode) { false }
-  let(:email_confirmation_form) { EmailConfirmationForm.new(notify_reference: "for-my-ref") }
+  let(:email_confirmation_form) { build :email_confirmation_form_opted_in }
 
   describe "#submit" do
     it "calls submit_form_to_processing_team method" do
       expect(service).to receive(:submit_form_to_processing_team).once
       service.submit
+    end
+
+    it "does not call submit_confirmation_email_to_user" do
+      expect(service).not_to receive(:submit_confirmation_email_to_user)
+      service.submit
+    end
+
+    describe "when email_confirmation feature is enabled", feature_email_confirmations_enabled: true do
+      it "calls submit_confirmation_email_to_user" do
+        expect(service).to receive(:submit_confirmation_email_to_user).once
+        service.submit
+      end
     end
   end
 
@@ -26,7 +45,7 @@ RSpec.describe FormSubmissionService do
         expect(FormSubmissionMailer).to have_received(:email_completed_form).with(
           { title: "Form 1",
             text_input: "# What is the meaning of life?\n42\n",
-            reference: "for-my-ref",
+            reference: email_confirmation_form.notify_reference,
             timestamp: Time.zone.now,
             submission_email: "testing@gov.uk",
             preview_mode: false },
@@ -66,7 +85,7 @@ RSpec.describe FormSubmissionService do
           expect(FormSubmissionMailer).to have_received(:email_completed_form).with(
             { title: "Form 1",
               text_input: "# What is the meaning of life?\n42\n",
-              reference: "for-my-ref",
+              reference: email_confirmation_form.notify_reference,
               timestamp: Time.zone.now,
               submission_email: "testing@gov.uk",
               preview_mode: true },
@@ -99,6 +118,41 @@ RSpec.describe FormSubmissionService do
             expect { result }.to raise_error("Form id(1) has no completed steps i.e questions/answers to include in submission email")
           end
         end
+      end
+    end
+  end
+
+  describe "#submit_confirmation_email_to_user" do
+    it "calls FormSubmissionConfirmationMailer" do
+      freeze_time do
+        delivery = double
+        expect(delivery).to receive(:deliver_now).with(no_args)
+        allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email).and_return(delivery)
+
+        service.submit_confirmation_email_to_user
+        expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
+          { title: "Form 1",
+            what_happens_next_text: form.what_happens_next_text,
+            support_contact_details: form.support_email,
+            submission_timestamp: Time.zone.now,
+            preview_mode:,
+            confirmation_email_address: email_confirmation_form.confirmation_email_address },
+        ).once
+      end
+    end
+
+    context "when user does not want a confirmation email" do
+      let(:email_confirmation_form) { build :email_confirmation_form }
+
+      it "does not call FormSubmissionConfirmationMailer" do
+        allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email)
+
+        service.submit_confirmation_email_to_user
+        expect(FormSubmissionConfirmationMailer).not_to have_received(:send_confirmation_email)
+      end
+
+      it "returns nil" do
+        expect(service.submit_confirmation_email_to_user).to be_nil
       end
     end
   end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.describe FormSubmissionService do
-  let(:service) { described_class.call(current_context:, reference: "for-my-ref", preview_mode:) }
+  let(:service) { described_class.call(current_context:, email_confirmation_form:, preview_mode:) }
   let(:form) { OpenStruct.new(id: 1, name: "Form 1", submission_email: "testing@gov.uk") }
   let(:current_context) { OpenStruct.new(form:, completed_steps: [step]) }
   let(:step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer_in_email: "42" }) }
   let(:preview_mode) { false }
+  let(:email_confirmation_form) { EmailConfirmationForm.new(notify_reference: "for-my-ref") }
 
   describe "#submit" do
     it "calls submit_form_to_processing_team method" do


### PR DESCRIPTION
### What problem does this pull request solve?

- Adds new email template id for confirmation emails
- Introduces a new mailer to send confirmation emails to form fillers
- Calls the new mailer from form_submission_service. if the feature flag is enabled and form filler provided a confirmation email
- refactors form submission service to accept a form_object instead of single params being passed in.
- fixes the time format used in e-mails to not include seconds and to use 12-hour clock


Trello card: https://trello.com/c/A7YmTtGq/1104-send-confirmation-email-to-form-filler

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
