### PR TITLE
Add notification reference for confirmation email

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -5,7 +5,6 @@ module Forms
 
       setup_check_your_answers
       email_confirmation_form = EmailConfirmationForm.new
-      email_confirmation_form.generate_submission_references!
 
       render template: "forms/check_your_answers/show", locals: { email_confirmation_form: }
     end
@@ -30,7 +29,6 @@ module Forms
         end
       else
         setup_check_your_answers
-        email_confirmation_form.generate_submission_references!
 
         render template: "forms/check_your_answers/show", locals: { email_confirmation_form: }, status: :unprocessable_entity
       end

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -4,7 +4,8 @@ module Forms
       return redirect_to form_page_path(current_context.form.id, current_context.form.form_slug, current_context.next_page_slug) unless current_context.can_visit?(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)
 
       setup_check_your_answers
-      email_confirmation_form = EmailConfirmationForm.new(**submission_reference_attributes)
+      email_confirmation_form = EmailConfirmationForm.new
+      email_confirmation_form.generate_submission_references!
 
       render template: "forms/check_your_answers/show", locals: { email_confirmation_form: }
     end
@@ -29,7 +30,7 @@ module Forms
         end
       else
         setup_check_your_answers
-        email_confirmation_form.attributes = submission_reference_attributes
+        email_confirmation_form.generate_submission_references!
 
         render template: "forms/check_your_answers/show", locals: { email_confirmation_form: }, status: :unprocessable_entity
       end
@@ -39,14 +40,6 @@ module Forms
     end
 
   private
-
-    def submission_reference_attributes
-      reference = SecureRandom.uuid
-      {
-        confirmation_email_reference: "#{reference}-confirmation-email",
-        notify_reference: "#{reference}-submission-email",
-      }
-    end
 
     def page_to_row(page)
       question_name = helpers.question_text_with_optional_suffix_inc_mode(page, @mode)

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -42,7 +42,10 @@ module Forms
 
     def submission_reference_attributes
       reference = SecureRandom.uuid
-      { notify_reference: "#{reference}-submission-email" }
+      {
+        confirmation_email_reference: "#{reference}-confirmation-email",
+        notify_reference: "#{reference}-submission-email",
+      }
     end
 
     def page_to_row(page)
@@ -63,7 +66,7 @@ module Forms
     end
 
     def email_confirmation_form_params
-      params.require(:email_confirmation_form).permit(:send_confirmation, :confirmation_email_address, :notify_reference)
+      params.require(:email_confirmation_form).permit(:send_confirmation, :confirmation_email_address, :confirmation_email_reference, :notify_reference)
     end
 
     def setup_check_your_answers

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -4,7 +4,8 @@ module Forms
       return redirect_to form_page_path(current_context.form.id, current_context.form.form_slug, current_context.next_page_slug) unless current_context.can_visit?(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)
 
       setup_check_your_answers
-      email_confirmation_form = EmailConfirmationForm.new(notify_reference: SecureRandom.uuid)
+      email_confirmation_form = EmailConfirmationForm.new(**submission_reference_attributes)
+
       render template: "forms/check_your_answers/show", locals: { email_confirmation_form: }
     end
 
@@ -28,7 +29,8 @@ module Forms
         end
       else
         setup_check_your_answers
-        email_confirmation_form.notify_reference = SecureRandom.uuid
+        email_confirmation_form.attributes = submission_reference_attributes
+
         render template: "forms/check_your_answers/show", locals: { email_confirmation_form: }, status: :unprocessable_entity
       end
     rescue StandardError => e
@@ -37,6 +39,11 @@ module Forms
     end
 
   private
+
+    def submission_reference_attributes
+      reference = SecureRandom.uuid
+      { notify_reference: "#{reference}-submission-email" }
+    end
 
     def page_to_row(page)
       question_name = helpers.question_text_with_optional_suffix_inc_mode(page, @mode)

--- a/app/form_objects/email_confirmation_form.rb
+++ b/app/form_objects/email_confirmation_form.rb
@@ -9,6 +9,11 @@ class EmailConfirmationForm
   validates :confirmation_email_address, presence: true, if: :validate_email?
   validates :confirmation_email_address, format: { with: URI::MailTo::EMAIL_REGEXP, message: :invalid_email }, allow_blank: true, if: :validate_email?
 
