### PR TITLE
Update Gemfile to use file reference for Ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN mkdir /node_modules && chown ruby:ruby -R /node_modules /app
 
 USER ruby
 
+COPY --chown=ruby:ruby .ruby-version ./
 COPY --chown=ruby:ruby Gemfile* ./
 
 ARG BUNDLE_WITHOUT=development:test

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.2"
+ruby file: ".ruby-version"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.3"


### PR DESCRIPTION
### What problem does this pull request solve?

This means we only have 1 file to update (and means I can update this [script](https://github.com/alphagov/forms-deploy/blob/main/support/update_app_versions.sh#L70) to not bother with updating the Gemfile)

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?