### PR TITLE
Add attributes to the confirmation_email input

### DIFF
--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -26,7 +26,7 @@
 
       <%= form.govuk_radio_buttons_fieldset(:send_confirmation, legend: { size: 'm', tag: 'h2' }) do %>
         <%= form.govuk_radio_button :send_confirmation, 'send_email' do %>
-          <%= form.govuk_text_field :confirmation_email_address %>
+          <%= form.govuk_text_field :confirmation_email_address, type: 'email', autocomplete: 'email', spellcheck: false  %>
         <% end %>
         <%= form.govuk_radio_button :send_confirmation, 'skip_confirmation' %>
       <% end %>

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -26,7 +26,7 @@
 
       <%= form.govuk_radio_buttons_fieldset(:send_confirmation, legend: { size: 'm', tag: 'h2' }) do %>
         <%= form.govuk_radio_button :send_confirmation, 'send_email' do %>
-          <%= form.govuk_text_field :confirmation_email_address, type: 'email', autocomplete: 'email', spellcheck: false  %>
+          <%= form.govuk_email_field :confirmation_email_address, autocomplete: 'email', spellcheck: false  %>
         <% end %>
         <%= form.govuk_radio_button :send_confirmation, 'skip_confirmation' %>
       <% end %>

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -59,7 +59,14 @@ describe "forms/check_your_answers/show.html.erb" do
   end
 
   it "displays the email field" do
-    expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_form.confirmation_email_address"))
+    expect(rendered).to have_field(
+      I18n.t("helpers.label.email_confirmation_form.confirmation_email_address"),
+      type: "email",
+    )
+  end
+
+  it "email field has correct atttributes set" do
+    expect(rendered).to have_selector("input[name='email_confirmation_form[confirmation_email_address]'][autocomplete='email'][spellcheck='false']")
   end
 
   it "contains a hidden notify reference for the confirmation email" do


### PR DESCRIPTION
# From the [trello ticket](https://trello.com/c/XpmRK8zg/1382-email-confirmation-form-field-is-a-plain-text-field):

## WCAG context

This fails WCAG 1.3.5 Identify Input Purpose, because this field should have an autocomplete=”email” attribute. The other aspects - type=”email” and spellcheck=”false” - aren’t WCAG failures, but they’ll help users enter their email addresses more easily, and it makes sense to implement them at the same time.

The field should have the following attributes:

- `type=”email”`
- `autocomplete=”email”`
- `spellcheck=”false”`

This commit adds a test to check the attributes are present and changes the code to include them.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
