### PR TITLE
Remove email_confirmations_enabled feature flag

### DIFF
--- a/app/form_objects/email_confirmation_form.rb
+++ b/app/form_objects/email_confirmation_form.rb
@@ -4,8 +4,8 @@ class EmailConfirmationForm
 
   attr_accessor :send_confirmation, :confirmation_email_address, :confirmation_email_reference, :notify_reference
 
-  validates :send_confirmation, presence: true, if: :validate_presence?
-  validates :send_confirmation, inclusion: { in: %w[send_email skip_confirmation] }, if: :validate_presence?
+  validates :send_confirmation, presence: true
+  validates :send_confirmation, inclusion: { in: %w[send_email skip_confirmation] }
   validates :confirmation_email_address, presence: true, if: :validate_email?
   validates :confirmation_email_address, format: { with: URI::MailTo::EMAIL_REGEXP, message: :invalid_email }, allow_blank: true, if: :validate_email?
 
@@ -15,11 +15,7 @@ class EmailConfirmationForm
   end
 
   def validate_email?
-    FeatureService.enabled?(:email_confirmations_enabled) && send_confirmation == "send_email"
-  end
-
-  def validate_presence?
-    FeatureService.enabled?(:email_confirmations_enabled)
+    send_confirmation == "send_email"
   end
 
 private

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -17,7 +17,7 @@ class FormSubmissionService
 
   def submit
     submit_form_to_processing_team
-    submit_confirmation_email_to_user if FeatureService.enabled?(:email_confirmations_enabled)
+    submit_confirmation_email_to_user
   end
 
   def submit_form_to_processing_team

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -24,16 +24,14 @@
         %>
       <% end %>
 
-      <% if FeatureService.enabled?(:email_confirmations_enabled) %>
-        <%= form.govuk_radio_buttons_fieldset(:send_confirmation, legend: { size: 'm', tag: 'h2' }) do %>
-          <%= form.govuk_radio_button :send_confirmation, 'send_email' do %>
-            <%= form.govuk_text_field :confirmation_email_address %>
-          <% end %>
-          <%= form.govuk_radio_button :send_confirmation, 'skip_confirmation' %>
+      <%= form.govuk_radio_buttons_fieldset(:send_confirmation, legend: { size: 'm', tag: 'h2' }) do %>
+        <%= form.govuk_radio_button :send_confirmation, 'send_email' do %>
+          <%= form.govuk_text_field :confirmation_email_address %>
         <% end %>
-
-        <%= form.hidden_field :confirmation_email_reference, id: 'confirmation-email-reference' %>
+        <%= form.govuk_radio_button :send_confirmation, 'skip_confirmation' %>
       <% end %>
+
+      <%= form.hidden_field :confirmation_email_reference, id: 'confirmation-email-reference' %>
 
       <%if @current_context.form.declaration_text.present? %>
         <h2 class="govuk-heading-m govuk-!-margin-top-7">Declaration</h2>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,4 @@
-features:
-  email_confirmations_enabled: false
+features: {}
 
 forms_admin:
   # URL to form-admin

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,0 @@
-features:
-  email_confirmations_enabled: true

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -19,9 +19,11 @@ describe "Settings" do
   end
 
   describe ".features" do
-    features = settings[:features]
+    it "has a default value" do
+      features = settings[:features]
 
-    include_examples expected_value_test, :email_confirmations_enabled, features, false
+      expect(features).to eq({})
+    end
   end
 
   describe ".forms_api" do

--- a/spec/features/email_confirmation_spec.rb
+++ b/spec/features/email_confirmation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Email confirmation", type: :feature, feature_email_confirmations_enabled: true do
+feature "Email confirmation", type: :feature do
   let(:pages) { [(build :page, :with_text_settings, id: 1, form_id: 1, routing_conditions: [])] }
   let(:form) { build :form, :live, id: 1, name: "Apply for a juggling license", pages:, start_page: 1 }
   let(:text_answer) { Faker::Lorem.sentence }

--- a/spec/features/fill_in_and_submit_form_spec.rb
+++ b/spec/features/fill_in_and_submit_form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Fill in and submit a form", type: :feature, feature_email_confirmations_enabled: true do
+feature "Fill in and submit a form", type: :feature do
   let(:pages) { [(build :page, :with_text_settings, id: 1, form_id: 1, routing_conditions: [])] }
   let(:form) { build :form, :live, id: 1, name: "Fill in this form", pages:, start_page: 1 }
   let(:question_text) { pages[0].question_text }

