### PR TITLE
Add reference number to confirmation screen

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,6 @@ class ApplicationController < ActionController::Base
   before_action :check_maintenance_mode_is_enabled
   after_action :add_robots_header
 
-  add_flash_types :email_sent
-
   def accessibility_statement; end
 
   def cookies; end

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -17,11 +17,13 @@ module Forms
         if current_context.form_submitted?
           redirect_to error_repeat_submission_path(current_form.id)
         else
-          FormSubmissionService.call(logging_context:,
-                                     current_context:,
-                                     request:,
-                                     email_confirmation_form:,
-                                     preview_mode: mode.preview?).submit
+          submission_reference = FormSubmissionService.call(logging_context:,
+                                                            current_context:,
+                                                            request:,
+                                                            email_confirmation_form:,
+                                                            preview_mode: mode.preview?).submit
+
+          current_context.save_submission_reference(submission_reference)
 
           redirect_to :form_submitted, email_sent: requested_email_confirmation
         end

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -23,9 +23,9 @@ module Forms
                                                             email_confirmation_form:,
                                                             preview_mode: mode.preview?).submit
 
-          current_context.save_submission_reference(submission_reference)
+          current_context.save_submission_details(submission_reference, requested_email_confirmation)
 
-          redirect_to :form_submitted, email_sent: requested_email_confirmation
+          redirect_to :form_submitted
         end
       else
         setup_check_your_answers

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -18,9 +18,12 @@ module Forms
       @step.update!(page_params)
 
       if current_context.save_step(@step)
+        current_context.clear_submission_details if is_first_page?
+
         unless mode.preview?
           LogEventService.new(current_context, @step, request, changing_existing_answer, page_params).log_page_save(logging_context)
         end
+
         redirect_to next_page
       else
         setup_instance_vars_for_view
@@ -78,6 +81,10 @@ module Forms
 
       EventLogger.log_page_event(logging_context, @step.question.question_text, "goto_page_before_routing_page_error", nil)
       render template: "errors/goto_page_before_routing_page", locals: { link_url: "#{Settings.forms_admin.base_url}/forms/#{@step.form_id}/pages/#{@step.page_slug}/conditions/#{@step.routing_conditions.first.id}", question_number: @step.page_number }, status: :unprocessable_entity
+    end
+
+    def is_first_page?
+      current_context.form.start_page == @step.id
     end
   end
 end

--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -69,4 +69,8 @@ class Context
   def requested_email_confirmation?
     @form_context.requested_email_confirmation?(form.id)
   end
+
+  def clear_submission_details
+    @form_context.clear_submission_details(form.id)
+  end
 end

--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -57,4 +57,12 @@ class Context
   def form_submitted?
     @form_context.form_submitted?(form.id)
   end
+
+  def save_submission_reference(reference)
+    @form_context.save_submission_reference(form.id, reference)
+  end
+
+  def get_submission_reference
+    @form_context.get_submission_reference(form.id)
+  end
 end

--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -58,11 +58,15 @@ class Context
     @form_context.form_submitted?(form.id)
   end
 
-  def save_submission_reference(reference)
-    @form_context.save_submission_reference(form.id, reference)
+  def save_submission_details(reference, email_sent)
+    @form_context.save_submission_details(form.id, reference, email_sent)
   end
 
   def get_submission_reference
     @form_context.get_submission_reference(form.id)
+  end
+
+  def email_sent?
+    @form_context.email_sent?(form.id)
   end
 end

--- a/app/lib/context.rb
+++ b/app/lib/context.rb
@@ -58,15 +58,15 @@ class Context
     @form_context.form_submitted?(form.id)
   end
 
-  def save_submission_details(reference, email_sent)
-    @form_context.save_submission_details(form.id, reference, email_sent)
+  def save_submission_details(reference, requested_email_confirmation)
+    @form_context.save_submission_details(form.id, reference, requested_email_confirmation)
   end
 
   def get_submission_reference
     @form_context.get_submission_reference(form.id)
   end
 
-  def email_sent?
-    @form_context.email_sent?(form.id)
+  def requested_email_confirmation?
+    @form_context.requested_email_confirmation?(form.id)
   end
 end

--- a/app/lib/form_context.rb
+++ b/app/lib/form_context.rb
@@ -45,6 +45,10 @@ class FormContext
     @store.dig(CONFIRMATION_KEY, form_id.to_s, REQUESTED_EMAIL_KEY.to_s)
   end
 
+  def clear_submission_details(form_id)
+    @store[CONFIRMATION_KEY][form_id.to_s] = nil
+  end
+
 private
 
   def page_key(step)

