### PR TITLE
Bump bundler from 2.4.10 to 2.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN mkdir /node_modules && chown ruby:ruby -R /node_modules /app
 USER ruby
 
 COPY --chown=ruby:ruby Gemfile* ./
-RUN gem install bundler -v 2.4.10
 
 RUN bundle config set --local without development:test \
     && bundle config set --local jobs "$(nproc)"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,4 +508,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.10
+   2.5.3


### PR DESCRIPTION
### What problem does this pull request solve?

Bumps [bundler](https://rubygems.org/gems/bundler) from 2.4.10 to 2.5.3.
- [Release notes](https://github.com/rubygems/rubygems/releases/tag/bundler-v2.5.3)
- [Changelog](https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md)
- [Commits](https://github.com/rubygems/rubygems/compare/bundler-v2.4.10...bundler-v2.5.3)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?