### PR TITLE
dont send confirmation email if forms "what happens next" or "support contact details" missing

### DIFF
--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -38,6 +38,7 @@ class FormSubmissionService
   end
 
   def submit_confirmation_email_to_user
+    return nil if @form.what_happens_next_text.blank?
     return nil unless @email_confirmation_form.send_confirmation == "send_email"
 
     FormSubmissionConfirmationMailer.send_confirmation_email(

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -38,13 +38,13 @@ class FormSubmissionService
   end
 
   def submit_confirmation_email_to_user
-    return nil if @form.what_happens_next_text.blank?
+    return nil unless @form.what_happens_next_text.present? && has_support_contact_details?
     return nil unless @email_confirmation_form.send_confirmation == "send_email"
 
     FormSubmissionConfirmationMailer.send_confirmation_email(
       title: form_title,
       what_happens_next_text: @form.what_happens_next_text,
-      support_contact_details: @form.support_email,
+      support_contact_details: formatted_support_details,
       submission_timestamp: @timestamp,
       preview_mode: @preview_mode,
       confirmation_email_address: @email_confirmation_form.confirmation_email_address,
@@ -124,5 +124,15 @@ private
 
   def submission_timestamp
     Time.use_zone(submission_timezone) { Time.zone.now }
+  end
+
+  def has_support_contact_details?
+    [@form.support_email, @form.support_phone].any?(&:present?) || [@form.support_url, @form.support_url_text].all?(&:present?)
+  end
+
+  def formatted_support_details
+    return nil unless has_support_contact_details?
+
+    @form.support_email.presence
   end
 end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -155,6 +155,35 @@ RSpec.describe FormSubmissionService do
         expect(service.submit_confirmation_email_to_user).to be_nil
       end
     end
+
+    context "when form is draft" do
+      context "when form does not have 'what happens next details'" do
+        let(:form) do
+          build(:form,
+                id: 1,
+                name: "Form 1",
+                what_happens_next_text:,
+                support_email: Faker::Internet.email(domain: "example.gov.uk"),
+                support_phone: Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4),
+                support_url: Faker::Internet.url(host: "gov.uk"),
+                support_url_text: Faker::Lorem.sentence(word_count: 1, random_words_to_add: 4),
+                submission_email: "testing@gov.uk")
+        end
+
+        let(:what_happens_next_text) { nil }
+
+        it "does not call FormSubmissionConfirmationMailer" do
+          allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email)
+
+          service.submit_confirmation_email_to_user
+          expect(FormSubmissionConfirmationMailer).not_to have_received(:send_confirmation_email)
+        end
+
+        it "returns nil" do
+          expect(service.submit_confirmation_email_to_user).to be_nil
+        end
+      end
+    end
   end
 
   describe "FormSubmissionService::NotifyTemplateBodyFilter" do


### PR DESCRIPTION
### What problem does this pull request solve?
Currently, if a form is missing "What happens next" or support contact email the attempt to send an email will fail and give the user a 500 error. We want to handle this more gracefully because it should only occur when a draft form hasn't been fully completed. We will do this by not calling the email confirmation mailer.

- fixes https://govuk-forms.sentry.io/issues/4570951866/?project=6576261

Trello card: https://trello.com/c/A7YmTtGq/1104-send-confirmation-email-to-form-filler

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