--- a/app/lib/form_context.rb
+++ b/app/lib/form_context.rb
@@ -1,29 +1,42 @@
 class FormContext
-  ROOT_KEY = :answers
+  ANSWERS_KEY = :answers
+  CONFIRMATION_KEY = :confirmation_details
+  SUBMISSION_REFERENCE_KEY = :submission_reference
+
   def initialize(store)
     @store = store
-    @store[ROOT_KEY] ||= {}
+    @store[ANSWERS_KEY] ||= {}
+    @store[CONFIRMATION_KEY] ||= {}
   end
 
   def save_step(step, answer)
-    @store[ROOT_KEY][form_key(step)] ||= {}
-    @store[ROOT_KEY][form_key(step)][page_key(step)] = answer
+    @store[ANSWERS_KEY][form_key(step)] ||= {}
+    @store[ANSWERS_KEY][form_key(step)][page_key(step)] = answer
   end
 
   def get_stored_answer(step)
-    @store.dig(ROOT_KEY, form_key(step), page_key(step))
+    @store.dig(ANSWERS_KEY, form_key(step), page_key(step))
   end
 
   def clear_stored_answer(step)
-    @store.dig(ROOT_KEY, form_key(step))&.delete(page_key(step))
+    @store.dig(ANSWERS_KEY, form_key(step))&.delete(page_key(step))
   end
 
   def clear(form_id)
-    @store[ROOT_KEY][form_id.to_s] = nil
+    @store[ANSWERS_KEY][form_id.to_s] = nil
   end
 
   def form_submitted?(form_id)
-    @store[ROOT_KEY][form_id.to_s].nil?
+    @store[ANSWERS_KEY][form_id.to_s].nil?
+  end
+
+  def save_submission_reference(form_id, reference)
+    @store[CONFIRMATION_KEY][form_id.to_s] ||= {}
+    @store[CONFIRMATION_KEY][form_id.to_s][SUBMISSION_REFERENCE_KEY.to_s] = reference
+  end
+
+  def get_submission_reference(form_id)
+    @store.dig(CONFIRMATION_KEY, form_id.to_s, SUBMISSION_REFERENCE_KEY.to_s)
   end
 
 private

--- a/app/lib/form_context.rb
+++ b/app/lib/form_context.rb
@@ -2,7 +2,7 @@ class FormContext
   ANSWERS_KEY = :answers
   CONFIRMATION_KEY = :confirmation_details
   SUBMISSION_REFERENCE_KEY = :submission_reference
-  EMAIL_SENT_KEY = :email_sent
+  REQUESTED_EMAIL_KEY = :requested_email_confirmation
 
   def initialize(store)
     @store = store
@@ -31,18 +31,18 @@ class FormContext
     @store[ANSWERS_KEY][form_id.to_s].nil?
   end
 
-  def save_submission_details(form_id, reference, email_sent)
+  def save_submission_details(form_id, reference, requested_email_confirmation)
     @store[CONFIRMATION_KEY][form_id.to_s] ||= {}
     @store[CONFIRMATION_KEY][form_id.to_s][SUBMISSION_REFERENCE_KEY.to_s] = reference
-    @store[CONFIRMATION_KEY][form_id.to_s][EMAIL_SENT_KEY.to_s] = email_sent
+    @store[CONFIRMATION_KEY][form_id.to_s][REQUESTED_EMAIL_KEY.to_s] = requested_email_confirmation
   end
 
   def get_submission_reference(form_id)
     @store.dig(CONFIRMATION_KEY, form_id.to_s, SUBMISSION_REFERENCE_KEY.to_s)
   end
 
-  def email_sent?(form_id)
-    @store.dig(CONFIRMATION_KEY, form_id.to_s, EMAIL_SENT_KEY.to_s)
+  def requested_email_confirmation?(form_id)
+    @store.dig(CONFIRMATION_KEY, form_id.to_s, REQUESTED_EMAIL_KEY.to_s)
   end
 
 private

--- a/app/lib/form_context.rb
+++ b/app/lib/form_context.rb
@@ -2,6 +2,7 @@ class FormContext
   ANSWERS_KEY = :answers
   CONFIRMATION_KEY = :confirmation_details
   SUBMISSION_REFERENCE_KEY = :submission_reference
+  EMAIL_SENT_KEY = :email_sent
 
   def initialize(store)
     @store = store
@@ -30,13 +31,18 @@ class FormContext
     @store[ANSWERS_KEY][form_id.to_s].nil?
   end
 
-  def save_submission_reference(form_id, reference)
+  def save_submission_details(form_id, reference, email_sent)
     @store[CONFIRMATION_KEY][form_id.to_s] ||= {}
     @store[CONFIRMATION_KEY][form_id.to_s][SUBMISSION_REFERENCE_KEY.to_s] = reference
