### PR TITLE
Fix visible production environment tag

### DIFF
--- a/app/components/form_header_component/view.rb
+++ b/app/components/form_header_component/view.rb
@@ -26,7 +26,7 @@ module FormHeaderComponent
   private
 
     def service_name_with_tag
-      govuk_tag(colour: colour_for_environment, text: environment_name).html_safe unless environment_name == "production"
+      govuk_tag(colour: colour_for_environment, text: environment_name).html_safe unless environment_name == I18n.t("environment_names.production")
     end
 
     def environment_name

--- a/spec/components/form_header_component/view_spec.rb
+++ b/spec/components/form_header_component/view_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe FormHeaderComponent::View, type: :component do
 
   context "when the environment is production" do
     before do
-      allow(HostingEnvironment).to receive(:friendly_environment_name).and_return("production")
+      allow(HostingEnvironment).to receive(:friendly_environment_name).and_return(I18n.t("environment_names.production"))
       render_inline(described_class.new(current_context:, mode:, service_url_overide: "/form/1/test"))
     end
 
     it "does not show an environment tag" do
-      expect(page).not_to have_css(".govuk-tag", text: "production")
+      expect(page).not_to have_css(".govuk-tag", text: I18n.t("environment_names.production"))
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/VeOkfpZv/1250-update-forms-runner-to-govuk-frontend-v5

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
In #535 we updated the tags to reflect the new tag casing rules in version 5 of govuk-frontend. Unfortunately, the 'production' text was not updated to 'Production' everywhere, so the logic for hiding the environment tag in production broke.

This PR fixes the problem, and updates the 'production' check to look at the translation directly, so that the environment check will stay up to date with any future changes to this text.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