+  def initialize(...)
+    super(...)
+    generate_submission_references! unless @confirmation_email_reference || @notify_reference
+  end
+
   def validate_email?
     FeatureService.enabled?(:email_confirmations_enabled) && send_confirmation == "send_email"
   end
@@ -16,6 +21,8 @@ class EmailConfirmationForm
   def validate_presence?
     FeatureService.enabled?(:email_confirmations_enabled)
   end
+
+private
 
   def generate_submission_references!
     reference = SecureRandom.uuid

--- a/app/form_objects/email_confirmation_form.rb
+++ b/app/form_objects/email_confirmation_form.rb
@@ -2,7 +2,7 @@ class EmailConfirmationForm
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  attr_accessor :send_confirmation, :confirmation_email_address, :notify_reference
+  attr_accessor :send_confirmation, :confirmation_email_address, :confirmation_email_reference, :notify_reference
 
   validates :send_confirmation, presence: true, if: :validate_presence?
   validates :send_confirmation, inclusion: { in: %w[send_email skip_confirmation] }, if: :validate_presence?

--- a/app/form_objects/email_confirmation_form.rb
+++ b/app/form_objects/email_confirmation_form.rb
@@ -16,4 +16,12 @@ class EmailConfirmationForm
   def validate_presence?
     FeatureService.enabled?(:email_confirmations_enabled)
   end
+
+  def generate_submission_references!
+    reference = SecureRandom.uuid
+    self.attributes = {
+      confirmation_email_reference: "#{reference}-confirmation-email",
+      notify_reference: "#{reference}-submission-email",
+    }
+  end
 end

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -1,5 +1,5 @@
 class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
-  def send_confirmation_email(title:, what_happens_next_text:, support_contact_details:, submission_timestamp:, preview_mode:, confirmation_email_address:)
+  def send_confirmation_email(title:, what_happens_next_text:, support_contact_details:, submission_timestamp:, preview_mode:, reference:, confirmation_email_address:)
     set_template(Settings.govuk_notify.form_filler_confirmation_email_template_id)
 
     set_personalisation(
@@ -13,6 +13,8 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
       # flags; but they must always have opposite values!
       test: make_notify_boolean(preview_mode),
     )
+
+    set_reference(reference)
 
     set_email_reply_to(Settings.govuk_notify.form_submission_email_reply_to_id)
 

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -47,6 +47,7 @@ class FormSubmissionService
       support_contact_details: formatted_support_details,
       submission_timestamp: @timestamp,
       preview_mode: @preview_mode,
+      reference: @email_confirmation_form.confirmation_email_reference,
       confirmation_email_address: @email_confirmation_form.confirmation_email_address,
     ).deliver_now
   end

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -31,6 +31,8 @@
           <% end %>
           <%= form.govuk_radio_button :send_confirmation, 'skip_confirmation' %>
         <% end %>
+
+        <%= form.hidden_field :confirmation_email_reference, id: 'confirmation-email-reference' %>
       <% end %>
 
       <%if @current_context.form.declaration_text.present? %>

--- a/spec/factories/form_objects/email_confirmation_form.rb
+++ b/spec/factories/form_objects/email_confirmation_form.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :email_confirmation_form, class: "EmailConfirmationForm" do
     send_confirmation { nil }
     confirmation_email_address { nil }
-    notify_reference { SecureRandom.uuid }
-    confirmation_email_reference { SecureRandom.uuid }
+    notify_reference { nil }
+    confirmation_email_reference { nil }
 
     factory :email_confirmation_form_opted_in do
       send_confirmation { "send_email" }

--- a/spec/factories/form_objects/email_confirmation_form.rb
+++ b/spec/factories/form_objects/email_confirmation_form.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     send_confirmation { nil }
     confirmation_email_address { nil }
     notify_reference { SecureRandom.uuid }
+    confirmation_email_reference { SecureRandom.uuid }
 
     factory :email_confirmation_form_opted_in do
       send_confirmation { "send_email" }