+    @store[CONFIRMATION_KEY][form_id.to_s][EMAIL_SENT_KEY.to_s] = email_sent
   end
 
   def get_submission_reference(form_id)
     @store.dig(CONFIRMATION_KEY, form_id.to_s, SUBMISSION_REFERENCE_KEY.to_s)
+  end
+
+  def email_sent?(form_id)
+    @store.dig(CONFIRMATION_KEY, form_id.to_s, EMAIL_SENT_KEY.to_s)
   end
 
 private

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -15,7 +15,10 @@ class FormSubmissionService
     @preview_mode = preview_mode
     @timestamp = submission_timestamp
     @submission_reference = generate_submission_reference
-    @logging_context[:submission_reference] = @submission_reference
+
+    if FeatureService.enabled?(:reference_numbers_enabled)
+      @logging_context[:submission_reference] = @submission_reference
+    end
   end
 
   def submit

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -15,6 +15,7 @@ class FormSubmissionService
     @preview_mode = preview_mode
     @timestamp = submission_timestamp
     @submission_reference = generate_submission_reference
+    @logging_context[:submission_reference] = @submission_reference
   end
 
   def submit

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -14,11 +14,13 @@ class FormSubmissionService
     @requested_email_confirmation = @email_confirmation_form.send_confirmation == "send_email"
     @preview_mode = preview_mode
     @timestamp = submission_timestamp
+    @submission_reference = generate_submission_reference
   end
 
   def submit
     submit_form_to_processing_team
     submit_confirmation_email_to_user
+    @submission_reference
   end
 
   def submit_form_to_processing_team
@@ -160,5 +162,9 @@ private
     return nil if [@form.support_url, @form.support_url_text].all?(&:blank?)
 
     "[#{@form.support_url_text}](#{@form.support_url})"
+  end
+
+  def generate_submission_reference
+    SecureRandom.base58(8).upcase
   end
 end

--- a/app/views/forms/submitted/submitted.html.erb
+++ b/app/views/forms/submitted/submitted.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel(title_text: t('form.submitted.title'), classes: ["govuk-!-margin-bottom-7"], ) do %>
-      <% if @current_context.get_submission_reference.present? %>
+      <% if FeatureService.enabled?(:reference_numbers_enabled) && @current_context.get_submission_reference.present? %>
         <%= t('form.submitted.your_reference') %><br>
         <strong><%= @current_context.get_submission_reference %></strong>
       <% end %>

--- a/app/views/forms/submitted/submitted.html.erb
+++ b/app/views/forms/submitted/submitted.html.erb
@@ -9,7 +9,7 @@
       <% end %>
     <% end %>
 
-    <% if email_sent %>
+    <% if @current_context.email_sent? %>
       <p><%= t('form.submitted.email_sent') %></p>
     <% end %>
 

--- a/app/views/forms/submitted/submitted.html.erb
+++ b/app/views/forms/submitted/submitted.html.erb
@@ -9,7 +9,7 @@
       <% end %>
     <% end %>
 
-    <% if @current_context.email_sent? %>
+    <% if @current_context.requested_email_confirmation? %>
       <p><%= t('form.submitted.email_sent') %></p>
     <% end %>
 

--- a/app/views/forms/submitted/submitted.html.erb
+++ b/app/views/forms/submitted/submitted.html.erb
@@ -2,14 +2,19 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_panel(title_text: t('form.submitted.title'), classes: ["govuk-!-margin-bottom-7"]) %>
+    <%= govuk_panel(title_text: t('form.submitted.title'), classes: ["govuk-!-margin-bottom-7"], ) do %>
+      <% if @current_context.get_submission_reference.present? %>
+        <%= t('form.submitted.your_reference') %><br>
+        <strong><%= @current_context.get_submission_reference %></strong>
+      <% end %>
+    <% end %>
 
     <% if email_sent %>
       <p><%= t('form.submitted.email_sent') %></p>
     <% end %>
 
     <%if @current_context.form.what_happens_next_markdown.present? %>
-      <h2 class="govuk-heading-m">What happens next</h2>
+      <h2 class="govuk-heading-m"><%= t('form.submitted.what_happens_next') %></h2>
       <%= HtmlMarkdownSanitizer.new.render_scrubbed_markdown(@current_context.form.what_happens_next_markdown) %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,8 @@ en:
     submitted:
       email_sent: We have sent you a confirmation email.
       title: Your form has been submitted
+      what_happens_next: What happens next
+      your_reference: Your reference number
   helpers:
     hint:
       email_confirmation_form:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,5 @@
