### PR TITLE
Adding config for unsafe_session_storage for local dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,4 +61,8 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Allow storing session in cookies. This should only be allowed in local
+  # development and testing. In production redis should be used
+  config.unsafe_session_storage = true
 end


### PR DESCRIPTION
### What problem does this pull request solve?

During the [upgrade to Rails 7.1.1](https://github.com/alphagov/forms-runner/pull/445/files#diff-d3c4b3f41072daa416f1920511e9b2e26caea8c5cec0a14cb9508589a4dafa47L62-L64) we removed config for `unsafe_session_storage` from our dev environment. This meant that without a `REDIS_URL` set, you weren't able to get things running locally. 

With this change, you can either run the server with a `REDIS_URL` set, which will store things in redis - or you can not set it and store stuff in cookies. 

This only seems to be an issue when running the server with `bundle exec rails s`, and not with `bin/dev` - unless you didn't have a `.env` file with a `REDIS_URL` set, in which case you may have seen it with `bin/dev`.