--- a/spec/factories/form_objects/email_confirmation_form.rb
+++ b/spec/factories/form_objects/email_confirmation_form.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :email_confirmation_form, class: "EmailConfirmationForm" do
     send_confirmation { nil }
     confirmation_email_address { nil }
-    notify_reference { nil }
-    confirmation_email_reference { nil }
+    notify_reference { "ffffffff-submission-email" }
+    confirmation_email_reference { "ffffffff-confirmation-email" }
 
     factory :email_confirmation_form_opted_in do
       send_confirmation { "send_email" }

--- a/spec/form_objects/email_confirmation_form_spec.rb
+++ b/spec/form_objects/email_confirmation_form_spec.rb
@@ -52,4 +52,35 @@ RSpec.describe EmailConfirmationForm, type: :model do
       end
     end
   end
+
+  describe "#generate_submission_references!" do
+    uuid = /[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}/
+
+    before do
+      email_confirmation_form.generate_submission_references!
+    end
+
+    let(:notify_reference) { email_confirmation_form.notify_reference }
+    let(:confirmation_email_reference) { email_confirmation_form.confirmation_email_reference }
+
+    it "generates a random submission notification reference" do
+      expect(notify_reference)
+        .to match(uuid).and end_with("-submission-email")
+    end
+
+    it "generates a random email confirmation notification reference" do
+      expect(confirmation_email_reference)
+        .to match(uuid).and end_with("-confirmation-email")
+    end
+
+    it "generates a different string for all notification references" do
+      expect(notify_reference).not_to eq confirmation_email_reference
+    end
+
+    it "includes a common identifier in all notification references" do
+      uuid_in = ->(str) { uuid.match(str).to_s }
+
+      expect(uuid_in[notify_reference]).to eq uuid_in[confirmation_email_reference]
+    end
+  end
 end

--- a/spec/form_objects/email_confirmation_form_spec.rb
+++ b/spec/form_objects/email_confirmation_form_spec.rb
@@ -53,11 +53,11 @@ RSpec.describe EmailConfirmationForm, type: :model do
     end
   end
 
-  describe "#generate_submission_references!" do
+  describe "submission references" do
     uuid = /[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}/
 
-    before do
-      email_confirmation_form.generate_submission_references!
+    let(:email_confirmation_form) do
+      described_class.new
     end
 
     let(:notify_reference) { email_confirmation_form.notify_reference }
@@ -81,6 +81,20 @@ RSpec.describe EmailConfirmationForm, type: :model do
       uuid_in = ->(str) { uuid.match(str).to_s }
 
       expect(uuid_in[notify_reference]).to eq uuid_in[confirmation_email_reference]
+    end
+
+    context "when intialised with references" do
+      let(:email_confirmation_form) do
+        described_class.new(
+          confirmation_email_reference: "foo",
+          notify_reference: "bar",
+        )
+      end
+
+      it "does not generate new references" do
+        expect(confirmation_email_reference).to eq "foo"
+        expect(notify_reference).to eq "bar"
+      end
     end
   end
 end

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -7,6 +7,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
                                             support_contact_details:,
                                             submission_timestamp:,
                                             preview_mode:,
+                                            reference: "for-my-ref",
                                             confirmation_email_address:)
   end
   let(:title) { "Form 1" }
@@ -36,6 +37,10 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
 
     it "includes the forms support contact details" do
       expect(mail.govuk_notify_personalisation[:support_contact_details]).to eq("Call: 0203 222 2222")
+    end
+
+    it "includes an email reference (mostly used to retrieve specific email in notify for e2e tests)" do
+      expect(mail.govuk_notify_reference).to eq("for-my-ref")
     end
 
     it "does include an email-reply-to" do

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
   let(:email_confirmation_form) do
     { send_confirmation: "send_email",
       confirmation_email_address: Faker::Internet.email,
+      confirmation_email_reference: "confirmation-email-ref",
       notify_reference: "for-my-ref" }
   end
 
@@ -89,9 +90,27 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
   shared_examples "for submission reference" do
     uuid = /[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}/
 
