### PR TITLE
Clean-up after #634

### DIFF
--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -38,7 +38,6 @@
         <%= HtmlMarkdownSanitizer.new.render_scrubbed_html(@current_context.form.declaration_text) %>
       <% end %>
 
-      <%= form.hidden_field :submission_email_reference, id: 'notification-id' %>
       <%= form.hidden_field :submission_email_reference, id: 'submission-email-reference' %>
 
       <%= form.govuk_submit(@current_context.form.declaration_text.present? ? t('form.check_your_answers.agree_and_submit') : t('form.check_your_answers.submit')) %>

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -48,7 +48,6 @@ describe "forms/check_your_answers/show.html.erb" do
   end
 
   it "contains a hidden notify reference for the submission email" do
-    expect(rendered).to have_field("notification-id", type: :hidden, with: email_confirmation_form.submission_email_reference)
     expect(rendered).to have_field("submission-email-reference", type: :hidden, with: email_confirmation_form.submission_email_reference)
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/SSMzBdHj/1338-improve-logging-of-notify-calls-in-forms-runner <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This reverts commit 9cc142311769e0feb9fe0a03031f0d7aa3ec67ef.

Now that [alphagov/forms-e2e-test#41](https://github.com/alphagov/forms-e2e-tests/pull/41) has been merged we don't need to have `#notification-id` in our app.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?