### PR TITLE
Use default Rails logger for development

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,6 @@ require "action_view/railtie"
 require "action_cable/engine"
 require "rails/test_unit/railtie"
 require "./app/lib/hosting_environment"
-require "./app/lib/json_log_formatter"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -47,37 +46,5 @@ module FormsRunner
     config.view_component.preview_controller = "ComponentPreviewController"
     # Replace with value which will be true in local dev
     config.view_component.show_previews = HostingEnvironment.test_environment?
-
-    #### LOGGING CONFIGURATION ####
-
-    # Use JSON log formatter for better support in Splunk. To use conventional
-    # logging use the Logger::Formatter.new.
-    config.log_formatter = JsonLogFormatter.new
-
-    if ENV["RAILS_LOG_TO_STDOUT"].present?
-      config.logger = ActiveSupport::Logger.new($stdout)
-      config.logger.formatter = config.log_formatter
-    end
-
-    # Lograge is used to format the standard HTTP request logging
-    config.lograge.enabled = true
-    config.lograge.formatter = Lograge::Formatters::Json.new
-
-    # Lograge suppresses the default Rails request logging. Set this to true to
-    # make lograge output it which includes some extra debugging
-    # information.
-    config.lograge.keep_original_rails_log = false
-
-    config.lograge.custom_options = lambda do |event|
-      {}.tap do |h|
-        h[:host] = event.payload[:host]
-        h[:request_id] = event.payload[:request_id]
-        h[:form_id] = event.payload[:form_id] if event.payload[:form_id]
-        h[:page_id] = event.payload[:page_id] if event.payload[:page_id]
-        h[:page_slug] = event.payload[:page_slug] if event.payload[:page_slug]
-        h[:exception] = event.payload[:exception] if event.payload[:exception]
-        h[:session_id_hash] = event.payload[:session_id_hash] if event.payload[:session_id_hash]
-      end
-    end
   end
 end

--- a/config/initializers/logging.rb
+++ b/config/initializers/logging.rb
@@ -1,0 +1,38 @@
+require "./app/lib/json_log_formatter"
+
+unless Rails.env.development?
+  Rails.application.configure do
+    #### LOGGING CONFIGURATION ####
+    config.log_level = :info
+
+    # Use JSON log formatter for better support in Splunk. To use conventional
+    # logging use the Logger::Formatter.new.
+    config.log_formatter = JsonLogFormatter.new
+
+    if ENV["RAILS_LOG_TO_STDOUT"].present?
+      config.logger = ActiveSupport::Logger.new($stdout)
+      config.logger.formatter = config.log_formatter
+    end
+
+    # Lograge is used to format the standard HTTP request logging
+    config.lograge.enabled = true
+    config.lograge.formatter = Lograge::Formatters::Json.new
+
+    # Lograge suppresses the default Rails request logging. Set this to true to
+    # make lograge output it which includes some extra debugging
+    # information.
+    config.lograge.keep_original_rails_log = false
+
+    config.lograge.custom_options = lambda do |event|
+      {}.tap do |h|
+        h[:host] = event.payload[:host]
+        h[:request_id] = event.payload[:request_id]
+        h[:form_id] = event.payload[:form_id] if event.payload[:form_id]
+        h[:page_id] = event.payload[:page_id] if event.payload[:page_id]
+        h[:page_slug] = event.payload[:page_slug] if event.payload[:page_slug]
+        h[:exception] = event.payload[:exception] if event.payload[:exception]
+        h[:session_id_hash] = event.payload[:session_id_hash] if event.payload[:session_id_hash]
+      end
+    end
+  end
+end

--- a/spec/config/initializers/logging_spec.rb
+++ b/spec/config/initializers/logging_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+require_relative "../../../app/lib/json_log_formatter"
+
+describe "Logging initializer" do
+  it "configures log level to be info" do
+    expect(Rails.application.config.log_level).to eq :info
+  end
+
+  it "configures log formatter to use JSON" do
+    expect(Rails.application.config.log_formatter).to be_instance_of JsonLogFormatter
+  end
+
+  it "configures lograge to be enabled" do
+    expect(Rails.application.config.lograge.enabled).to eq true
+  end
+
+  it "configures lograge formatter to use JSON" do
+    expect(Rails.application.config.lograge.formatter).to be_instance_of Lograge::Formatters::Json
+  end
+
+  it "configures lograge custom options" do
+    expect(Rails.application.config.lograge.custom_options).to respond_to :call
+  end
+
+  describe "lograge custom options" do
+    let(:lograge_custom_options) do
+      Rails.application.config.lograge.custom_options
+    end
+
+    let(:event) do
+      OpenStruct.new(
+        payload: {
+          host: "foo.com",
+          request_id: Faker::Internet.uuid,
+          form_id: 11,
+          page_id: 111,
+          page_slug: 111,
+          session_id_hash: Faker::Number.hexadecimal,
+        },
+      )
+    end
+
+    it "adds extra details from event payload to the log event" do
+      expect(lograge_custom_options.call(event)).to eq event.payload
+    end
+
+    it "does not add all information from event payload" do
+      event.payload[:extra] = "foobar"
+      expect(lograge_custom_options.call(event)).not_to include :extra
+    end
+
+    %i[form_id page_id exception].each do |key|
+      it "does not add #{key} if it is not in the event payload" do
+        event.payload.delete(key)
+        expect(lograge_custom_options.call(event)).not_to include key
+      end
+    end
+
+    it "adds exception if it is in the event payload" do
+      event = OpenStruct.new(payload: { exception: "FooBar error" })
+      expect(lograge_custom_options.call(event)).to include(exception: "FooBar error")
+    end
+  end
+
+  context "when loading" do
+    let(:env) { "test" }
+
+    before do
+      allow(Rails).to receive(:env).and_return(
+        ActiveSupport::EnvironmentInquirer.new(env),
+      )
+      allow(Rails.application).to receive(:configure)
+
+      load File.realpath("../../../config/initializers/logging.rb", __dir__)
+    end
+
+    describe "in the development environment" do
+      let(:env) { "development" }
+
+      it "does not configure logging" do
+        expect(Rails.application).not_to have_received :configure
+      end
+    end
+
+    describe "in the production environment" do
+      let(:env) { "production" }
+
+      it "does configure logging" do
+        expect(Rails.application).to have_received :configure
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Move the logging configuration from application.rb to an initializer. This makes it easier to apply it to test and production but not development environment.

The desired effect is that when developing locally, the default Rails logger is used. Our default logger, lograge, outputs structured log messages that are optimised for machine readability, rather than human readability.

If a developer wants to see what the production logging looks like they can change the RAILS_ENV environment variable or comment out the conditional in the initializer.

This also means we can be aware of what we are missing in our lograge configuration that we could be getting from Rails.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?