### PR TITLE
1184 prevent forms runner and forms admin cloudwatch requests when in unsuitable environments

### DIFF
--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -2,6 +2,8 @@ class CloudWatchService
   REGION = "eu-west-2".freeze
 
   def self.log_form_submission(form_id:)
+    return unless Settings.cloudwatch_metrics_enabled
+
     cloudwatch_client.put_metric_data(
       namespace: metric_namespace,
       metric_data: [
@@ -21,6 +23,8 @@ class CloudWatchService
   end
 
   def self.log_form_start(form_id:)
+    return unless Settings.cloudwatch_metrics_enabled
+
     cloudwatch_client.put_metric_data(
       namespace: metric_namespace,
       metric_data: [

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,3 +34,6 @@ forms_env: local
 
 # When set to true, any capybara tests will run chrome normally rather than in headless mode.
 show_browser_during_tests: false
+
+# When set to true, the CloudWatch service will attempt to send data to CloudWatch
+cloudwatch_metrics_enabled: false

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -62,4 +62,12 @@ describe "Settings" do
       expect(forms_env).to eq("local")
     end
   end
+
+  describe "cloudwatch_metrics_enabled" do
+    it "has a default value" do
+      cloudwatch_metrics_enabled = settings[:cloudwatch_metrics_enabled]
+
+      expect(cloudwatch_metrics_enabled).to be(false)
+    end
+  end
 end

--- a/spec/services/cloud_watch_service_spec.rb
+++ b/spec/services/cloud_watch_service_spec.rb
@@ -2,12 +2,27 @@ require "rails_helper"
 require "aws-sdk-cloudwatch"
 
 RSpec.describe CloudWatchService do
-  describe ".log_form_submission" do
-    let(:form_id) { 3 }
-    let(:forms_env) { "test" }
+  let(:form_id) { 3 }
+  let(:forms_env) { "test" }
+  let(:cloudwatch_metrics_enabled) { true }
 
-    before do
-      allow(Settings).to receive(:forms_env).and_return(forms_env)
+  before do
+    allow(Settings).to receive(:forms_env).and_return(forms_env)
+    allow(Settings).to receive(:cloudwatch_metrics_enabled).and_return(cloudwatch_metrics_enabled)
+  end
+
+  describe ".log_form_submission" do
+    context "when CloudWatch metrics are disabled" do
+      let(:cloudwatch_metrics_enabled) { false }
+
+      it "does not call the CloudWatch client with .put_metric_data" do
+        cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
+        allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+
+        expect(cloudwatch_client).not_to receive(:put_metric_data)
+
+        described_class.log_form_submission(form_id:)
+      end
     end
 
     it "calls the cloudwatch client with put_metric_data" do
@@ -37,11 +52,17 @@ RSpec.describe CloudWatchService do
   end
 
   describe ".log_form_start" do
-    let(:form_id) { 3 }
-    let(:forms_env) { "test" }
+    context "when CloudWatch metrics are disabled" do
+      let(:cloudwatch_metrics_enabled) { false }
 
-    before do
-      allow(Settings).to receive(:forms_env).and_return(forms_env)
+      it "does not call the CloudWatch client with .put_metric_data" do
+        cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
+        allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+
+        expect(cloudwatch_client).not_to receive(:put_metric_data)
+
+        described_class.log_form_start(form_id:)
+      end
     end
 
     it "calls the cloudwatch client with put_metric_data" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/eGLh3RTp/1184-prevent-forms-runner-and-forms-admin-cloudwatch-requests-when-in-unsuitable-environments
Now that https://github.com/alphagov/forms-deploy/pull/435 is in, we can make use of the environment variable that it's set to turn off metrics in dev and user research. 

This PR makes the CloudWatchService check the environment variable `cloudwatch_metrics_enabled` before it continues making CloudWatch requests, and breaks early if they're disabled. 

### Things to consider when reviewing

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
