### PR TITLE
Adding Support contact details for phone and online methods

### DIFF
--- a/app/components/support_details_component/view.html.erb
+++ b/app/components/support_details_component/view.html.erb
@@ -9,7 +9,7 @@
     <h3 class="govuk-heading-s"><%= t("support_details.phone") %></h3>
     <%= simple_format(@support_details.phone) %>
     <p class="govuk-body">
-      <a class="govuk-link" href="https://www.gov.uk/call-charges" target="_blank" rel="noopener noreferrer"><%= t("support_details.call_charges") %></a>
+      <a class="govuk-link" href="<% @support_details.call_charges_url %>" target="_blank" rel="noopener noreferrer"><%= t("support_details.call_charges") %></a>
     </p>
   <% end %>
   <% if @support_details.url.present? && @support_details.url_text.present? %>

--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -10,6 +10,7 @@ class Context
     @support_details = OpenStruct.new({
       email: form.support_email,
       phone: form.support_phone,
+      call_charges_url: "https://www.gov.uk/call-charges",
       url: form.support_url,
       url_text: form.support_url_text,
     })

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -133,6 +133,27 @@ private
   def formatted_support_details
     return nil unless has_support_contact_details?
 
-    @form.support_email.presence
+    [support_phone_details, support_email_details, support_online_details].compact_blank.join("\n\n")
+  end
+
+  def support_phone_details
+    return nil if @form.support_phone.blank?
+
+    notify_body = NotifyTemplateBodyFilter.new
+    formatted_phone_number = notify_body.normalize_whitespace(@form.support_phone)
+
+    "#{formatted_phone_number}\n\n[#{I18n.t('support_details.call_charges')}](#{@current_context.support_details.call_back_url})"
+  end
+
+  def support_email_details
+    return nil if @form.support_email.blank?
+
+    "[#{@form.support_email}](mailto:#{@form.support_email})"
+  end
+
+  def support_online_details
+    return nil if [@form.support_url, @form.support_url_text].all?(&:blank?)
+
+    "[#{@form.support_url_text}](#{@form.support_url})"
   end
 end

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -358,15 +358,24 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           expected_personalisation = {
             title: form_data.name,
             what_happens_next_text: form_data.what_happens_next_text,
-            support_contact_details: form_data.support_email,
+            support_contact_details: contact_support_details_format,
             submission_time: "10:00am",
             submission_date: "14 December 2022",
             test: "no",
           }
 
-          expect(mail.body.raw_source).to match(expected_personalisation.to_s)
+          expect(mail.body.raw_source).to include(expected_personalisation.to_s)
         end
       end
     end
+  end
+
+private
+
+  def contact_support_details_format
+    phone_number = "#{form_data.support_phone}\n\n[#{I18n.t('support_details.call_charges')}]()"
+    email = "[#{form_data.support_email}](mailto:#{form_data.support_email})"
+    online = "[#{form_data.support_url_text}](#{form_data.support_url})"
+    [phone_number, email, online].compact_blank.join("\n\n")
   end
 end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe FormSubmissionService do
   let(:support_url) { Faker::Internet.url(host: "gov.uk") }
   let(:support_url_text) { Faker::Lorem.sentence(word_count: 1, random_words_to_add: 4) }
 
-  let(:current_context) { OpenStruct.new(form:, completed_steps: [step]) }
+  let(:current_context) { OpenStruct.new(form:, completed_steps: [step], support_details: OpenStruct.new(call_back_url: "http://gov.uk")) }
   let(:step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer_in_email: "42" }) }
   let(:preview_mode) { false }
   let(:email_confirmation_form) { build :email_confirmation_form_opted_in }
@@ -142,7 +142,7 @@ RSpec.describe FormSubmissionService do
         expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
           { title: "Form 1",
             what_happens_next_text: form.what_happens_next_text,
-            support_contact_details: form.support_email,
+            support_contact_details: contact_support_details_format,
             submission_timestamp: Time.zone.now,
             preview_mode:,
             confirmation_email_address: email_confirmation_form.confirmation_email_address },
@@ -258,5 +258,14 @@ RSpec.describe FormSubmissionService do
         end
       end
     end
+  end
+
+private
+
+  def contact_support_details_format
+    phone_number = "#{form.support_phone}\n\n[#{I18n.t('support_details.call_charges')}](http://gov.uk)"
+    email = "[#{form.support_email}](mailto:#{form.support_email})"
+    online = "[#{form.support_url_text}](#{form.support_url})"
+    [phone_number, email, online].compact_blank.join("\n\n")
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Adds phone number and online contact methods if they are setup for the form

![Screenshot 2023-10-30 at 14 36 08](https://github.com/alphagov/forms-runner/assets/3441519/a0cca6b3-0287-4dc8-8984-e23480223e91)


Trello card: https://trello.com/c/r4RTqUPa/1143-add-all-support-contact-detail-methods-to-confirmation-email

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
