### PR TITLE
Move stdout logging back to prod as the default

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -57,11 +57,6 @@ module FormsRunner
     # logging use the Logger::Formatter.new.
     config.log_formatter = JsonLogFormatter.new
 
-    if ENV["RAILS_LOG_TO_STDOUT"].present?
-      config.logger = ActiveSupport::Logger.new($stdout)
-      config.logger.formatter = config.log_formatter
-    end
-
     # Lograge is used to format the standard HTTP request logging
     config.lograge.enabled = true
     config.lograge.formatter = Lograge::Formatters::Json.new

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,9 +46,8 @@ Rails.application.configure do
   config.ssl_options = { redirect: { exclude: ->(request) { request.path =~ /\/ping$/ } } }
 
   # Log to STDOUT by default
-  # config.logger = ActiveSupport::Logger.new(STDOUT)
-  #   .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
-  #   .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+  config.logger = ActiveSupport::Logger.new($stdout)
+    .tap { |logger| logger.formatter = config.log_formatter }
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :request_id ]


### PR DESCRIPTION
### What problem does this pull request solve?

Making logging consistent across our apps.

Otherwise every environment was getting debug output in the stdout. Also this is closer to how Rails is set up, which hopefully means we have less diversion to help with future upgrades.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
