### PR TITLE
Add logging of submission of form previews

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -17,15 +17,12 @@ module Forms
         if current_context.form_submitted?
           redirect_to error_repeat_submission_path(current_form.id)
         else
-          unless mode.preview?
-            LogEventService.log_submit(current_context, request, requested_email_confirmation:)
-          end
-
           FormSubmissionService.call(current_context:,
+                                     request:,
                                      email_confirmation_form:,
                                      preview_mode: mode.preview?).submit
-          redirect_to :form_submitted, email_sent: requested_email_confirmation
 
+          redirect_to :form_submitted, email_sent: requested_email_confirmation
         end
       else
         setup_check_your_answers

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -37,7 +37,7 @@ class FormSubmissionService
                             submission_email: @form.submission_email).deliver_now
     end
 
-    LogEventService.log_submit(@current_context, @request, requested_email_confirmation: @requested_email_confirmation) unless @preview_mode
+    LogEventService.log_submit(@current_context, @request, requested_email_confirmation: @requested_email_confirmation, preview: @preview_mode)
   end
 
   def submit_confirmation_email_to_user

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -5,11 +5,12 @@ class FormSubmissionService
     end
   end
 
-  def initialize(current_context:, email_confirmation_form:, preview_mode:)
+  def initialize(current_context:, request:, email_confirmation_form:, preview_mode:)
     @current_context = current_context
+    @request = request
     @form = current_context.form
     @email_confirmation_form = email_confirmation_form
-    @reference = @email_confirmation_form.notify_reference
+    @requested_email_confirmation = @email_confirmation_form.send_confirmation == "send_email"
     @preview_mode = preview_mode
     @timestamp = submission_timestamp
   end
@@ -28,18 +29,20 @@ class FormSubmissionService
 
     unless @form.submission_email.blank? && @preview_mode
       FormSubmissionMailer
-        .email_completed_form(title: form_title,
-                              text_input: email_body,
-                              preview_mode: @preview_mode,
-                              reference: @reference,
-                              timestamp: @timestamp,
-                              submission_email: @form.submission_email).deliver_now
+      .email_completed_form(title: form_title,
+                            text_input: email_body,
+                            preview_mode: @preview_mode,
+                            reference: @email_confirmation_form.notify_reference,
+                            timestamp: @timestamp,
+                            submission_email: @form.submission_email).deliver_now
     end
+
+    LogEventService.log_submit(@current_context, @request, requested_email_confirmation: @requested_email_confirmation) unless @preview_mode
   end
 
   def submit_confirmation_email_to_user
     return nil unless @form.what_happens_next.present? && has_support_contact_details?
-    return nil unless @email_confirmation_form.send_confirmation == "send_email"
+    return nil unless @requested_email_confirmation
 
     FormSubmissionConfirmationMailer.send_confirmation_email(
       title: form_title,

--- a/app/services/log_event_service.rb
+++ b/app/services/log_event_service.rb
@@ -11,16 +11,21 @@ class LogEventService
     EventLogger.log_form_event(context, request, "visit") # Logging to Splunk
   end
 
-  def self.log_submit(context, request, requested_email_confirmation: false)
-    # Logging to Splunk
-    EventLogger.log_form_event(context, request, "submission")
-    EventLogger.log_form_event(context, request, "requested_email_confirmation") if requested_email_confirmation
+  def self.log_submit(context, request, requested_email_confirmation: false, preview: false)
+    if preview
+      EventLogger.log_form_event(context, request, "preview_submission")
+    else
+      # Logging to Splunk
+      EventLogger.log_form_event(context, request, "submission")
 
-    # Logging to CloudWatch
-    begin
-      CloudWatchService.log_form_submission(form_id: context.form.id)
-    rescue StandardError => e
-      Sentry.capture_exception(e)
+      EventLogger.log_form_event(context, request, "requested_email_confirmation") if requested_email_confirmation
+
+      # Logging to CloudWatch
+      begin
+        CloudWatchService.log_form_submission(form_id: context.form.id)
+      rescue StandardError => e
+        Sentry.capture_exception(e)
+      end
     end
   end
 

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -232,10 +232,6 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
   end
 
   describe "#submit_answers" do
-    before do
-      allow(LogEventService).to receive(:log_submit).at_least(:once)
-    end
-
     context "with preview mode on" do
       before do
         travel_to frozen_time do
@@ -245,10 +241,6 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
       it "redirects to confirmation page" do
         expect(response).to redirect_to(form_submitted_path)
-      end
-
-      it "does not log the form_submission event" do
-        expect(LogEventService).not_to have_received(:log_submit)
       end
 
       it "emails the form submission" do
@@ -284,10 +276,6 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(response).to redirect_to(form_submitted_path)
       end
 
-      it "Logs the submit event with service logger" do
-        expect(LogEventService).to have_received(:log_submit).with(instance_of(Context), instance_of(ActionDispatch::Request), requested_email_confirmation: true)
-      end
-
       it "emails the form submission" do
         deliveries = ActionMailer::Base.deliveries
         expect(deliveries.length).to eq 1
@@ -305,24 +293,6 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         }
 
         expect(mail.body.raw_source).to match(expected_personalisation.to_s)