+    let(:notify_reference) { assigns[:email_confirmation_form].notify_reference }
+    let(:confirmation_email_reference) { assigns[:email_confirmation_form].confirmation_email_reference }
+
     it "generates a random submission notification reference" do
-      expect(assigns[:email_confirmation_form].notify_reference)
+      expect(notify_reference)
         .to match(uuid).and end_with("-submission-email")
+    end
+
+    it "generates a random email confirmation notification reference" do
+      expect(confirmation_email_reference)
+        .to match(uuid).and end_with("-confirmation-email")
+    end
+
+    it "generates a different string for all notification references" do
+      expect(notify_reference).not_to eq confirmation_email_reference
+    end
+
+    it "includes a common identifier in all notification references" do
+      uuid_in = ->(str) { uuid.match(str).to_s }
+
+      expect(uuid_in[notify_reference]).to eq uuid_in[confirmation_email_reference]
     end
   end
 
@@ -343,6 +362,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
         it "generates a new submission reference" do
           expect(assigns[:email_confirmation_form].notify_reference).not_to eq email_confirmation_form[:notify_reference]
+          expect(assigns[:email_confirmation_form].confirmation_email_reference).not_to eq email_confirmation_form[:confirmation_email_reference]
         end
 
         include_examples "for submission reference"
@@ -365,6 +385,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
         it "generates a new submission reference" do
           expect(assigns[:email_confirmation_form].notify_reference).not_to eq email_confirmation_form[:notify_reference]
+          expect(assigns[:email_confirmation_form].confirmation_email_reference).not_to eq email_confirmation_form[:confirmation_email_reference]
         end
 
         include_examples "for submission reference"
@@ -383,7 +404,12 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       end
 
       context "when user has requested a confirmation email" do
-        let(:email_confirmation_form) { { send_confirmation: "send_email", confirmation_email_address: Faker::Internet.email, notify_reference: "for-my-ref" } }
+        let(:email_confirmation_form) do
+          { send_confirmation: "send_email",
+            confirmation_email_address: Faker::Internet.email,
+            confirmation_email_reference: "confirmation-email-ref",
+            notify_reference: "for-my-ref" }
+        end
 
         before do
           travel_to timestamp_of_request do
@@ -412,6 +438,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           }
 
           expect(mail.body.raw_source).to include(expected_personalisation.to_s)
+
+          expect(mail.govuk_notify_reference).to eq "confirmation-email-ref"
         end
       end
     end

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -340,7 +340,13 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
     context "when the confirmation email flag is enabled", feature_email_confirmations_enabled: true do
       context "when user has not specified whether they want a confirmation email" do
-        let(:email_confirmation_form) { { send_confirmation: nil } }
+        let(:email_confirmation_form) do
+          {
+            send_confirmation: nil,
+            confirmation_email_reference: "test-ref-for-confirmation-email",
+            notify_reference: "test-ref-for-submission-email",
+          }
+        end
 
         before do
           post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_form: }
@@ -354,16 +360,21 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           expect(response).to render_template("forms/check_your_answers/show")
         end
 
-        it "generates a new submission reference" do
-          expect(assigns[:email_confirmation_form].notify_reference).not_to eq email_confirmation_form[:notify_reference]
-          expect(assigns[:email_confirmation_form].confirmation_email_reference).not_to eq email_confirmation_form[:confirmation_email_reference]
+        it "does not generate a new submission reference" do
+          expect(response.body).to include "test-ref-for-confirmation-email"
+          expect(response.body).to include "test-ref-for-submission-email"
         end
-
-        include_examples "for submission reference"
       end
 
       context "when user has not specified the confirmation email address" do
-        let(:email_confirmation_form) { { send_confirmation: "send_email", confirmation_email_address: nil } }
+        let(:email_confirmation_form) do
+          {
+            send_confirmation: "send_email",
+            confirmation_email_address: nil,
+            confirmation_email_reference: "test-ref-for-confirmation-email",
+            notify_reference: "test-ref-for-submission-email",
+          }
+        end
 
         before do
           post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_form: }
@@ -377,12 +388,10 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           expect(response).to render_template("forms/check_your_answers/show")
         end
 
