### PR TITLE
Add fill and submit form feature test

### DIFF
--- a/spec/features/fill_in_and_submit_form_spec.rb
+++ b/spec/features/fill_in_and_submit_form_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+feature "Fill in and submit a form", type: :feature, feature_email_confirmations_enabled: true do
+  let(:pages) { [(build :page, :with_text_settings, id: 1, form_id: 1, routing_conditions: [])] }
+  let(:form) { build :form, :live, id: 1, name: "Fill in this form", pages:, start_page: 1 }
+  let(:question_text) { pages[0].question_text }
+  let(:answer_text) { "Answer text" }
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Content-Type" => "application/json",
+    }
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
+      mock.get "/api/v1/forms/1/live", req_headers, form.to_json(include: [:pages]), 200
+    end
+  end
+
+  scenario "As a form filler" do
+    when_i_visit_the_form_start_page
+    then_i_should_see_the_first_question
+
+    when_i_fill_in_the_question
+    and_i_click_on_continue
+    then_i_should_see_the_check_your_answers_page
+
+    when_i_opt_out_of_email_confirmation
+    and_i_submit_my_form
+    then_my_form_should_be_submitted
+  end
+
+  def when_i_visit_the_form_start_page
+    visit form_path(mode: "form", form_id: 1, form_slug: "fill-in-this-form")
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def then_i_should_see_the_first_question
+    expect(page.find("h1")).to have_text question_text
+  end
+
+  def when_i_fill_in_the_question
+    fill_in question_text, with: answer_text
+  end
+
+  def and_i_click_on_continue
+    click_button "Continue"
+  end
+
+  def then_i_should_see_the_check_your_answers_page
+    expect(page.find("h1")).to have_text "Check your answers before submitting your form"
+    expect(page).to have_text question_text
+    expect(page).to have_text answer_text
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def when_i_opt_out_of_email_confirmation
+    choose "No"
+  end
+
+  def and_i_submit_my_form
+    click_on "Submit"
+  end
+
+  def then_my_form_should_be_submitted
+    expect(page.find("h1")).to have_text "Your form has been submitted"
+    expect_page_to_have_no_axe_errors(page)
+  end
+end

--- a/spec/support/axe_feature_helpers.rb
+++ b/spec/support/axe_feature_helpers.rb
@@ -1,10 +1,14 @@
 module AxeFeatureHelpers
+  ARIA_ALLOWED_ATTR = "aria-allowed-attr".freeze
+
   def expect_page_to_have_no_axe_errors(page)
-    expect(page).to be_axe_clean.according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa)
+    expect(page).to be_axe_clean.according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa).skipping ARIA_ALLOWED_ATTR
+    expect(page).to be_axe_clean.excluding(".govuk-radios__input").checking_only ARIA_ALLOWED_ATTR
   end
 
   def expect_component_to_have_no_axe_errors(page)
-    expect(page).to be_axe_clean.within("#main-content").according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa)
+    expect(page).to be_axe_clean.within("#main-content").according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa).skipping ARIA_ALLOWED_ATTR
+    expect(page).to be_axe_clean.within("#main-content").excluding(".govuk-radios__input").checking_only ARIA_ALLOWED_ATTR
   end
 end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/BP0bsQOf/1171-add-beginnings-of-missing-feature-tests-to-the-runner

This adds a basic feature test that covers filling in and submitting a form. 
There's also a change to our Axe check helper, which skips checking radio buttons for the `aria-allowed-attr` rule. This is a rule that probably shouldn't be catching our use of `aria-expanded="false"` as explored in [this thread](https://github.com/alphagov/govuk-frontend/issues/979).

I've opted to turn the email confirmation feature on in this test, as it's currently off by default. I kind of got most of the way through writing the tests before realising I'd turned it on locally, and it felt a bit pointless removing the opt-out-of-email-confirmation step in the test just because we haven't removed the feature flag yet.

The `ARIA_ALLOWED_ATTR` constant was added as sonarcloud thought it smelled funny otherwise.
