### PR TITLE
Use blank? instead of nil? in heading size check

### DIFF
--- a/app/components/question/base.rb
+++ b/app/components/question/base.rb
@@ -23,7 +23,7 @@ module Question
     end
 
     def question_text_size_and_tag
-      return { tag: "h1", size: "l" } if question.page_heading.nil? && question.guidance_markdown.blank?
+      return { tag: "h1", size: "l" } if question.page_heading.blank? && question.guidance_markdown.blank?
 
       { size: "m" }
     end

--- a/spec/components/question/base_spec.rb
+++ b/spec/components/question/base_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe Question::Base, type: :component do
+  let(:extra_question_text_suffix) { nil }
+  let(:form_builder) do
+    GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+  end
+  let(:page_heading) { "National insurance number" }
+  let(:guidance_markdown) { "## National insurance number\n\nYou can find this on your National insurance card." }
+  let(:question) { build :full_name_question, page_heading:, guidance_markdown: }
+
+  let(:question_base) { described_class.new(form_builder:, question:, extra_question_text_suffix:) }
+
+  describe "#question_text_size_and_tag" do
+    context "when both guidance fields are present" do
+      it "returns config for a medium default tag" do
+        expect(question_base.question_text_size_and_tag).to eq({ size: "m" })
+      end
+    end
+
+    context "when page_heading is present but the page heading is nil" do
+      let(:page_heading) { nil }
+
+      it "returns config for a medium default tag" do
+        expect(question_base.question_text_size_and_tag).to eq({ size: "m" })
+      end
+    end
+
+    context "when page_heading is present but the guidance markdown is nil" do
+      let(:guidance_markdown) { nil }
+
+      it "returns config for a medium default tag" do
+        expect(question_base.question_text_size_and_tag).to eq({ size: "m" })
+      end
+    end
+
+    context "when the page heading is empty but the guidance markdown is present" do
+      let(:page_heading) { "" }
+
+      it "returns config for a medium default tag" do
+        expect(question_base.question_text_size_and_tag).to eq({ size: "m" })
+      end
+    end
+
+    context "when the guidance markdown is empty but the guidance markdown is present" do
+      let(:guidance_markdown) { "" }
+
+      it "returns config for a medium default tag" do
+        expect(question_base.question_text_size_and_tag).to eq({ size: "m" })
+      end
+    end
+
+    context "when both the page heading and guidance markdown are nil" do
+      let(:page_heading) { nil }
+      let(:guidance_markdown) { nil }
+
+      it "returns config for a large h1 tag" do
+        expect(question_base.question_text_size_and_tag).to eq({ tag: "h1", size: "l" })
+      end
+    end
+
+    context "when the page heading and guidance markdown are empty" do
+      let(:page_heading) { "" }
+      let(:guidance_markdown) { "" }
+
+      it "returns config for a large h1 tag" do
+        expect(question_base.question_text_size_and_tag).to eq({ tag: "h1", size: "l" })
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

Fixes an issue with the wrong heading size and tag being returned for a question with an empty string as its `page_heading`. We think this arises when a page has detailed guidance which is subsequently removed.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
