### PR TITLE
Improve request test coverage

### DIFF
--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -19,7 +19,7 @@ module Forms
         redirect_to next_page
       else
         setup_instance_vars_for_view
-        render :show
+        render :show, status: :unprocessable_entity
       end
     end
 

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -347,6 +347,20 @@ RSpec.describe Forms::PageController, type: :request do
           expect(response).not_to have_http_status(:not_found)
         end
       end
+
+      context "when the form is invalid" do
+        before do
+          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "" }, changing_existing_answer: false }
+        end
+
+        it "renders the show page template" do
+          expect(response).to render_template("forms/page/show")
+        end
+
+        it "returns 422" do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
     end
 
     context "with preview mode off" do
@@ -403,6 +417,20 @@ RSpec.describe Forms::PageController, type: :request do
             expect(EventLogger).to receive(:log_page_event).with(instance_of(Context), instance_of(Step), instance_of(ActionDispatch::Request), "optional_save", false)
             post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
           end
+        end
+      end
+
+      context "when the form is invalid" do
+        before do
+          post save_form_page_path("form", 2, form_data.form_slug, 1), params: { question: { text: "" }, changing_existing_answer: false }
+        end
+
+        it "renders the show page template" do
+          expect(response).to render_template("forms/page/show")
+        end
+
+        it "returns 422" do
+          expect(response).to have_http_status(:unprocessable_entity)
         end
       end
     end

--- a/spec/requests/forms/privacy_page_controller_spec.rb
+++ b/spec/requests/forms/privacy_page_controller_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe Forms::PrivacyPageController, type: :request do
+  let(:form_data) do
+    build(:form, :with_support,
+          id: 2,
+          start_page: 1,
+          privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+          what_happens_next_markdown: "Good things come to those that wait",
+          declaration_text: "agree to the declaration",
+          pages: pages_data)
+  end
+
+  let(:pages_data) do
+    [
+      {
+        id: 1,
+        position: 1,
+        question_text: "Question one",
+        answer_type: "date",
+        next_page: 2,
+        is_optional: nil,
+      },
+      {
+        id: 2,
+        position: 2,
+        question_text: "Question two",
+        answer_type: "date",
+        is_optional: nil,
+      },
+    ]
+  end
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  describe "#show" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2/draft", req_headers, form_data.to_json, 200
+      end
+
+      get form_privacy_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug)
+    end
+
+    it "includes the privacy policy URL" do
+      expect(response.body).to include(form_data.privacy_policy_url)
+    end
+
+    it "renders the show privacy page template" do
+      expect(response).to render_template("forms/privacy_page/show")
+    end
+
+    it "returns 200" do
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/forms/submitted_controller_spec.rb
+++ b/spec/requests/forms/submitted_controller_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe Forms::SubmittedController, type: :request do
+  let(:context) { Context.new(form: form_data, store:) }
+
+  let(:form_data) do
+    build(:form, :with_support,
+          id: 2,
+          start_page: 1,
+          privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+          what_happens_next_markdown: "Your application will be processed within a few days.\n\nContact us if you need to:\n\n-change the details of your application\n-cancel your application",
+          declaration_text: "agree to the declaration",
+          pages: pages_data)
+  end
+
+  let(:pages_data) do
+    [
+      build(:page,
+            id: 1,
+            position: 1,
+            question_text: "Question one",
+            answer_type: "date",
+            next_page: 2,
+            is_optional: nil),
+      build(:page,
+            id: 2,
+            position: 2,
+            question_text: "Question two",
+            answer_type: "date",
+            is_optional: nil),
+    ]
+  end
+
+  let(:store) do
+    {
+      answers: {
+        "2" => {
+          "1" => {
+            "date_year" => "2000",
+            "date_month" => "1",
+            "date_day" => "1",
+          },
+          "2" => {
+            "date_year" => "2023",
+            "date_month" => "6",
+            "date_day" => "9",
+          },
+        },
+      },
+    }
+  end
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  describe "#submitted" do
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2/draft", req_headers, form_data.to_json, 200
+      end
+
+      allow(Context).to receive(:new).and_return(context)
+      allow(context).to receive(:clear)
+
+      get form_submitted_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug)
+    end
+
+    it "renders the what happens next markdown" do
+      expect(response.body).to include(HtmlMarkdownSanitizer.new.render_scrubbed_markdown(form_data.what_happens_next_markdown))
+    end
+
+    it "renders the submitted page template" do
+      expect(response).to render_template("forms/submitted/submitted")
+    end
+
+    it "returns 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "clears the context" do
+      expect(context).to have_received(:clear)
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/9sjKA9FO/238-form-runner-improve-request-tests

Adds request specs for missing scenarios in the controllers. Includes:
- test for the check your answers page's error handling
- validation tests for the page controller
- privacy page controller request specs
- submitted controller request specs

Also includes a fix for a missing status code that was highlighted by one of the new tests:
- Fix missing HTTP status on page controller 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