-features: {}
+features:
+  reference_numbers_enabled: false
 
 forms_admin:
   # URL to form-admin

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -19,11 +19,9 @@ describe "Settings" do
   end
 
   describe ".features" do
-    it "has a default value" do
-      features = settings[:features]
+    features = settings[:features]
 
-      expect(features).to eq({})
-    end
+    include_examples expected_value_test, :reference_numbers_enabled, features, false
   end
 
   describe ".forms_api" do

--- a/spec/features/fill_in_and_submit_form_spec.rb
+++ b/spec/features/fill_in_and_submit_form_spec.rb
@@ -41,7 +41,7 @@ feature "Fill in and submit a form", type: :feature do
     when_i_opt_out_of_email_confirmation
     and_i_submit_my_form
     then_my_form_should_be_submitted
-    and_i_should_receive_a_reference_number
+    and_i_should_receive_a_reference_number if FeatureService.enabled?(:reference_numbers_enabled)
   end
 
   def when_i_visit_the_form_start_page

--- a/spec/features/fill_in_and_submit_form_spec.rb
+++ b/spec/features/fill_in_and_submit_form_spec.rb
@@ -5,6 +5,7 @@ feature "Fill in and submit a form", type: :feature do
   let(:form) { build :form, :live, id: 1, name: "Fill in this form", pages:, start_page: 1 }
   let(:question_text) { pages[0].question_text }
   let(:answer_text) { "Answer text" }
