### PR TITLE
Add exception logging to submit your answers action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,6 +42,33 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def log_rescued_exception(exception)
+    # add exception to payload with same format used by ActiveSupport::Notifications::Instrumenter
+    logging_context[:rescued_exception] = [exception.class.name, exception.message]
+
+    # log exception with the same format used by ActionDispatch::DebugExceptions
+    backtrace_cleaner = request.get_header("action_dispatch.backtrace_cleaner")
+    wrapper = ActionDispatch::ExceptionWrapper.new(backtrace_cleaner, exception)
+    trace = wrapper.exception_trace
+    message = []
+    message << "Rescued exception:"
+    message << "  "
+    message << "#{wrapper.exception_class_name} (#{wrapper.message}):"
+    if wrapper.has_cause?
+      message << "\nCauses:"
+      wrapper.wrapped_causes.each do |wrapped_cause|
+        message << "#{wrapped_cause.exception_class_name} (#{wrapped_cause.message})"
+      end
+    end
+    message.concat(wrapper.annotated_source_code)
+    message << "  "
+    message.concat(trace)
+    logger.warn message.join("\n")
+
+    # send exception to Sentry
+    Sentry.capture_exception(exception)
+  end
+
 private
 
   def add_robots_header

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,6 +65,9 @@ class ApplicationController < ActionController::Base
     message.concat(trace)
     logger.warn message.join("\n")
 
+    # add additional info to request log
+    logging_context[:rescued_exception_trace] = message
+
     # send exception to Sentry
     Sentry.capture_exception(exception)
   end

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -31,7 +31,8 @@ module Forms
         render template: "forms/check_your_answers/show", locals: { email_confirmation_form: }, status: :unprocessable_entity
       end
     rescue StandardError => e
-      Sentry.capture_exception(e)
+      log_rescued_exception(e)
+
       render "errors/submission_error", status: :internal_server_error
     end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -36,6 +36,25 @@ RSpec.describe ApplicationController do
 
       expect(controller.logging_context).to include(rescued_exception: ["RuntimeError", "oh no\nwhat happened"])
     end
+
+    it "adds exception trace to logging context" do
+      get :raise_error
+
+      expect(controller.logging_context).to include(:rescued_exception_trace)
+      expect(controller.logging_context[:rescued_exception_trace]).to include(
+        "spec/controllers/application_controller_spec.rb:11:in `raise_error'",
+      )
+    end
+
+    it "adds exception causes to logging context" do
+      get :raise_error_with_cause
+
+      expect(controller.logging_context).to include(:rescued_exception_trace)
+      expect(controller.logging_context[:rescued_exception_trace]).to include(
+        "\nCauses:",
+        "RuntimeError (inner error)",
+      )
+    end
   end
 
   describe "logging exception" do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe ApplicationController do
+  controller do
+    rescue_from RuntimeError do |e|
+      log_rescued_exception(e)
+      render "errors/internal_server_error", status: :internal_server_error
+    end
+
+    def raise_error
+      raise "oh no\nwhat happened"
+    end
+
+    def raise_error_with_cause
+      raise "inner error"
+    rescue RuntimeError
+      raise "outer error"
+    end
+  end
+
+  before do
+    routes.draw do
+      get "raise_error" => "anonymous#raise_error"
+      get "raise_error_with_cause" => "anonymous#raise_error_with_cause"
+    end
+  end
+
+  specify "anonymous controller" do
+    get :raise_error
+    expect(response).to have_http_status :internal_server_error
+  end
+
+  describe "adding exception to logging context" do
+    it "adds rescued exception to logging context" do
+      get :raise_error
+
+      expect(controller.logging_context).to include(rescued_exception: ["RuntimeError", "oh no\nwhat happened"])
+    end
+  end
+
+  describe "logging exception" do
+    let(:output) { StringIO.new }
+    let(:logger) do
+      Logger.new(output).tap do |logger|
+        logger.formatter = JsonLogFormatter.new
+      end
+    end
+
+    before do
+      Rails.logger.broadcast_to logger
+    end
+
+    after do
+      Rails.logger.stop_broadcasting_to logger
+    end
+
+    it "logs rescued exceptions as warnings" do
+      get :raise_error
+
+      expect(output.string.lines.first)
+        .to include('"level":"WARN"')
+        .and include('Rescued exception:\n  \nRuntimeError (oh no\nwhat happened)')
+    end
+
+    it "logs causes of rescued exceptions" do
+      get :raise_error_with_cause
+
+      expect(output.string.lines.first)
+        .to include('"level":"WARN"')
+        .and include('RuntimeError (outer error):\n\nCauses:\nRuntimeError (inner error)')
+    end
+  end
+
+  describe "sending exception to Sentry" do
+    before do
+      allow(Sentry).to receive(:capture_exception)
+    end
+
+    it "captures the exception" do
+      get :raise_error
+
+      expect(Sentry).to have_received(:capture_exception)
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/SSMzBdHj/1338-improve-logging-of-notify-calls-in-forms-runner <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to log exceptions that happen in the `submit_answers` action even if we rescue them.

Unfortunately I couldn't find an easy way to hook into the standard Rails exception logging mechanisms at the same time as using `rescue` or `rescue_from`; so this commit adds a new method to our application controller that has the same behaviour.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?