### PR TITLE
Remove dotenv-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,6 @@ gem "puma", "~> 6.4.0"
 gem "sentry-rails"
 gem "sentry-ruby"
 
-gem "dotenv-rails", groups: %i[development test]
-
 gem "config"
 
 # Use GOV.UK Nofity api to send emails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,10 +147,6 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    dotenv (2.7.6)
-    dotenv-rails (2.7.6)
-      dotenv (= 2.7.6)
-      railties (>= 3.2)
     dry-cli (1.0.0)
     dry-configurable (1.1.0)
       dry-core (~> 1.0, < 2)
@@ -459,7 +455,6 @@ DEPENDENCIES
   capybara
   config
   debug
-  dotenv-rails
   factory_bot_rails
   faker
   govuk-components (~> 4.1.1)


### PR DESCRIPTION
### What problem does this pull request solve?

We are using config gem instead of dotenv-rails [[1]], so we should remove it.

[1]: https://github.com/alphagov/forms-admin/commit/3ffbf1598871e36332d75fa200d62aaf4e0d60f1

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?