### PR TITLE
Log Question_Number

### DIFF
--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -1,6 +1,11 @@
 module Forms
   class PageController < BaseController
-    before_action :prepare_step, :changing_existing_answer, :check_goto_page_before_routing_page
+    before_action :prepare_step, :set_logging_context, :changing_existing_answer, :check_goto_page_before_routing_page
+
+    def set_logging_context
+      super
+      @logging_context[:question_number] = @step.page_number if @step&.page_number
+    end
 
     def show
       redirect_to form_page_path(@step.form_id, @step.form_slug, current_context.next_page_slug) unless current_context.can_visit?(@step.page_slug)

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -57,12 +57,34 @@ RSpec.describe Forms::PageController, type: :request do
   end
 
   context "when setting logging context" do
+    let(:form_data) do
+      build(:form, :with_support,
+            id: 200,
+            live_at:,
+            start_page: 101,
+            declaration_text: "agree to the declaration",
+            pages: [
+              build(:page, :with_text_settings,
+                    id: 101,
+                    position: 1,
+                    is_optional: false),
+            ])
+    end
+
     before do
-      get form_page_path("form", 2, form_data.form_slug, 1)
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/200#{api_url_suffix}", req_headers, form_data.to_json, 200
+      end
+
+      get form_page_path("form", 200, form_data.form_slug, 101)
     end
 
     it "adds the page ID to the instrumentation payload" do
-      expect(logging_context).to include(page_id: "1")
+      expect(logging_context).to include(page_id: "101")
+    end
+
+    it "adds the question_number to the instrumentation payload" do
+      expect(logging_context).to include(question_number: 1)
     end
   end
 


### PR DESCRIPTION
The `question_number` field was omitted during the recent refactor to logging[[1]]. This adds it back in. Note that `question_number` is the sequential position of the question with reference to the form (e.g. the first or second question in the form) and the `page_id` is the unique identifier of the page in our records.


[1]: https://github.com/alphagov/forms-runner/pull/598

### What problem does this pull request solve?

Puts question_number back into the logs to help with analytics.

### Things to consider when reviewing
I have run this locally and seen that `question_number` appears as expected.

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