--- a/spec/form_objects/email_confirmation_form_spec.rb
+++ b/spec/form_objects/email_confirmation_form_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe EmailConfirmationForm, type: :model do
   let(:email_confirmation_form) { build :email_confirmation_form }
 
-  context "when the email confirmations flag is enabled", feature_email_confirmations_enabled: true do
+  context "when the email confirmations flag is enabled" do
     context "when given an empty string or nil" do
       it "returns invalid with blank email" do
         expect(email_confirmation_form).not_to be_valid
@@ -40,15 +40,6 @@ RSpec.describe EmailConfirmationForm, type: :model do
       it "returns valid with empty string" do
         email_confirmation_form.confirmation_email_address = ""
         expect(email_confirmation_form).to be_valid
-      end
-    end
-  end
-
-  context "when the email confirmations flag is not enabled", feature_email_confirmations_enabled: false do
-    context "when send_confirmation is null" do
-      it "returns valid" do
-        expect(email_confirmation_form).to be_valid
-        expect(email_confirmation_form.errors[:send_confirmation]).to be_empty
       end
     end
   end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -31,16 +31,9 @@ RSpec.describe FormSubmissionService do
       service.submit
     end
 
-    it "does not call submit_confirmation_email_to_user" do
-      expect(service).not_to receive(:submit_confirmation_email_to_user)
+    it "calls submit_confirmation_email_to_user" do
+      expect(service).to receive(:submit_confirmation_email_to_user).once
       service.submit
-    end
-
-    describe "when email_confirmation feature is enabled", feature_email_confirmations_enabled: true do
-      it "calls submit_confirmation_email_to_user" do
-        expect(service).to receive(:submit_confirmation_email_to_user).once
-        service.submit
-      end
     end
   end
 

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -51,36 +51,18 @@ describe "forms/check_your_answers/show.html.erb" do
     expect(rendered).to have_field("notification-id", type: :hidden, with: email_confirmation_form.notify_reference)
   end
 
-  context "when the email confirmation feature flag is off", feature_email_confirmations_enabled: false do
-    it "does not display the email radio buttons" do
-      expect(rendered).not_to have_text(I18n.t("helpers.legend.email_confirmation_form.send_confirmation"))
-      expect(rendered).not_to have_field(I18n.t("helpers.label.email_confirmation_form.send_confirmation_options.send_email"))
-      expect(rendered).not_to have_field(I18n.t("helpers.label.email_confirmation_form.send_confirmation_options.skip_confirmation"))
-    end
-
-    it "does not display the email field" do
-      expect(rendered).not_to have_field(I18n.t("helpers.label.email_confirmation_form.confirmation_email_address"))
-    end
-
-    it "does not contain a hidden notify reference for the confirmation email" do
-      expect(rendered).not_to have_field("confirmation-email-reference", type: "hidden", with: email_confirmation_form.confirmation_email_reference)
-    end
+  it "displays the email radio buttons" do
+    expect(rendered).to have_text(I18n.t("helpers.legend.email_confirmation_form.send_confirmation"))
+    expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_form.send_confirmation_options.send_email"))
+    expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_form.send_confirmation_options.skip_confirmation"))
   end
 
-  context "when the email confirmation feature flag is on", feature_email_confirmations_enabled: true do
-    it "displays the email radio buttons" do
-      expect(rendered).to have_text(I18n.t("helpers.legend.email_confirmation_form.send_confirmation"))
-      expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_form.send_confirmation_options.send_email"))
-      expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_form.send_confirmation_options.skip_confirmation"))
-    end
+  it "displays the email field" do
+    expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_form.confirmation_email_address"))
+  end
 
-    it "displays the email field" do
-      expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_form.confirmation_email_address"))
-    end
-
-    it "contains a hidden notify reference for the confirmation email" do
-      expect(rendered).to have_field("confirmation-email-reference", type: "hidden", with: email_confirmation_form.confirmation_email_reference)
-    end
+  it "contains a hidden notify reference for the confirmation email" do
+    expect(rendered).to have_field("confirmation-email-reference", type: "hidden", with: email_confirmation_form.confirmation_email_reference)
   end
 
   # TODO: add view tests for playing back questions and Answers


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/bXjqCIVe/1192-remove-confirmation-email-feature-flag

This feature is enabled in all of our environments, and we've seen from our analytics that it's very popular, so we can safely remove the feature flag.

Still to come:
 -   removing the flag variables from forms-deploy

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