+  let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 
   let(:req_headers) do
     {
@@ -25,6 +26,8 @@ feature "Fill in and submit a form", type: :feature do
       mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
       mock.get "/api/v1/forms/1/live", req_headers, form.to_json(include: [:pages]), 200
     end
+
+    allow(SecureRandom).to receive(:base58).with(8).and_return(reference)
   end
 
   scenario "As a form filler" do
@@ -38,6 +41,7 @@ feature "Fill in and submit a form", type: :feature do
     when_i_opt_out_of_email_confirmation
     and_i_submit_my_form
     then_my_form_should_be_submitted
+    and_i_should_receive_a_reference_number
   end
 
   def when_i_visit_the_form_start_page
@@ -75,5 +79,9 @@ feature "Fill in and submit a form", type: :feature do
   def then_my_form_should_be_submitted
     expect(page.find("h1")).to have_text "Your form has been submitted"
     expect_page_to_have_no_axe_errors(page)
+  end
+
+  def and_i_should_receive_a_reference_number
+    expect(page).to have_text reference
   end
 end

--- a/spec/lib/context_spec.rb
+++ b/spec/lib/context_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Context do
     end
   end
 
-  describe "submission references" do
+  describe "submission details" do
     let(:context) { described_class.new(form:, store: {}) }
     let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
     let(:requested_email_confirmation) { true }
@@ -112,6 +112,14 @@ RSpec.describe Context do
 
       it "the requested_email_confirmation value can be retrieved" do
         expect(context.requested_email_confirmation?).to eq(requested_email_confirmation)
+      end
+
+      it "can be cleared" do
+        context.save_submission_details(reference, requested_email_confirmation)
+        context.clear_submission_details
+
+        expect(context.get_submission_reference).to eq(nil)
+        expect(context.requested_email_confirmation?).to eq(nil)
       end
     end
   end

--- a/spec/lib/context_spec.rb
+++ b/spec/lib/context_spec.rb
@@ -99,19 +99,19 @@ RSpec.describe Context do
   describe "submission references" do
     let(:context) { described_class.new(form:, store: {}) }
     let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
-    let(:email_sent) { true }
+    let(:requested_email_confirmation) { true }
 
     context "when submission details have been stored" do
       before do
-        context.save_submission_details(reference, email_sent)
+        context.save_submission_details(reference, requested_email_confirmation)
       end
 
       it "the reference number can be retrieved" do
         expect(context.get_submission_reference).to eq(reference)
       end
 
-      it "the email_sent value can be retrieved" do
-        expect(context.email_sent?).to eq(email_sent)
+      it "the requested_email_confirmation value can be retrieved" do
+        expect(context.requested_email_confirmation?).to eq(requested_email_confirmation)
       end
     end
   end

--- a/spec/lib/context_spec.rb
+++ b/spec/lib/context_spec.rb
@@ -95,5 +95,20 @@ RSpec.describe Context do
       expect(context2.find_or_create("1").show_answer).to eq("")
     end
   end
+
+  describe "submission references" do
+    let(:context) { described_class.new(form:, store: {}) }
+    let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+
+    context "when a reference has been stored" do
+      before do
+        context.save_submission_reference(reference)
+      end
+
+      it "the reference number can be retrieved" do
+        expect(context.get_submission_reference).to eq(reference)
+      end
+    end
+  end
 end
 # rubocop:enable RSpec/InstanceVariable

--- a/spec/lib/context_spec.rb
+++ b/spec/lib/context_spec.rb
@@ -99,14 +99,19 @@ RSpec.describe Context do
   describe "submission references" do
     let(:context) { described_class.new(form:, store: {}) }
     let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+    let(:email_sent) { true }
 
-    context "when a reference has been stored" do
+    context "when submission details have been stored" do
       before do
-        context.save_submission_reference(reference)
+        context.save_submission_details(reference, email_sent)
       end
 
       it "the reference number can be retrieved" do
         expect(context.get_submission_reference).to eq(reference)
+      end
+
+      it "the email_sent value can be retrieved" do
+        expect(context.email_sent?).to eq(email_sent)
       end
     end
   end

--- a/spec/lib/form_context_spec.rb
+++ b/spec/lib/form_context_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe FormContext do
   let(:step2) { OpenStruct.new({ page_id: "1", form_id: 2 }) }
   let(:form_context) { described_class.new(store) }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
-  let(:email_sent) { true }
+  let(:requested_email_confirmation) { true }
 
   it "stores the answer for a step" do
     form_context.save_step(step, "test answer")
@@ -67,28 +67,28 @@ RSpec.describe FormContext do
   end
 
   it "stores submission details " do
-    form_context.save_submission_details(1, reference, email_sent)
+    form_context.save_submission_details(1, reference, requested_email_confirmation)
     expect(form_context.get_submission_reference(1)).to eq(reference)
-    expect(form_context.email_sent?(1)).to eq(email_sent)
+    expect(form_context.requested_email_confirmation?(1)).to eq(requested_email_confirmation)
   end
 
   it "stores the submission details for multiple forms without overwriting them" do
-    form_context.save_submission_details(1, reference, email_sent)
+    form_context.save_submission_details(1, reference, requested_email_confirmation)
 
     reference2 = Faker::Alphanumeric.alphanumeric(number: 8).upcase
-    email_sent2 = false
-    form_context.save_submission_details(2, reference2, email_sent2)
+    requested_email_confirmation2 = false
+    form_context.save_submission_details(2, reference2, requested_email_confirmation2)
 
     expect(form_context.get_submission_reference(1)).to eq(reference)
-    expect(form_context.email_sent?(1)).to eq(email_sent)
+    expect(form_context.requested_email_confirmation?(1)).to eq(requested_email_confirmation)
     expect(form_context.get_submission_reference(2)).to eq(reference2)
-    expect(form_context.email_sent?(2)).to eq(email_sent2)
+    expect(form_context.requested_email_confirmation?(2)).to eq(requested_email_confirmation2)
   end
 
   it "clearing answers for a form doesn't clear the submission details" do
-    form_context.save_submission_details(1, reference, email_sent)
+    form_context.save_submission_details(1, reference, requested_email_confirmation)
     form_context.clear(1)
     expect(form_context.get_submission_reference(1)).to eq(reference)
-    expect(form_context.email_sent?(1)).to eq(email_sent)
+    expect(form_context.requested_email_confirmation?(1)).to eq(requested_email_confirmation)
   end
 end

--- a/spec/lib/form_context_spec.rb
+++ b/spec/lib/form_context_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe FormContext do
   let(:step) { OpenStruct.new({ page_id: "5", form_id: 1 }) }
   let(:step2) { OpenStruct.new({ page_id: "1", form_id: 2 }) }
   let(:form_context) { described_class.new(store) }
+  let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 
   it "stores the answer for a step" do
     form_context.save_step(step, "test answer")
@@ -62,5 +63,24 @@ RSpec.describe FormContext do
         expect(form_context.form_submitted?(123)).to eq false
       end
     end
+  end
+
+  it "stores a submission reference " do
+    form_context.save_submission_reference(1, reference)
+    expect(form_context.get_submission_reference(1)).to eq(reference)
+  end
+
+  it "stores the submission reference for multiple forms without overwriting them" do
+    form_context.save_submission_reference(1, reference)
+    reference2 = Faker::Alphanumeric.alphanumeric(number: 8).upcase
+    form_context.save_submission_reference(2, reference2)
+    expect(form_context.get_submission_reference(1)).to eq(reference)
+    expect(form_context.get_submission_reference(2)).to eq(reference2)
+  end
+
+  it "clearing answers for a form doesn't clear the reference" do
+    form_context.save_submission_reference(1, reference)
+    form_context.clear(1)
+    expect(form_context.get_submission_reference(1)).to eq(reference)
   end
 end

--- a/spec/lib/form_context_spec.rb
+++ b/spec/lib/form_context_spec.rb
@@ -29,18 +29,29 @@ RSpec.describe FormContext do
     expect(form_context.get_stored_answer(step)).to eq("test answer")
   end
 
-  it "clears the session for a form" do
-    form_context.save_step(step, "test answer")
-    form_context.clear(1)
-    expect(form_context.get_stored_answer(step)).to eq(nil)
-  end
+  describe "#clear" do
+    it "clears the session for a form" do
+      form_context.save_step(step, "test answer")
+      form_context.clear(1)
+      expect(form_context.get_stored_answer(step)).to eq(nil)
+    end
 
-  it "clear on one form doesn't change other forms" do
-    fc2 = described_class.new(store)
-    form_context.save_step(step, "form1 answer")
-    fc2.save_step(step2, "form2 answer")
-    form_context.clear(1)
-    expect(fc2.get_stored_answer(step2)).to eq("form2 answer")
+    it "doesn't change other forms" do
+      fc2 = described_class.new(store)
+      form_context.save_step(step, "form1 answer")
+      fc2.save_step(step2, "form2 answer")
+      form_context.clear(1)
+      expect(fc2.get_stored_answer(step2)).to eq("form2 answer")
+    end
+
+    it "doesn't clear the submission details" do
+      form_context.save_submission_details(1, reference, requested_email_confirmation)
+
+      form_context.clear(1)
+
+      expect(form_context.get_submission_reference(1)).to eq(reference)
+      expect(form_context.requested_email_confirmation?(1)).to eq(requested_email_confirmation)
+    end
   end
 
   it "returns the answers for a form" do
@@ -66,7 +77,7 @@ RSpec.describe FormContext do
     end
   end
 
-  it "stores submission details " do
+  it "stores and retrieves submission details" do
     form_context.save_submission_details(1, reference, requested_email_confirmation)
     expect(form_context.get_submission_reference(1)).to eq(reference)
     expect(form_context.requested_email_confirmation?(1)).to eq(requested_email_confirmation)
@@ -85,10 +96,14 @@ RSpec.describe FormContext do
     expect(form_context.requested_email_confirmation?(2)).to eq(requested_email_confirmation2)
   end
 
-  it "clearing answers for a form doesn't clear the submission details" do
-    form_context.save_submission_details(1, reference, requested_email_confirmation)
-    form_context.clear(1)
-    expect(form_context.get_submission_reference(1)).to eq(reference)
-    expect(form_context.requested_email_confirmation?(1)).to eq(requested_email_confirmation)
+  describe "#clear_submission_details" do
+    it "clears the submission details" do
+      form_context.save_submission_details(1, reference, requested_email_confirmation)
+
+      form_context.clear_submission_details(1)
+
+      expect(form_context.get_submission_reference(1)).to eq(nil)
+      expect(form_context.requested_email_confirmation?(1)).to eq(nil)
+    end
   end
 end

--- a/spec/lib/form_context_spec.rb
+++ b/spec/lib/form_context_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe FormContext do
   let(:step2) { OpenStruct.new({ page_id: "1", form_id: 2 }) }
   let(:form_context) { described_class.new(store) }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+  let(:email_sent) { true }
 
   it "stores the answer for a step" do
     form_context.save_step(step, "test answer")
@@ -65,22 +66,29 @@ RSpec.describe FormContext do
     end
   end
 
-  it "stores a submission reference " do
-    form_context.save_submission_reference(1, reference)
+  it "stores submission details " do
+    form_context.save_submission_details(1, reference, email_sent)
     expect(form_context.get_submission_reference(1)).to eq(reference)
+    expect(form_context.email_sent?(1)).to eq(email_sent)
   end
 
-  it "stores the submission reference for multiple forms without overwriting them" do
-    form_context.save_submission_reference(1, reference)
+  it "stores the submission details for multiple forms without overwriting them" do
+    form_context.save_submission_details(1, reference, email_sent)
+
     reference2 = Faker::Alphanumeric.alphanumeric(number: 8).upcase
-    form_context.save_submission_reference(2, reference2)
+    email_sent2 = false
+    form_context.save_submission_details(2, reference2, email_sent2)
+
     expect(form_context.get_submission_reference(1)).to eq(reference)
+    expect(form_context.email_sent?(1)).to eq(email_sent)
     expect(form_context.get_submission_reference(2)).to eq(reference2)
+    expect(form_context.email_sent?(2)).to eq(email_sent2)
   end
 
-  it "clearing answers for a form doesn't clear the reference" do
-    form_context.save_submission_reference(1, reference)
+  it "clearing answers for a form doesn't clear the submission details" do
+    form_context.save_submission_details(1, reference, email_sent)
     form_context.clear(1)
     expect(form_context.get_submission_reference(1)).to eq(reference)
+    expect(form_context.email_sent?(1)).to eq(email_sent)
   end
 end

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -328,6 +328,10 @@ RSpec.describe Forms::PageController, type: :request do
   end
 
   describe "#save" do
+    before do
+      allow_any_instance_of(Context).to receive(:clear_submission_details)
+    end
+
     context "with preview mode on" do
       let(:api_url_suffix) { "/draft" }
 
@@ -353,11 +357,21 @@ RSpec.describe Forms::PageController, type: :request do
           expect(EventLogger).not_to receive(:log)
           post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "answer text" } }
         end
