### PR TITLE
Log hash of session.id if session exists

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,7 @@ class ApplicationController < ActionController::Base
     payload[:form_id] = params[:form_id] if params[:form_id].present?
     payload[:page_id] = params[:page_slug] if params[:page_slug].present? && params[:page_slug].match(Page::PAGE_ID_REGEX)
     payload[:page_slug] = params[:page_slug] if params[:page_slug].present?
+    payload[:session_id_hash] = Digest::SHA256.hexdigest session.id.to_s if session.exists?
   end
 
 private

--- a/config/application.rb
+++ b/config/application.rb
@@ -76,6 +76,7 @@ module FormsRunner
         h[:page_id] = event.payload[:page_id] if event.payload[:page_id]
         h[:page_slug] = event.payload[:page_slug] if event.payload[:page_slug]
         h[:exception] = event.payload[:exception] if event.payload[:exception]
+        h[:session_id_hash] = event.payload[:session_hash] if event.payload[:session_hash]
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -76,7 +76,7 @@ module FormsRunner
         h[:page_id] = event.payload[:page_id] if event.payload[:page_id]
         h[:page_slug] = event.payload[:page_slug] if event.payload[:page_slug]
         h[:exception] = event.payload[:exception] if event.payload[:exception]
-        h[:session_id_hash] = event.payload[:session_hash] if event.payload[:session_hash]
+        h[:session_id_hash] = event.payload[:session_id_hash] if event.payload[:session_id_hash]
       end
     end
   end


### PR DESCRIPTION
# Logging session id

https://trello.com/c/VCUrEL0y/1172-log-hash-of-session-id

It's difficult to trace users behaviour over multiple pages.

Individual page requests aren't linked by any values.

Guessing based on URLs and client IP is the only way to reconstruct user's journeys through forms.

This commit adds a hash of the user's session id to the request logs.

This value is will be stable across individual page request so can be used to connect multiple requests.

## Why log the hash and not the session id directly?

We don't log the session id directly as it would leak information that could be used to retrieve user's data.

The session id is a random string of lowercase hex digits, for example, 'ffdc96b6cd5a8f8601f6b11352e6d9c2'.

It's stored directly inside the cookie sent to the form-filler's browser when they visit the service. We use it as the key when storing session data in Redis. An attacker with access to logs could copy session ids and use them in the cookie inside their own browser to view the answers from other form fillers.

To stop this, we use SHA256 to hash the session id into a 64 character string hex string, for example,
'33462ac55ada9a08d0806e7248476e892c35b0ac75f4de4a25f6e829e982830e', which is logged under 'session_id_hash'.

SHA256 is a one way function. It would take ages to brute force the original session id because the search space is so large.

SHA256 was chosen because SHA1 and MD5 are no longer recommended for "applications that require collision resistance". I don't think we gain anything from using a hash algorithm built for passwords like Bcrypt because the use case is different.

## Will this be slow if we run it on every request?

I ran this benchmark I found on the internet and it performs 100,000 hashes under a second, which I think is fast enough.

```ruby
require "digest/sha1"
require "digest/sha2"
require "benchmark"

SRC = File.read "/dev/urandom", 4096

Benchmark.bmbm do |bm|
  bm.report("MD5")    { 100_000.times { Digest::MD5.hexdigest    SRC } }
  bm.report("SHA1")   { 100_000.times { Digest::SHA1.hexdigest   SRC } }
  bm.report("SHA2")   { 100_000.times { Digest::SHA2.hexdigest   SRC } }
  bm.report("SHA256") { 100_000.times { Digest::SHA256.hexdigest SRC } }
end
```

## It sounds like you don't know what you are talking about and I'm worried about security

I'm a little out of my depth discussing the security implications of exposing hashes of sessions.

To avoid getting bogged down, we could just add a new random number to the session and use that in logs.

The advantage of this approach is that it's impossible to link the randomly generated session id to the randomly generated log id and we don't need to fret about cryptography, salts and other mysterious things.

Adding state to the session does have it's own disadvantages. The session, stored in Redis, is a JSON string. It doesn't currently have much structure or validation. Adding values to it across the code is a bit messy and could come back to bite us.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
