### PR TITLE
Move the CloudWatch form start to first page save event

### DIFF
--- a/spec/services/log_event_service_spec.rb
+++ b/spec/services/log_event_service_spec.rb
@@ -2,11 +2,13 @@ require "rails_helper"
 
 RSpec.describe LogEventService do
   let(:request) { "request" }
-  let(:current_context) { "current_context" }
+  let(:current_context) { OpenStruct.new(form:) }
+  let(:form) { OpenStruct.new(id: 3, start_page: 1) }
 
   describe "#log_page_save" do
     let(:changing_answers) { true }
-    let(:step) { OpenStruct.new(question:) }
+    let(:step) { OpenStruct.new(id: step_id, question:) }
+    let(:step_id) { 2 }
     let(:question) { OpenStruct.new(is_optional?: true) }
     let(:answers) { { "name": "John" } }
 
@@ -24,12 +26,50 @@ RSpec.describe LogEventService do
         false,
       )
     end
+
+    context "when the form is being started" do
+      let(:step_id) { 1 }
+
+      before do
+        allow(EventLogger).to receive(:log_page_event).and_return(true)
+        allow(Sentry).to receive(:capture_exception)
+      end
+
+      it "calls the CloudWatchService with .log_form_start" do
+        allow(CloudWatchService).to receive(:log_form_start).and_return(true)
+
+        log_event_service = described_class.new(current_context, step, request, changing_answers, answers)
+
+        log_event_service.log_page_save
+
+        expect(CloudWatchService).to have_received(:log_form_start).with(form_id: current_context.form.id)
+      end
+
+      it "Sentry doesn't receive an error" do
+        allow(CloudWatchService).to receive(:log_form_start).and_return(true)
+
+        log_event_service = described_class.new(current_context, step, request, changing_answers, answers)
+
+        log_event_service.log_page_save
+
+        expect(Sentry).not_to have_received(:capture_exception)
+      end
+
+      context "when CloudWatchService returns an error" do
+        it "raises the error to Sentry" do
+          allow(CloudWatchService).to receive(:log_form_start).and_raise(StandardError)
+
+          log_event_service = described_class.new(current_context, step, request, changing_answers, answers)
+
+          log_event_service.log_page_save
+
+          expect(Sentry).to have_received(:capture_exception)
+        end
+      end
+    end
   end
 
   describe ".log_form_submit" do
-    let(:current_context) { OpenStruct.new(form:) }
-    let(:form) { OpenStruct.new(id: 1) }
-
     before do
       allow(EventLogger).to receive(:log_form_event).and_return(true)
       allow(CloudWatchService).to receive(:log_form_submission).and_return(true)
@@ -64,12 +104,8 @@ RSpec.describe LogEventService do
   end
 
   describe ".log_form_start" do
-    let(:current_context) { OpenStruct.new(form:) }
-    let(:form) { OpenStruct.new(id: 1) }
-
     before do
       allow(EventLogger).to receive(:log_form_event).and_return(true)
-      allow(CloudWatchService).to receive(:log_form_start).and_return(true)
     end
 
     it "calls the event logger with .log_form_event" do
@@ -80,23 +116,6 @@ RSpec.describe LogEventService do
         request,
         "visit",
       )
-    end
-
-    it "calls the cloud watch service with .log_form_start" do
-      described_class.log_form_start(current_context, request)
-
-      expect(CloudWatchService).to have_received(:log_form_start).with(form_id: current_context.form.id)
-    end
-
-    context "when CloudWatchService returns an error" do
-      it "raises the error to Sentry" do
-        allow(CloudWatchService).to receive(:log_form_start).and_raise(StandardError)
-        allow(Sentry).to receive(:capture_exception)
-
-        described_class.log_submit(current_context, request)
-
-        expect(Sentry).to have_received(:capture_exception)
-      end
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/Zhxsdx7i/1170-fix-completion-rate-metric

Moves the CloudWatch form started event so that's it's triggered when the first page of the form is saved. This will help avoid metrics going wonky when linking to the first page of a form directly, as this bypasses the form_start event.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