+
+        it "clears the submission reference from the session" do
+          expect_any_instance_of(Context).to receive(:clear_submission_details).once
+          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "answer text" } }
+        end
       end
 
       context "with a subsequent page" do
         it "Logs the page_save event" do
           expect(EventLogger).not_to receive(:log)
+          post save_form_page_path("preview-draft", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+        end
+
+        it "does not clear the submission reference from the session" do
+          expect_any_instance_of(Context).not_to receive(:clear_submission_details)
           post save_form_page_path("preview-draft", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
         end
       end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -44,6 +44,11 @@ RSpec.describe FormSubmissionService do
     it "returns the submission reference" do
       expect(service.submit).to eq reference
     end
+
+    it "includes the submission reference in the logging context" do
+      service.submit
+      expect(logging_context).to include({ submission_reference: reference })
+    end
   end
 
   describe "#submit_form_to_processing_team" do

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe FormSubmissionService do
   let(:step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer_in_email: "42" }) }
   let(:preview_mode) { false }
   let(:email_confirmation_form) { build :email_confirmation_form_opted_in }
+  let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+
+  before do
+    allow(SecureRandom).to receive(:base58).with(8).and_return(reference)
+  end
 
   describe "#submit" do
     it "calls submit_form_to_processing_team method" do
@@ -34,6 +39,10 @@ RSpec.describe FormSubmissionService do
     it "calls submit_confirmation_email_to_user" do
       expect(service).to receive(:submit_confirmation_email_to_user).once
       service.submit