-        it "generates a new submission reference" do
-          expect(assigns[:email_confirmation_form].notify_reference).not_to eq email_confirmation_form[:notify_reference]
-          expect(assigns[:email_confirmation_form].confirmation_email_reference).not_to eq email_confirmation_form[:confirmation_email_reference]
+        it "does not generate a new submission reference" do
+          expect(response.body).to include "test-ref-for-confirmation-email"
+          expect(response.body).to include "test-ref-for-submission-email"
         end
-
-        include_examples "for submission reference"
       end
 
       context "when user has not requested a confirmation email" do

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
     it "generates a random submission notification reference" do
       expect(assigns[:email_confirmation_form].notify_reference)
-        .to match(uuid)
+        .to match(uuid).and end_with("-submission-email")
     end
   end
 

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe FormSubmissionService do
             support_contact_details: contact_support_details_format,
             submission_timestamp: Time.zone.now,
             preview_mode:,
+            reference: email_confirmation_form.confirmation_email_reference,
             confirmation_email_address: email_confirmation_form.confirmation_email_address },
         ).once
       end

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -47,7 +47,7 @@ describe "forms/check_your_answers/show.html.erb" do
     end
   end
 
-  it "contains a hidden notify reference" do
+  it "contains a hidden notify reference for the submission email" do
     expect(rendered).to have_css("input", id: "notification-id", visible: :hidden)
   end
 
@@ -61,6 +61,10 @@ describe "forms/check_your_answers/show.html.erb" do
     it "does not display the email field" do
       expect(rendered).not_to have_field(I18n.t("helpers.label.email_confirmation_form.confirmation_email_address"))
     end
+
+    it "does not contain a hidden notify reference for the confirmation email" do
+      expect(rendered).not_to have_css("input", id: "confirmation-email-reference", visible: :hidden)
+    end
   end
 
   context "when the email confirmation feature flag is on", feature_email_confirmations_enabled: true do
@@ -72,6 +76,10 @@ describe "forms/check_your_answers/show.html.erb" do
 
     it "displays the email field" do
       expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_form.confirmation_email_address"))
+    end
+
+    it "contains a hidden notify reference for the confirmation email" do
+      expect(rendered).to have_css("input", id: "confirmation-email-reference", visible: :hidden)
     end
   end
 

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -48,7 +48,7 @@ describe "forms/check_your_answers/show.html.erb" do
   end
 
   it "contains a hidden notify reference for the submission email" do
-    expect(rendered).to have_css("input", id: "notification-id", visible: :hidden)
+    expect(rendered).to have_field("notification-id", type: :hidden, with: email_confirmation_form.notify_reference)
   end
 
   context "when the email confirmation feature flag is off", feature_email_confirmations_enabled: false do
@@ -63,7 +63,7 @@ describe "forms/check_your_answers/show.html.erb" do
     end
 
     it "does not contain a hidden notify reference for the confirmation email" do
-      expect(rendered).not_to have_css("input", id: "confirmation-email-reference", visible: :hidden)
+      expect(rendered).not_to have_field("confirmation-email-reference", type: "hidden", with: email_confirmation_form.confirmation_email_reference)
     end
   end
 
@@ -79,7 +79,7 @@ describe "forms/check_your_answers/show.html.erb" do
     end
 
     it "contains a hidden notify reference for the confirmation email" do
-      expect(rendered).to have_css("input", id: "confirmation-email-reference", visible: :hidden)
+      expect(rendered).to have_field("confirmation-email-reference", type: "hidden", with: email_confirmation_form.confirmation_email_reference)
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/bnWjTvpU/1197-add-an-e2e-test-to-cover-adding-confirmation-email-being-filled-in-on-forms <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to be able to find the confirmation email for a form filler in the GOV.UK Notify API. This is currently for our end to end tests, so we can check that a notification is actually queued.

This commit adds a notification reference for the confirmation email, similar to how we already have a notification reference for the email with the submission. To make it easier for any humans looking at the Notify logs to associate the two emails together, we give them both the same random prefix, and differentiate with a human readable suffix.



### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?