### PR TITLE
Add notification banner for form previews

### DIFF
--- a/app/components/preview_banner_component/view.html.erb
+++ b/app/components/preview_banner_component/view.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_notification_banner(title_text: t("preview_banner.title")) do |nb| %>
+      <% nb.with_heading(text: t("preview_banner.heading")) %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/preview_banner_component/view.rb
+++ b/app/components/preview_banner_component/view.rb
@@ -1,0 +1,13 @@
+module PreviewBannerComponent
+  class View < ViewComponent::Base
+    def initialize(mode:)
+      @mode = mode || Mode.new
+
+      super
+    end
+
+    def render?
+      @mode.preview?
+    end
+  end
+end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -38,6 +38,8 @@
       <%= yield(:before_content) %>
 
       <%= render(MainComponent::View.new(mode: @mode, is_question: @is_question)) do %>
+        <%= render(PreviewBannerComponent::View.new(mode: @mode)) %>
+
         <%= yield %>
       <% end %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,9 @@ en:
     optional: "(optional)"
   page_titles:
     error_prefix: 'Error: '
+  preview_banner:
+    heading: This is a preview of this form. Do not enter personal information.
+    title: Important
   question/name:
     label:
       first_name: First name

--- a/spec/components/preview_banner_component/preview_banner_component_preview.rb
+++ b/spec/components/preview_banner_component/preview_banner_component_preview.rb
@@ -1,0 +1,16 @@
+class PreviewBannerComponent::PreviewBannerComponentPreview < ViewComponent::Preview
+  def live
+    mode = OpenStruct.new(live: true, preview?: false, preview_draft?: false, preview_live?: false)
+    render(PreviewBannerComponent::View.new(mode:))
+  end
+
+  def preview_draft
+    mode = OpenStruct.new(live: false, preview?: true, preview_draft?: true, preview_live?: false, to_s: "preview-draft")
+    render(PreviewBannerComponent::View.new(mode:))
+  end
+
+  def preview_live
+    mode = OpenStruct.new(live: false, preview?: true, preview_draft?: false, preview_live?: true, to_s: "preview-live")
+    render(PreviewBannerComponent::View.new(mode:))
+  end
+end

--- a/spec/components/preview_banner_component/view_spec.rb
+++ b/spec/components/preview_banner_component/view_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe PreviewBannerComponent::View, type: :component do
+  it "shows in preview_draft" do
+    mode = Mode.new("preview-draft")
+    render_inline(described_class.new(mode:))
+    expect(page).to have_selector(".govuk-notification-banner")
+    expect(page).to have_content(I18n.t("preview_banner.title"))
+    expect(page).to have_content(I18n.t("preview_banner.heading"))
+  end
+
+  it "shows in preview_live" do
+    mode = Mode.new("preview-live")
+    render_inline(described_class.new(mode:))
+    expect(page).to have_selector(".govuk-notification-banner")
+    expect(page).to have_content(I18n.t("preview_banner.title"))
+    expect(page).to have_content(I18n.t("preview_banner.heading"))
+  end
+
+  it "does not show in live" do
+    mode = Mode.new("form")
+    render_inline(described_class.new(mode:))
+    expect(page).not_to have_selector(".govuk-notification-banner")
+  end
+end


### PR DESCRIPTION
For both live and draft previews, show a notification banner telling the user not to enter personal information. This is a mitigation for the use of trial accounts to collect information via form previews, even though they can't make forms live.

This is implemented using a separate `PreviewBannerComponent` rather than making changes to the `PreviewComponent` to keep them isolated from one another, but if people would prefer I'm open to merging the components into one.

### What problem does this pull request solve?

Trello card: https://trello.com/c/6ZGD5RAE

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
