### PR TITLE
enforce 4-digit year field for date answer types

### DIFF
--- a/app/models/question/date.rb
+++ b/app/models/question/date.rb
@@ -35,6 +35,7 @@ module Question
       return errors.add(:date, :blank) if blank?
       return errors.add(:date, :blank_date_fields, fields: blank_fields.to_sentence) if present? && blank_fields.any?
       return errors.add(:date, :invalid_date) if invalid?
+      return errors.add(:date, :invalid_number_of_digits_for_year) if invalid_year?
       return errors.add(:date, :future_date) if date_of_birth? && future_date?
     end
 
@@ -60,6 +61,10 @@ module Question
 
     def future_date?
       date.future?
+    end
+
+    def invalid_year?
+      !date_year.to_i.between?(1000, 9999)
     end
 
     def blank_fields

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
               blank_date_fields: Enter a day, month and year
               future_date: Enter a date that’s in the past
               invalid_date: Enter a real date
+              invalid_number_of_digits_for_year: Year must include 4 numbers
         question/email:
           attributes:
             email:

--- a/spec/models/question/date_spec.rb
+++ b/spec/models/question/date_spec.rb
@@ -65,6 +65,56 @@ RSpec.describe Question::Date, type: :model do
     end
   end
 
+  context "when a year is not 4-digits" do
+    let(:year) { "2023" }
+
+    before do
+      set_date("01", "11", year)
+    end
+
+    context "when year is less than 1000" do
+      let(:year) { "567" }
+
+      it "isn't valid" do
+        expect(question).not_to be_valid
+        expect(question.errors[:date]).to include(I18n.t("activemodel.errors.models.question/date.attributes.date.invalid_number_of_digits_for_year"))
+      end
+    end
+
+    context "when year is 1000" do
+      let(:year) { "1000" }
+
+      it "is valid" do
+        expect(question).to be_valid
+      end
+    end
+
+    context "when year is between 1000 and 9999" do
+      let(:year) { "3400" }
+
+      it "is valid" do
+        expect(question).to be_valid
+      end
+    end
+
+    context "when year is 9999" do
+      let(:year) { "9999" }
+
+      it "is valid" do
+        expect(question).to be_valid
+      end
+    end
+
+    context "when year more than 9999" do
+      let(:year) { "10000" }
+
+      it "isn't valid" do
+        expect(question).not_to be_valid
+        expect(question.errors[:date]).to include(I18n.t("activemodel.errors.models.question/date.attributes.date.invalid_number_of_digits_for_year"))
+      end
+    end
+  end
+
   context "when given non-integers as values for day, month or year" do
     it "isn't valid" do
       day_month_years = [


### PR DESCRIPTION
### What problem does this pull request solve?
Year fields should not accept two digits. Instead of checking the length of year which would mean that 0000 to 0999 would be valid dates, I instead check that year is between 1000 and 9999. This isn't exactly ideal. Having checked this with a designer, we decided to do this check and allow us to later add more refined validations which could be configured by form creators.

This follows the GOV.UK Design System pattern to ensure years are 4-digit numbers https://design-system.service.gov.uk/components/date-input/#if-the-date-is-incomplete

![image](https://github.com/alphagov/forms-runner/assets/3441519/63229775-acd3-4e58-afca-bc380673e436)

Trello card: https://trello.com/c/QAyMX8OZ/1224-year-input-for-the-date-answer-type-allows-user-to-only-enter-2-digits

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
