### PR TITLE
Rename submission email reference attribute

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -56,7 +56,7 @@ module Forms
     end
 
     def email_confirmation_form_params
-      params.require(:email_confirmation_form).permit(:send_confirmation, :confirmation_email_address, :confirmation_email_reference, :notify_reference)
+      params.require(:email_confirmation_form).permit(:send_confirmation, :confirmation_email_address, :confirmation_email_reference, :submission_email_reference)
     end
 
     def setup_check_your_answers
@@ -77,7 +77,7 @@ module Forms
       if params[:email_confirmation_form].present?
         logging_context[:notification_references] = {}.tap do |h|
           h[:confirmation_email_reference] = email_confirmation_form_params[:confirmation_email_reference] if email_confirmation_form_params[:send_confirmation] == "send_email"
-          h[:notify_reference] = email_confirmation_form_params[:notify_reference]
+          h[:submission_email_reference] = email_confirmation_form_params[:submission_email_reference]
         end
       end
     end

--- a/app/form_objects/email_confirmation_form.rb
+++ b/app/form_objects/email_confirmation_form.rb
@@ -2,7 +2,7 @@ class EmailConfirmationForm
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  attr_accessor :send_confirmation, :confirmation_email_address, :confirmation_email_reference, :notify_reference
+  attr_accessor :send_confirmation, :confirmation_email_address, :confirmation_email_reference, :submission_email_reference
 
   validates :send_confirmation, presence: true
   validates :send_confirmation, inclusion: { in: %w[send_email skip_confirmation] }
@@ -11,7 +11,7 @@ class EmailConfirmationForm
 
   def initialize(...)
     super(...)
-    generate_submission_references! unless @confirmation_email_reference || @notify_reference
+    generate_submission_references! unless @confirmation_email_reference || @submission_email_reference
   end
 
   def validate_email?
@@ -24,7 +24,7 @@ private
     reference = SecureRandom.uuid
     self.attributes = {
       confirmation_email_reference: "#{reference}-confirmation-email",
-      notify_reference: "#{reference}-submission-email",
+      submission_email_reference: "#{reference}-submission-email",
     }
   end
 end

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -33,7 +33,7 @@ class FormSubmissionService
       .email_completed_form(title: form_title,
                             text_input: email_body,
                             preview_mode: @preview_mode,
-                            reference: @email_confirmation_form.notify_reference,
+                            reference: @email_confirmation_form.submission_email_reference,
                             timestamp: @timestamp,
                             submission_email: @form.submission_email).deliver_now
     end

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -38,7 +38,7 @@
         <%= HtmlMarkdownSanitizer.new.render_scrubbed_html(@current_context.form.declaration_text) %>
       <% end %>
 
-      <%= form.hidden_field :notify_reference, id: 'notification-id' %>
+      <%= form.hidden_field :submission_email_reference, id: 'submission-email-reference' %>
 
       <%= form.govuk_submit(@current_context.form.declaration_text.present? ? t('form.check_your_answers.agree_and_submit') : t('form.check_your_answers.submit')) %>
     <% end %>

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -38,6 +38,7 @@
         <%= HtmlMarkdownSanitizer.new.render_scrubbed_html(@current_context.form.declaration_text) %>
       <% end %>
 
+      <%= form.hidden_field :submission_email_reference, id: 'notification-id' %>
       <%= form.hidden_field :submission_email_reference, id: 'submission-email-reference' %>
 
       <%= form.govuk_submit(@current_context.form.declaration_text.present? ? t('form.check_your_answers.agree_and_submit') : t('form.check_your_answers.submit')) %>

--- a/spec/factories/form_objects/email_confirmation_form.rb
+++ b/spec/factories/form_objects/email_confirmation_form.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :email_confirmation_form, class: "EmailConfirmationForm" do
     send_confirmation { nil }
     confirmation_email_address { nil }
-    notify_reference { "ffffffff-submission-email" }
+    submission_email_reference { "ffffffff-submission-email" }
     confirmation_email_reference { "ffffffff-confirmation-email" }
 
     factory :email_confirmation_form_opted_in do

--- a/spec/form_objects/email_confirmation_form_spec.rb
+++ b/spec/form_objects/email_confirmation_form_spec.rb
@@ -51,11 +51,11 @@ RSpec.describe EmailConfirmationForm, type: :model do
       described_class.new
     end
 
