### PR TITLE
Change live and draft tag colours

### DIFF
--- a/app/components/form_header_component/_index.scss
+++ b/app/components/form_header_component/_index.scss
@@ -1,9 +1,9 @@
 .app-header--preview-draft .govuk-header__container {
-  border-bottom-color: govuk-colour("purple");
+  border-bottom-color: govuk-colour("yellow");
 }
 
 .app-header--preview-live .govuk-header__container {
-  border-bottom-color: govuk-colour("blue");
+  border-bottom-color: govuk-colour("turquoise");
 }
 
 .app-header .govuk-header__link--homepage {

--- a/app/components/preview_component/view.rb
+++ b/app/components/preview_component/view.rb
@@ -17,9 +17,9 @@ module PreviewComponent
 
     def phase_banner_colour
       if @mode.preview_draft?
-        "purple"
+        "yellow"
       else
-        "blue"
+        "turquoise"
       end
     end
 

--- a/spec/components/preview_component/view_spec.rb
+++ b/spec/components/preview_component/view_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PreviewComponent::View, type: :component do
     mode = Mode.new("preview-draft")
     render_inline(described_class.new(mode:, question_edit_link: "https://gov.uk"))
     expect(page).to have_selector(".govuk-phase-banner")
-    expect(page).to have_content(I18n.t("mode.phase_banner_tag_preview-draft"))
+    expect(page).to have_selector(".govuk-tag--yellow", text: I18n.t("mode.phase_banner_tag_preview-draft"))
     expect(page).to have_content(I18n.t("mode.phase_banner_text_preview-draft"))
     expect(page).to have_link(I18n.t("mode.phase_banner_text_preview-draft_edit_link", href: "https://gov.uk"))
   end
@@ -14,7 +14,7 @@ RSpec.describe PreviewComponent::View, type: :component do
     mode = Mode.new("preview-live")
     render_inline(described_class.new(mode:))
     expect(page).to have_selector(".govuk-phase-banner")
-    expect(page).to have_content(I18n.t("mode.phase_banner_tag_preview-live"))
+    expect(page).to have_selector(".govuk-tag--turquoise", text: I18n.t("mode.phase_banner_tag_preview-live"))
     expect(page).to have_content(I18n.t("mode.phase_banner_text_preview-live"))
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/RFWi2tB5/1401-update-draft-and-live-tags

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Changes the colour of 'live' tags to turquoise, and 'draft' tags to yellow. Also:
- adds the tag selector to the tests, so we can check the right colours are appearing.
- updates the colour of the bar under the header to match the  tag.

### Screenshots
Live preview:
![The header of a GOV.UK Form, with a turqoise border at the bottom of the header, followed by a banner reading "Live preview You’re previewing the live version of this form" where "Live preview" is presented as a turquoise tag](https://github.com/alphagov/forms-runner/assets/5861235/56d5e8b0-ba70-4edb-8512-990a8698d153)

Draft preview:
![The header of a GOV.UK Form, with a yellow border at the bottom of the header, followed by a banner reading "Draft preview You’re previewing the draft version of this form. Edit this question" where "Draft preview" is presented as a yellow tag](https://github.com/alphagov/forms-runner/assets/5861235/9ee3c023-be9a-40e8-995d-d6f30bc127f9)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
