### PR TITLE
Log confirmation email opt-ins

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -10,19 +10,20 @@ module Forms
 
     def submit_answers
       email_confirmation_form = EmailConfirmationForm.new(email_confirmation_form_params)
+      requested_email_confirmation = email_confirmation_form.send_confirmation == "send_email"
 
       if email_confirmation_form.valid?
         if current_context.form_submitted?
           redirect_to error_repeat_submission_path(current_form.id)
         else
           unless mode.preview?
-            LogEventService.log_submit(current_context, request)
+            LogEventService.log_submit(current_context, request, requested_email_confirmation:)
           end
 
           FormSubmissionService.call(current_context:,
                                      email_confirmation_form:,
                                      preview_mode: mode.preview?).submit
-          redirect_to :form_submitted, email_sent: email_confirmation_form.send_confirmation == "send_email"
+          redirect_to :form_submitted, email_sent: requested_email_confirmation
 
         end
       else

--- a/app/services/log_event_service.rb
+++ b/app/services/log_event_service.rb
@@ -16,10 +16,14 @@ class LogEventService
     end
   end
 
-  def self.log_submit(context, request)
-    EventLogger.log_form_event(context, request, "submission") # Logging to Splunk
+  def self.log_submit(context, request, requested_email_confirmation: false)
+    # Logging to Splunk
+    EventLogger.log_form_event(context, request, "submission")
+    EventLogger.log_form_event(context, request, "requested_email_confirmation") if requested_email_confirmation
+
+    # Logging to CloudWatch
     begin
-      CloudWatchService.log_form_submission(form_id: context.form.id) # Logging to CloudWatch
+      CloudWatchService.log_form_submission(form_id: context.form.id)
     rescue StandardError => e
       Sentry.capture_exception(e)
     end

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       end
 
       it "Logs the submit event with service logger" do
-        expect(LogEventService).to have_received(:log_submit).with(instance_of(Context), instance_of(ActionDispatch::Request))
+        expect(LogEventService).to have_received(:log_submit).with(instance_of(Context), instance_of(ActionDispatch::Request), requested_email_confirmation: true)
       end
 
       it "emails the form submission" do
@@ -275,6 +275,24 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         }
 
         expect(mail.body.raw_source).to match(expected_personalisation.to_s)
+      end
+
+      context "when user has opted into the confirmation email" do
+        it "Logs the submit event with requested_email_confirmation set to true" do
+          expect(LogEventService).to have_received(:log_submit).with(instance_of(Context), instance_of(ActionDispatch::Request), requested_email_confirmation: true)
+        end
+      end
+
+      context "when user has not opted into the confirmation email" do
+        let(:email_confirmation_form) do
+          { send_confirmation: "skip_confirmation",
+            confirmation_email_address: nil,
+            notify_reference: "for-my-ref" }
+        end
+
+        it "Logs the submit event with requested_email_confirmation set to false" do
+          expect(LogEventService).to have_received(:log_submit).with(instance_of(Context), instance_of(ActionDispatch::Request), requested_email_confirmation: false)
+        end
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/g4Z4kg6e/1135-we-log-a-new-event-so-we-can-tell-how-many-users-requested-confirmation-emails

Adds a new splunk log event for tracking confirmation email requests.

When a user submits their answers, pass whether they opted in to the confirmation email into the LogEventService. If they did opt in, log a new event `requested_email_confirmation` to Splunk, so that we can understand how useful this feature is.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