+    end
+
+    it "returns the submission reference" do
+      expect(service.submit).to eq reference
     end
   end
 

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe FormSubmissionService do
       expect(service.submit).to eq reference
     end
 
-    it "includes the submission reference in the logging context" do
+    it "includes the submission reference in the logging context", feature_reference_numbers_enabled: true do
       service.submit
       expect(logging_context).to include({ submission_reference: reference })
     end

--- a/spec/views/forms/submitted/submitted.html.erb_spec.rb
+++ b/spec/views/forms/submitted/submitted.html.erb_spec.rb
@@ -4,11 +4,12 @@ describe "forms/submitted/submitted.html.erb" do
   let(:form) { build :form, id: 1, what_happens_next_markdown: }
   let(:what_happens_next_markdown) { nil }
   let(:email_sent) { false }
+  let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 
   before do
     assign(:mode, OpenStruct.new(preview_draft?: false, preview_live?: false))
 
-    assign(:current_context, OpenStruct.new(form:))
+    assign(:current_context, OpenStruct.new(form:, get_submission_reference: reference))
 
     render template: "forms/submitted/submitted", locals: { email_sent: }
   end
@@ -17,11 +18,26 @@ describe "forms/submitted/submitted.html.erb" do
     expect(rendered).to have_css("h1.govuk-panel__title", text: "Your form has been submitted")
   end
 
+  context "when there is a reference present in the session" do
+    it "displays the submission reference" do
+      expect(rendered).to have_text(I18n.t("form.submitted.your_reference"))
+      expect(rendered).to have_text(reference)
+    end
+  end
+
+  context "when there is no reference present in the session" do
+    let(:reference) { nil }
+
+    it "does not display the submission reference text" do
+      expect(rendered).not_to have_text(I18n.t("form.submitted.your_reference"))
+    end
+  end
+
   context "when the form has extra information about what happens next" do
     let(:what_happens_next_markdown) { "See what the day brings" }
 
     it "displays what happens next heading" do
-      expect(rendered).to have_css("h2", text: "What happens next")
+      expect(rendered).to have_css("h2", text: I18n.t("form.submitted.what_happens_next"))
     end
 
     it "displays tells the user what happens next" do