-    let(:notify_reference) { email_confirmation_form.notify_reference }
+    let(:submission_email_reference) { email_confirmation_form.submission_email_reference }
     let(:confirmation_email_reference) { email_confirmation_form.confirmation_email_reference }
 
     it "generates a random submission notification reference" do
-      expect(notify_reference)
+      expect(submission_email_reference)
         .to match(uuid).and end_with("-submission-email")
     end
 
@@ -65,26 +65,26 @@ RSpec.describe EmailConfirmationForm, type: :model do
     end
 
     it "generates a different string for all notification references" do
-      expect(notify_reference).not_to eq confirmation_email_reference
+      expect(submission_email_reference).not_to eq confirmation_email_reference
     end
 
     it "includes a common identifier in all notification references" do
       uuid_in = ->(str) { uuid.match(str).to_s }
 
-      expect(uuid_in[notify_reference]).to eq uuid_in[confirmation_email_reference]
+      expect(uuid_in[submission_email_reference]).to eq uuid_in[confirmation_email_reference]
     end
 
     context "when intialised with references" do
       let(:email_confirmation_form) do
         described_class.new(
           confirmation_email_reference: "foo",
-          notify_reference: "bar",
+          submission_email_reference: "bar",
         )
       end
 
       it "does not generate new references" do
         expect(confirmation_email_reference).to eq "foo"
-        expect(notify_reference).to eq "bar"
+        expect(submission_email_reference).to eq "bar"
       end
     end
   end

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     { send_confirmation: "send_email",
       confirmation_email_address: Faker::Internet.email,
       confirmation_email_reference: "confirmation-email-ref",
-      notify_reference: "for-my-ref" }
+      submission_email_reference: "for-my-ref" }
   end
 
   let(:store) do
@@ -88,12 +88,12 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
   end
 
   describe "#show" do
-    shared_examples "for submission references" do
+    shared_examples "for notification references" do
       prepend_before do
         allow(EmailConfirmationForm).to receive(:new).and_wrap_original do |original_method, *args|
           double = original_method.call(*args)
           allow(double).to receive(:confirmation_email_reference).and_return("00000000-confirmation-email")
-          allow(double).to receive(:notify_reference).and_return("00000000-submission-email")
+          allow(double).to receive(:submission_email_reference).and_return("00000000-submission-email")
           double
         end
       end
@@ -151,7 +151,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           expect(EventLogger).not_to have_received(:log)
         end
 
-        include_examples "for submission references"
+        include_examples "for notification references"
       end
 
       context "and a form has a live_at value in the future" do
@@ -212,7 +212,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           expect(EventLogger).to have_received(:log_form_event).with(instance_of(Hash), "check_answers")
         end
 
-        include_examples "for submission references"
+        include_examples "for notification references"
       end
 
       context "and a form has a live_at value in the future" do
@@ -229,11 +229,11 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
   end
 
   describe "#submit_answers" do
-    shared_examples "for submission references" do
+    shared_examples "for notification references" do
       it "includes the notification references in the logging_context" do
         expect(logging_context).to include(notification_references: {
           confirmation_email_reference: email_confirmation_form[:confirmation_email_reference],
-          notify_reference: email_confirmation_form[:notify_reference],
+          submission_email_reference: email_confirmation_form[:submission_email_reference],
         }.compact)
       end
     end
@@ -270,7 +270,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(mail.govuk_notify_reference).to eq "for-my-ref"
       end
 
-      include_examples "for submission references"
+      include_examples "for notification references"
     end
 
     context "with preview mode off" do
@@ -303,7 +303,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(mail.body.raw_source).to match(expected_personalisation.to_s)
       end
 
-      include_examples "for submission references"
+      include_examples "for notification references"
     end
 
     context "when answers have already been submitted" do
@@ -323,7 +323,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         {
           send_confirmation: nil,
           confirmation_email_reference: "test-ref-for-confirmation-email",
-          notify_reference: "test-ref-for-submission-email",
+          submission_email_reference: "test-ref-for-submission-email",
         }
       end
 
