### PR TITLE
Change header hompage link to forms-admin homepage when in preview mode

### DIFF
--- a/app/components/form_header_component/view.rb
+++ b/app/components/form_header_component/view.rb
@@ -1,4 +1,6 @@
 module FormHeaderComponent
+  GOVUK_BASE_URL = "https://www.gov.uk/".freeze
+
   class View < ViewComponent::Base
     def initialize(current_context:, mode:, service_url_overide: :not_set, hosting_environment: HostingEnvironment)
       @current_context = current_context
@@ -10,14 +12,16 @@ module FormHeaderComponent
 
     def call
       if @current_context.present?
+        homepage_url = @mode.preview? ? Settings.forms_admin.base_url : GOVUK_BASE_URL
+
         govuk_header(service_name: @current_context.form.name,
-                     homepage_url: "https://www.gov.uk/",
+                     homepage_url:,
                      service_url:,
                      classes: ["app-header", "app-header--#{@mode}"]) do |header|
           header.with_product_name(name: service_name_with_tag)
         end
       else
-        govuk_header(homepage_url: "https://www.gov.uk/", classes: ["app-header", "app-header--#{@mode}"]) do |header|
+        govuk_header(homepage_url: GOVUK_BASE_URL, classes: ["app-header", "app-header--#{@mode}"]) do |header|
           header.with_product_name(name: service_name_with_tag)
         end
       end

--- a/spec/components/form_header_component/view_spec.rb
+++ b/spec/components/form_header_component/view_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe FormHeaderComponent::View, type: :component do
     expect(page).to have_text("test_form_name")
   end
 
+  it "links to the GOV.UK homepage" do
+    render_inline(described_class.new(current_context:, mode:, service_url_overide: "/form/1/test"))
+
+    expect(page.find("a.govuk-header__link--homepage")[:href]).to eq "https://www.gov.uk/"
+  end
+
   context "when mode is preview_draft" do
     let(:mode) { Mode.new("preview-draft") }
 
@@ -21,6 +27,14 @@ RSpec.describe FormHeaderComponent::View, type: :component do
       expect(page).to have_selector(".govuk-header__service-name")
       expect(page).to have_selector(".app-header--preview-draft")
       expect(page).to have_content("test_form_name")
+    end
+
+    it "links to the forms-admin homepage" do
+      allow(Settings.forms_admin).to receive(:base_url).and_return("http://forms-admin/")
+
+      render_inline(described_class.new(current_context:, mode:, service_url_overide: "/form/1/test"))
+
+      expect(page.find(".govuk-header__link--homepage")[:href]).to eq "http://forms-admin/"
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/LtOJrgEO/1173-make-govuk-home-page-link-go-to-my-forms-in-preview <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?