### PR TITLE
Add notification references to logging context for form submission

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -71,5 +71,16 @@ module Forms
 
       answers_need_full_width
     end
+
+    def set_logging_context
+      super
+      if params[:email_confirmation_form].present?
+        logging_context[:notification_references] =
+          email_confirmation_form_params.permit(
+            :confirmation_email_reference,
+            :notify_reference,
+          ).to_hash.symbolize_keys
+      end
+    end
   end
 end

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -75,11 +75,10 @@ module Forms
     def set_logging_context
       super
       if params[:email_confirmation_form].present?
-        logging_context[:notification_references] =
-          email_confirmation_form_params.permit(
-            :confirmation_email_reference,
-            :notify_reference,
-          ).to_hash.symbolize_keys
+        logging_context[:notification_references] = {}.tap do |h|
+          h[:confirmation_email_reference] = email_confirmation_form_params[:confirmation_email_reference] if email_confirmation_form_params[:send_confirmation] == "send_email"
+          h[:notify_reference] = email_confirmation_form_params[:notify_reference]
+        end
       end
     end
   end

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -87,26 +87,26 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     end
   end
 
-  shared_examples "for submission reference" do
-    prepend_before do
-      allow(EmailConfirmationForm).to receive(:new).and_wrap_original do |original_method, *args|
-        double = original_method.call(*args)
-        allow(double).to receive(:confirmation_email_reference).and_return("00000000-confirmation-email")
-        allow(double).to receive(:notify_reference).and_return("00000000-submission-email")
-        double
+  describe "#show" do
+    shared_examples "for submission references" do
+      prepend_before do
+        allow(EmailConfirmationForm).to receive(:new).and_wrap_original do |original_method, *args|
+          double = original_method.call(*args)
+          allow(double).to receive(:confirmation_email_reference).and_return("00000000-confirmation-email")
+          allow(double).to receive(:notify_reference).and_return("00000000-submission-email")
+          double
+        end
+      end
+
+      it "includes a notification reference for the submission email" do
+        expect(response.body).to include "00000000-submission-email"
+      end
+
+      it "includes a notification reference for the confirmation email" do
+        expect(response.body).to include "00000000-confirmation-email"
       end
     end
 
-    it "includes a notification reference for the submission email" do
-      expect(response.body).to include "00000000-submission-email"
-    end
-
-    it "includes a notification reference for the confirmation email" do
-      expect(response.body).to include "00000000-confirmation-email"
-    end
-  end
-
-  describe "#show" do
     context "with preview mode on" do
       let(:api_url_suffix) { "/draft" }
 
@@ -151,7 +151,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           expect(EventLogger).not_to have_received(:log)
         end
 
-        include_examples "for submission reference"
+        include_examples "for submission references"
       end
 
       context "and a form has a live_at value in the future" do
@@ -212,7 +212,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           expect(EventLogger).to have_received(:log_form_event).with(instance_of(Hash), "check_answers")
         end
 
-        include_examples "for submission reference"
+        include_examples "for submission references"
       end
 
       context "and a form has a live_at value in the future" do
@@ -229,6 +229,15 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
   end
 
   describe "#submit_answers" do
+    shared_examples "for submission references" do
+      it "includes the notification references in the logging_context" do
+        expect(logging_context).to include(notification_references: {
+          confirmation_email_reference: email_confirmation_form[:confirmation_email_reference],
+          notify_reference: email_confirmation_form[:notify_reference],
+        }.compact)
+      end
+    end
+
     context "with preview mode on" do
       before do
         travel_to frozen_time do
@@ -260,6 +269,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
         expect(mail.govuk_notify_reference).to eq "for-my-ref"
       end
+
+      include_examples "for submission references"
     end
 
     context "with preview mode off" do
@@ -291,6 +302,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
         expect(mail.body.raw_source).to match(expected_personalisation.to_s)
       end
+
+      include_examples "for submission references"
     end
 
     context "when answers have already been submitted" do
@@ -358,6 +371,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(response.body).to include "test-ref-for-confirmation-email"
         expect(response.body).to include "test-ref-for-submission-email"
       end
+
+      include_examples "for submission references"
     end
 
     context "when user has not requested a confirmation email" do
@@ -370,6 +385,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       it "redirects to confirmation page" do
         expect(response).to redirect_to(form_submitted_path)
       end
+
+      include_examples "for submission references"
     end
 
     context "when user has requested a confirmation email" do
@@ -410,6 +427,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
         expect(mail.govuk_notify_reference).to eq "confirmation-email-ref"
       end
+
+      include_examples "for submission references"
     end
 
     context "when there is a submission error" do
@@ -440,6 +459,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       it "returns 500" do
         expect(response).to have_http_status(:internal_server_error)
       end
+
+      include_examples "for submission references"
     end
   end
 

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -376,7 +376,14 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     end
 
     context "when user has not requested a confirmation email" do
-      let(:email_confirmation_form) { { send_confirmation: "skip_confirmation", confirmation_email_address: nil, notify_reference: "for-my-ref" } }
+      let(:email_confirmation_form) do
+        {
+          send_confirmation: "skip_confirmation",
+          confirmation_email_address: nil,
+          confirmation_email_reference: "confirmation-email-ref",
+          notify_reference: "for-my-ref",
+        }
+      end
 
       before do
         post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_form: }
@@ -386,7 +393,13 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(response).to redirect_to(form_submitted_path)
       end
 
-      include_examples "for submission references"
+      it "does include submission email reference in logging context" do
+        expect(logging_context[:notification_references]).to include(notify_reference: "for-my-ref")
+      end
+
+      it "does not include confirmation email reference in logging context" do
+        expect(logging_context[:notification_references]).not_to include(:confirmation_email_reference)
+      end
     end
 
     context "when user has requested a confirmation email" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/SSMzBdHj/1338-improve-logging-of-notify-calls-in-forms-runner <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to be able to correlate logs in GOV.UK Notify with logs in our system; to do this we can use the notification references.

This commit adds the notification references for submission emails and confirmation emails to the log messages for the `submit_answers` action.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?