@@ -351,7 +351,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           send_confirmation: "send_email",
           confirmation_email_address: nil,
           confirmation_email_reference: "test-ref-for-confirmation-email",
-          notify_reference: "test-ref-for-submission-email",
+          submission_email_reference: "test-ref-for-submission-email",
         }
       end
 
@@ -372,7 +372,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(response.body).to include "test-ref-for-submission-email"
       end
 
-      include_examples "for submission references"
+      include_examples "for notification references"
     end
 
     context "when user has not requested a confirmation email" do
@@ -381,7 +381,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           send_confirmation: "skip_confirmation",
           confirmation_email_address: nil,
           confirmation_email_reference: "confirmation-email-ref",
-          notify_reference: "for-my-ref",
+          submission_email_reference: "for-my-ref",
         }
       end
 
@@ -394,7 +394,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       end
 
       it "does include submission email reference in logging context" do
-        expect(logging_context[:notification_references]).to include(notify_reference: "for-my-ref")
+        expect(logging_context[:notification_references]).to include(submission_email_reference: "for-my-ref")
       end
 
       it "does not include confirmation email reference in logging context" do
@@ -407,7 +407,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         { send_confirmation: "send_email",
           confirmation_email_address: Faker::Internet.email,
           confirmation_email_reference: "confirmation-email-ref",
-          notify_reference: "for-my-ref" }
+          submission_email_reference: "for-my-ref" }
       end
 
       before do
@@ -441,7 +441,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(mail.govuk_notify_reference).to eq "confirmation-email-ref"
       end
 
-      include_examples "for submission references"
+      include_examples "for notification references"
     end
 
     context "when there is a submission error" do
@@ -449,7 +449,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         { send_confirmation: "send_email",
           confirmation_email_address: Faker::Internet.email,
           confirmation_email_reference: "confirmation-email-ref",
-          notify_reference: "for-my-ref" }
+          submission_email_reference: "for-my-ref" }
       end
 
       before do
@@ -473,7 +473,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(response).to have_http_status(:internal_server_error)
       end
 
-      include_examples "for submission references"
+      include_examples "for notification references"
     end
   end
 

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe FormSubmissionService do
         expect(FormSubmissionMailer).to have_received(:email_completed_form).with(
           { title: "Form 1",
             text_input: "# What is the meaning of life?\n42\n",
-            reference: email_confirmation_form.notify_reference,
+            reference: email_confirmation_form.submission_email_reference,
             timestamp: Time.zone.now,
             submission_email: "testing@gov.uk",
             preview_mode: false },
@@ -101,7 +101,7 @@ RSpec.describe FormSubmissionService do
           expect(FormSubmissionMailer).to have_received(:email_completed_form).with(
             { title: "Form 1",
               text_input: "# What is the meaning of life?\n42\n",
-              reference: email_confirmation_form.notify_reference,
+              reference: email_confirmation_form.submission_email_reference,
               timestamp: Time.zone.now,
               submission_email: "testing@gov.uk",
               preview_mode: true },

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -48,7 +48,7 @@ describe "forms/check_your_answers/show.html.erb" do
   end
 
   it "contains a hidden notify reference for the submission email" do
-    expect(rendered).to have_field("notification-id", type: :hidden, with: email_confirmation_form.notify_reference)
+    expect(rendered).to have_field("submission-email-reference", type: :hidden, with: email_confirmation_form.submission_email_reference)
   end
 
   it "displays the email radio buttons" do

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -48,6 +48,7 @@ describe "forms/check_your_answers/show.html.erb" do
   end
 
   it "contains a hidden notify reference for the submission email" do
+    expect(rendered).to have_field("notification-id", type: :hidden, with: email_confirmation_form.submission_email_reference)
     expect(rendered).to have_field("submission-email-reference", type: :hidden, with: email_confirmation_form.submission_email_reference)
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/SSMzBdHj/1338-improve-logging-of-notify-calls-in-forms-runner <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Rename `notify_reference` to `submission_email_reference`.

This better describes the attribute, and disambiguates it from the confirmation email reference.

Because this change affects the end to end tests, we use the 'expand and contract' pattern to keep the old name around where necessary. There is also an associated change in alphagov/forms-e2e-tests#41 to rename the reference ID. That PR can be merged after this PR has been deployed.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?