--- a/spec/views/forms/submitted/submitted.html.erb_spec.rb
+++ b/spec/views/forms/submitted/submitted.html.erb_spec.rb
@@ -9,7 +9,7 @@ describe "forms/submitted/submitted.html.erb" do
   before do
     assign(:mode, OpenStruct.new(preview_draft?: false, preview_live?: false))
 
-    assign(:current_context, OpenStruct.new(form:, get_submission_reference: reference))
+    assign(:current_context, OpenStruct.new(form:, get_submission_reference: reference, email_sent?: email_sent))
 
     render template: "forms/submitted/submitted", locals: { email_sent: }
   end

--- a/spec/views/forms/submitted/submitted.html.erb_spec.rb
+++ b/spec/views/forms/submitted/submitted.html.erb_spec.rb
@@ -3,15 +3,15 @@ require "rails_helper"
 describe "forms/submitted/submitted.html.erb" do
   let(:form) { build :form, id: 1, what_happens_next_markdown: }
   let(:what_happens_next_markdown) { nil }
-  let(:email_sent) { false }
+  let(:requested_email_confirmation) { false }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 
   before do
     assign(:mode, OpenStruct.new(preview_draft?: false, preview_live?: false))
 
-    assign(:current_context, OpenStruct.new(form:, get_submission_reference: reference, email_sent?: email_sent))
+    assign(:current_context, OpenStruct.new(form:, get_submission_reference: reference, requested_email_confirmation?: requested_email_confirmation))
 
-    render template: "forms/submitted/submitted", locals: { email_sent: }
+    render template: "forms/submitted/submitted", locals: { requested_email_confirmation: }
   end
 
   it "contains a green govuk panel with success message " do
@@ -52,7 +52,7 @@ describe "forms/submitted/submitted.html.erb" do
   end
 
   context "when the user has opted into the confirmation email" do
-    let(:email_sent) { true }
+    let(:requested_email_confirmation) { true }
 
     it "displays the email confirmation message" do
       expect(rendered).to have_css("p", text: I18n.t("form.submitted.email_sent"))

--- a/spec/views/forms/submitted/submitted.html.erb_spec.rb
+++ b/spec/views/forms/submitted/submitted.html.erb_spec.rb
@@ -18,14 +18,14 @@ describe "forms/submitted/submitted.html.erb" do
     expect(rendered).to have_css("h1.govuk-panel__title", text: "Your form has been submitted")
   end
 
-  context "when there is a reference present in the session" do
+  context "when there is a reference present in the session", feature_reference_numbers_enabled: true do
     it "displays the submission reference" do
       expect(rendered).to have_text(I18n.t("form.submitted.your_reference"))
       expect(rendered).to have_text(reference)
     end
   end
 
-  context "when there is no reference present in the session" do
+  context "when there is no reference present in the session", feature_reference_numbers_enabled: true do
     let(:reference) { nil }
 
     it "does not display the submission reference text" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/44ZcfuuB/1360-generate-a-reference-for-form-submissions

This PR generates a reference number and adds it to the confirmation page.
<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
To do this we:
- generate an 8 digit alphanumeric reference number and store it in a special bit of the session which doesn't get cleared on submit
- read the stored reference number on the confirmation page
- move the `email_sent` flag into the session, and rename it to make it clearer
- add the submission reference to the logging context
- clear the submission details from the session when the user restarts the form and saves the first question.
- feature flag the logging and display of the reference, so that we can turn it on after the email work is complete.

There's additional context on each commit message.

#### To be done in another PR
- pass the reference number into Notify and display it in the submission and confirmation emails ([trello #1361](https://trello.com/c/dm8jKunt/1361-generate-a-reference-for-form-submissions-email-work))

#### Other things we might want to do later
These are some loosely related things we might want to do at some point, but which I don't think are part of this reference work. 
- at some point we might want to edit FormContext's 'form_submitted?' method to check for the presence of the submission reference rather than an empty session. I think this would make sense because there are other possible ways to empty the answers store, but you can only get a submission reference by submitting the form.
- it might make sense to redirect from the submitted page back to an earlier step in the form if the user doesn't have a confirmation reference. We do this for every other page, and I think this work makes it possible to do it for the confirmation screen too.

### Screenshots
![A confirmation page showing a green GOV.UK panel component with the heading 'Your form has been submitted' and the text 'Your reference number BQJMNQNW'. Undernathe the panel component is a paragraph reading 'We have sent you a confirmation email', a small heading 'What happens next', and a paragraph saying 'We aim to respond to all applications within 5 working days, but this may vary at busy times. Our service status page shows our current expected waiting times (opens in new tab)'](https://github.com/alphagov/forms-runner/assets/5861235/b9045b7f-12c6-4642-807f-520cfbfff1df)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
