### PR TITLE
Refactor submission error exception handling

### DIFF
--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ErrorsController, type: :request do
         form_submission_service = original_method.call(**args)
 
         allow(form_submission_service).to receive(:submit_form_to_processing_team)
-          .and_raise("Oh no!").with(any_args)
+          .and_raise(FormSubmissionService::SubmissionError, "Oh no!").with(any_args)
 
         form_submission_service
       end

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -453,7 +453,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       end
 
       before do
-        allow(FormSubmissionService).to receive(:call).and_raise(StandardError)
+        allow(FormSubmissionService).to receive(:call).and_raise(FormSubmissionService::SubmissionError)
         allow(Sentry).to receive(:capture_exception)
 
         travel_to timestamp_of_request do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/SSMzBdHj/1338-improve-logging-of-notify-calls-in-forms-runner <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

While looking at how to improve the amount of information we log related to form submission emails, I noticed a few things that could be improved in our current codebase.

This PR refactors the `submit_answers` action to use a specific exception class `SubmissionError`, rather than the generic `StandardError`.

See the commit messages for more details.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?