-      end
-
-      context "when user has opted into the confirmation email" do
-        it "Logs the submit event with requested_email_confirmation set to true" do
-          expect(LogEventService).to have_received(:log_submit).with(instance_of(Context), instance_of(ActionDispatch::Request), requested_email_confirmation: true)
-        end
-      end
-
-      context "when user has not opted into the confirmation email" do
-        let(:email_confirmation_form) do
-          { send_confirmation: "skip_confirmation",
-            confirmation_email_address: nil,
-            notify_reference: "for-my-ref" }
-        end
-
-        it "Logs the submit event with requested_email_confirmation set to false" do
-          expect(LogEventService).to have_received(:log_submit).with(instance_of(Context), instance_of(ActionDispatch::Request), requested_email_confirmation: false)
-        end
       end
     end
 

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe FormSubmissionService do
         current_context,
         request,
         requested_email_confirmation: true,
+        preview: false,
       )
     end
 
@@ -115,6 +116,19 @@ RSpec.describe FormSubmissionService do
               preview_mode: true },
           ).once
         end
+      end
+
+      it "logs preview submission" do
+        allow(LogEventService).to receive(:log_submit).once
+
+        service.submit_form_to_processing_team
+
+        expect(LogEventService).to have_received(:log_submit).with(
+          current_context,
+          request,
+          requested_email_confirmation: true,
+          preview: true,
+        )
       end
 
       describe "validations" do

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe FormSubmissionService do
-  let(:service) { described_class.call(current_context:, email_confirmation_form:, preview_mode:) }
+  let(:service) { described_class.call(current_context:, request:, email_confirmation_form:, preview_mode:) }
   let(:form) do
     build(:form,
           id: 1,
@@ -22,6 +22,7 @@ RSpec.describe FormSubmissionService do
   let(:support_url_text) { Faker::Lorem.sentence(word_count: 1, random_words_to_add: 4) }
 
   let(:current_context) { OpenStruct.new(form:, completed_steps: [step], support_details: OpenStruct.new(call_back_url: "http://gov.uk")) }
+  let(:request) { OpenStruct.new({ url: "url", method: "method" }) }
   let(:step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer_in_email: "42" }) }
   let(:preview_mode) { false }
   let(:email_confirmation_form) { build :email_confirmation_form_opted_in }
@@ -62,6 +63,18 @@ RSpec.describe FormSubmissionService do
             preview_mode: false },
         ).once
       end
+    end
+
+    it "logs submission" do
+      allow(LogEventService).to receive(:log_submit).once
+
+      service.submit_form_to_processing_team
+
+      expect(LogEventService).to have_received(:log_submit).with(
+        current_context,
+        request,
+        requested_email_confirmation: true,
+      )
     end
 
     describe "validations" do

--- a/spec/services/log_event_service_spec.rb
+++ b/spec/services/log_event_service_spec.rb
@@ -75,14 +75,22 @@ RSpec.describe LogEventService do
       allow(CloudWatchService).to receive(:log_form_submission).and_return(true)
     end
 
-    it "calls the event logger with .log_form_event" do
-      described_class.log_submit(current_context, request)
+    context "when in preview mode" do
+      it "calls the event logger with .log_form_event" do
+        described_class.log_submit(current_context, request, preview: true)
 
-      expect(EventLogger).to have_received(:log_form_event).with(
-        current_context,
-        request,
-        "submission",
-      )
+        expect(EventLogger).to have_received(:log_form_event).with(
+          current_context,
+          request,
+          "preview_submission",
+        )
+      end
+
+      it "does not call the cloud watch service" do
+        described_class.log_submit(current_context, request, preview: true)
+
+        expect(CloudWatchService).not_to have_received(:log_form_submission)
+      end
     end
 
     context "when not in preview mode" do


### PR DESCRIPTION
### What problem does this pull request solve?
We'd like to monitor submissions of preview forms in case form previews are not being used as intended. This PR refactors existing submission logging into the FormSubmissionService, and adds logging of preview form submissions separately from live form submissions, so that we can setup alerts off the logs.

Trello card: https://trello.com/c/g4FkBxx8

### Things to consider when reviewing

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
