### PR TITLE
Clean up what happens next markdown changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,8 +56,6 @@ gem "lograge"
 
 gem "aws-sdk-cloudwatch"
 
-gem "reverse_markdown", "~> 2.1"
-
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,8 +353,6 @@ GEM
       io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
-    reverse_markdown (2.1.1)
-      nokogiri
     rexml (3.2.6)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
@@ -493,7 +491,6 @@ DEPENDENCIES
   rails-controller-testing
   redis
   redis-session-store
-  reverse_markdown (~> 2.1)
   rspec-rails
   rubocop-govuk
   selenium-webdriver

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -1,10 +1,10 @@
 class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
-  def send_confirmation_email(title:, what_happens_next_text:, support_contact_details:, submission_timestamp:, preview_mode:, reference:, confirmation_email_address:)
+  def send_confirmation_email(title:, what_happens_next_markdown:, support_contact_details:, submission_timestamp:, preview_mode:, reference:, confirmation_email_address:)
     set_template(Settings.govuk_notify.form_filler_confirmation_email_template_id)
 
     set_personalisation(
       title:,
-      what_happens_next_text:,
+      what_happens_next_text: what_happens_next_markdown,
       support_contact_details:,
       submission_time: submission_timestamp.strftime("%l:%M%P").strip,
       submission_date: submission_timestamp.strftime("%-d %B %Y"),

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -32,9 +32,4 @@ class Form < ActiveResource::Base
   def live_at_date
     try(:live_at).try(:to_time)
   end
-
-  # TODO: remove this method and ReverseMarkdown gem once we've converted the existing content in forms-api to markdown
-  def what_happens_next
-    what_happens_next_markdown
-  end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -35,6 +35,6 @@ class Form < ActiveResource::Base
 
   # TODO: remove this method and ReverseMarkdown gem once we've converted the existing content in forms-api to markdown
   def what_happens_next
-    (what_happens_next_markdown.presence || ReverseMarkdown.convert(HtmlMarkdownSanitizer.new.render_scrubbed_html(what_happens_next_text)).strip)
+    what_happens_next_markdown
   end
 end

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -46,7 +46,7 @@ class FormSubmissionService
 
     FormSubmissionConfirmationMailer.send_confirmation_email(
       title: form_title,
-      what_happens_next_text: @form.what_happens_next_markdown,
+      what_happens_next_markdown: @form.what_happens_next_markdown,
       support_contact_details: formatted_support_details,
       submission_timestamp: @timestamp,
       preview_mode: @preview_mode,

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -41,12 +41,12 @@ class FormSubmissionService
   end
 
   def submit_confirmation_email_to_user
-    return nil unless @form.what_happens_next.present? && has_support_contact_details?
+    return nil unless @form.what_happens_next_markdown.present? && has_support_contact_details?
     return nil unless @requested_email_confirmation
 
     FormSubmissionConfirmationMailer.send_confirmation_email(
       title: form_title,
-      what_happens_next_text: @form.what_happens_next,
+      what_happens_next_text: @form.what_happens_next_markdown,
       support_contact_details: formatted_support_details,
       submission_timestamp: @timestamp,
       preview_mode: @preview_mode,

--- a/app/views/forms/submitted/submitted.html.erb
+++ b/app/views/forms/submitted/submitted.html.erb
@@ -8,9 +8,9 @@
       <p><%= t('form.submitted.email_sent') %></p>
     <% end %>
 
-    <%if @current_context.form.what_happens_next.present? %>
+    <%if @current_context.form.what_happens_next_markdown.present? %>
       <h2 class="govuk-heading-m">What happens next</h2>
-      <%= HtmlMarkdownSanitizer.new.render_scrubbed_markdown(@current_context.form.what_happens_next) %>
+      <%= HtmlMarkdownSanitizer.new.render_scrubbed_markdown(@current_context.form.what_happens_next_markdown) %>
     <% end %>
   </div>
 </div>

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
     privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
     org { "test-org" }
     live_at { nil }
-    what_happens_next_text { nil }
     what_happens_next_markdown { nil }
     support_email { nil }
     support_phone { nil }
@@ -21,13 +20,12 @@ FactoryBot.define do
     trait :new_form do
       submission_email { nil }
       privacy_policy_url { nil }
-      what_happens_next_text { nil }
     end
 
     trait :ready_for_live do
       with_pages
       support_email { Faker::Internet.email(domain: "example.gov.uk") }
-      what_happens_next_text { "We usually respond to applications within 10 working days." }
+      what_happens_next_markdown { "We usually respond to applications within 10 working days." }
     end
 
     trait :live do

--- a/spec/lib/context_spec.rb
+++ b/spec/lib/context_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Context do
           id: 2,
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-          what_happens_next_text: "Good things come to those that wait",
+          what_happens_next_markdown: "Good things come to those that wait",
           declaration_text: "agree to the declaration",
           pages:)
   end

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe FormSubmissionConfirmationMailer, type: :mailer do
   let(:mail) do
     described_class.send_confirmation_email(title:,
-                                            what_happens_next_text: what_happens_next,
+                                            what_happens_next_text: what_happens_next_markdown,
                                             support_contact_details:,
                                             submission_timestamp:,
                                             preview_mode:,
@@ -11,7 +11,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
                                             confirmation_email_address:)
   end
   let(:title) { "Form 1" }
-  let(:what_happens_next) { "Please wait for a response" }
+  let(:what_happens_next_markdown) { "Please wait for a response" }
   let(:support_contact_details) { "Call: 0203 222 2222" }
   let(:preview_mode) { false }
   let(:confirmation_email_address) { "testing@gov.uk" }

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe FormSubmissionConfirmationMailer, type: :mailer do
   let(:mail) do
     described_class.send_confirmation_email(title:,
-                                            what_happens_next_text: what_happens_next_markdown,
+                                            what_happens_next_markdown:,
                                             support_contact_details:,
                                             submission_timestamp:,
                                             preview_mode:,

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe FormSubmissionConfirmationMailer, type: :mailer do
   let(:mail) do
     described_class.send_confirmation_email(title:,
-                                            what_happens_next_text:,
+                                            what_happens_next_text: what_happens_next,
                                             support_contact_details:,
                                             submission_timestamp:,
                                             preview_mode:,
@@ -11,7 +11,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
                                             confirmation_email_address:)
   end
   let(:title) { "Form 1" }
-  let(:what_happens_next_text) { "Please wait for a response" }
+  let(:what_happens_next) { "Please wait for a response" }
   let(:support_contact_details) { "Call: 0203 222 2222" }
   let(:preview_mode) { false }
   let(:confirmation_email_address) { "testing@gov.uk" }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -94,23 +94,4 @@ RSpec.describe Form, type: :model do
       end
     end
   end
-
-  describe "what_happens_next" do
-    let(:what_happens_next_markdown) { nil }
-    let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", start_page: 1, what_happens_next_markdown: }.to_json }
-
-    context "when what_happens_next_markdown is nil" do
-      it "returns nil" do
-        expect(described_class.find(1).what_happens_next).to eq nil
-      end
-    end
-
-    context "when what_happens_next_markdown has a value" do
-      let(:what_happens_next_markdown) { "We’ll send you an email to let you know the outcome. Visit our [service status page](https://example.com) to see current response times.\n\nYou'll also need to:\n\n1. provide a certified copy of your documents\n2. make a payment" }
-
-      it "returns the what_happens_next_markdown" do
-        expect(described_class.find(1).what_happens_next).to eq what_happens_next_markdown
-      end
-    end
-  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -96,13 +96,12 @@ RSpec.describe Form, type: :model do
   end
 
   describe "what_happens_next" do
-    let(:what_happens_next_text) { "We’ll send you an email to let you know the outcome. Visit our <a href=\"https://example.com\" target=\"_blank\" rel\"noreferrer noopener\">service status page</a> to see current response times.\n\nYou'll also need to:\n\n<ul class=\"govuk-list govuk-list--bullet\"><li>provide a certified copy of your documents</li><li>make a payment</li></ul>" }
     let(:what_happens_next_markdown) { nil }
-    let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", start_page: 1, what_happens_next_text:, what_happens_next_markdown: }.to_json }
+    let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", start_page: 1, what_happens_next_markdown: }.to_json }
 
     context "when what_happens_next_markdown is nil" do
-      it "returns the what_happens_next_text converted tp notify-compliant markdown format" do
-        expect(described_class.find(1).what_happens_next).to eq "We’ll send you an email to let you know the outcome. Visit our [service status page](https://example.com) to see current response times.\n\nYou'll also need to:\n\n- provide a certified copy of your documents\n- make a payment"
+      it "returns nil" do
+        expect(described_class.find(1).what_happens_next).to eq nil
       end
     end
 

--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Forms::BaseController, type: :request do
           live_at:,
           start_page:,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-          what_happens_next_text: "Good things come to those that wait",
+          what_happens_next_markdown: "Good things come to those that wait",
           declaration_text: "agree to the declaration",
           pages: pages_data)
   end

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
           expected_personalisation = {
             title: form_data.name,
-            what_happens_next_text: form_data.what_happens_next,
+            what_happens_next_text: form_data.what_happens_next_markdown,
             support_contact_details: contact_support_details_format,
             submission_time: "10:00am",
             submission_date: "14 December 2022",

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           live_at:,
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-          what_happens_next_text: "Good things come to those that wait",
+          what_happens_next_markdown: "Good things come to those that wait",
           declaration_text: "agree to the declaration",
           pages: pages_data)
   end

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Forms::PageController, type: :request do
           live_at:,
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-          what_happens_next_text: "Good things come to those that wait",
+          what_happens_next_markdown: "Good things come to those that wait",
           declaration_text: "agree to the declaration",
           pages: pages_data)
   end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe FormSubmissionService do
         service.submit_confirmation_email_to_user
         expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
           { title: "Form 1",
-            what_happens_next_text: form.what_happens_next_markdown,
+            what_happens_next_markdown: form.what_happens_next_markdown,
             support_contact_details: contact_support_details_format,
             submission_timestamp: Time.zone.now,
             preview_mode:,

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe FormSubmissionService do
     build(:form,
           id: 1,
           name: "Form 1",
-          what_happens_next_text:,
           what_happens_next_markdown:,
           support_email:,
           support_phone:,
@@ -14,8 +13,7 @@ RSpec.describe FormSubmissionService do
           support_url_text:,
           submission_email: "testing@gov.uk")
   end
-  let(:what_happens_next_text) { "We usually respond to applications within 10 working days." }
-  let(:what_happens_next_markdown) { nil }
+  let(:what_happens_next_markdown) { "We usually respond to applications within 10 working days." }
   let(:support_email) { Faker::Internet.email(domain: "example.gov.uk") }
   let(:support_phone) { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
   let(:support_url) { Faker::Internet.url(host: "gov.uk") }
@@ -197,7 +195,7 @@ RSpec.describe FormSubmissionService do
 
     context "when form is draft" do
       context "when form does not have 'what happens next details'" do
-        let(:what_happens_next_text) { nil }
+        let(:what_happens_next_markdown) { nil }
 
         it "does not call FormSubmissionConfirmationMailer" do
           allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email)

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe FormSubmissionService do
         service.submit_confirmation_email_to_user
         expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
           { title: "Form 1",
-            what_happens_next_text: form.what_happens_next,
+            what_happens_next_text: form.what_happens_next_markdown,
             support_contact_details: contact_support_details_format,
             submission_timestamp: Time.zone.now,
             preview_mode:,

--- a/spec/views/forms/submitted/submitted.html.erb_spec.rb
+++ b/spec/views/forms/submitted/submitted.html.erb_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 describe "forms/submitted/submitted.html.erb" do
-  let(:form) { build :form, id: 1, what_happens_next_text: }
-  let(:what_happens_next_text) { nil }
+  let(:form) { build :form, id: 1, what_happens_next_markdown: }
+  let(:what_happens_next_markdown) { nil }
   let(:email_sent) { false }
 
   before do
@@ -18,7 +18,7 @@ describe "forms/submitted/submitted.html.erb" do
   end
 
   context "when the form has extra information about what happens next" do
-    let(:what_happens_next_text) { "See what the day brings" }
+    let(:what_happens_next_markdown) { "See what the day brings" }
 
     it "displays what happens next heading" do
       expect(rendered).to have_css("h2", text: "What happens next")


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

Removes some of the code that was added for the `what_happens_next_text` -> `what_happens_next_markdown` switchover. Mostly consists of renaming or removing references to `what_happens_next_text`, but also includes:

- removing a redundant method from the form model
- removing an unused gem

See individual commits for details.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
