### PR TITLE
Log notification IDs for form submission

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,8 +39,8 @@ Rails.application.configure do
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
-  GovukNotifyRails::Mailer.default(delivery_method: :test, from: "forms@example.com")
+  config.action_mailer.delivery_method = :govuk_notify_test
+  GovukNotifyRails::Mailer.default(delivery_method: :govuk_notify_test, from: "forms@example.com")
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/initializers/mailers.rb
+++ b/config/initializers/mailers.rb
@@ -1,1 +1,6 @@
 ActionMailer::Base.add_delivery_method :govuk_notify, GovukNotifyRails::Delivery, api_key: Settings.govuk_notify.api_key
+
+if Rails.env.test?
+  require "govuk_notify_rails/test_mailer"
+  ActionMailer::Base.add_delivery_method :govuk_notify_test, GovukNotifyRails::TestMailer if Rails.env.test?
+end

--- a/lib/govuk_notify_rails/test_mailer.rb
+++ b/lib/govuk_notify_rails/test_mailer.rb
@@ -1,0 +1,17 @@
+module GovukNotifyRails
+  class TestMailer < Mail::TestMailer
+    @govuk_notify_responses = []
+
+    class << self
+      attr_reader :govuk_notify_responses
+    end
+
+    def deliver!(mail)
+      super
+
+      mail.govuk_notify_response =
+        GovukNotifyRails::TestMailer.govuk_notify_responses.pop \
+        || Notifications::Client::ResponseNotification.new({})
+    end
+  end
+end

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -229,6 +229,19 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
   end
 
   describe "#submit_answers" do
+    before do
+      allow_mailer_to_return_mail_with_govuk_notify_response_with(
+        FormSubmissionMailer,
+        :email_completed_form,
+        id: "1111",
+      )
+      allow_mailer_to_return_mail_with_govuk_notify_response_with(
+        FormSubmissionConfirmationMailer,
+        :send_confirmation_email,
+        id: "2222",
+      )
+    end
+
     shared_examples "for notification references" do
       it "includes the notification references in the logging_context" do
         expect(logging_context).to include(notification_references: {
@@ -270,6 +283,14 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(mail.govuk_notify_reference).to eq "for-my-ref"
       end
 
+      it "includes the submission notification IDs in the logging context" do
+        expect(logging_context[:notification_ids]).to include(submission_email_id: "1111")
+      end
+
+      it "includes the confirmation notification IDs in the logging context" do
+        expect(logging_context[:notification_ids]).to include(confirmation_email_id: "2222")
+      end
+
       include_examples "for notification references"
     end
 
@@ -301,6 +322,14 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         }
 
         expect(mail.body.raw_source).to match(expected_personalisation.to_s)
+      end
+
+      it "includes the submission notification IDs in the logging context" do
+        expect(logging_context[:notification_ids]).to include(submission_email_id: "1111")
+      end
+
+      it "includes the confirmation notification IDs in the logging context" do
+        expect(logging_context[:notification_ids]).to include(confirmation_email_id: "2222")
       end
 
       include_examples "for notification references"
@@ -393,6 +422,14 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(response).to redirect_to(form_submitted_path)
       end
 
+      it "includes the submission notification IDs in the logging context" do
+        expect(logging_context[:notification_ids]).to include(submission_email_id: "1111")
+      end
+
+      it "does not include the confirmation notification IDs in the logging context" do
+        expect(logging_context[:notification_ids]).not_to include(:confirmation_email_id)
+      end
+
       it "does include submission email reference in logging context" do
         expect(logging_context[:notification_references]).to include(submission_email_reference: "for-my-ref")
       end
@@ -439,6 +476,14 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(mail.body.raw_source).to include(expected_personalisation.to_s)
 
         expect(mail.govuk_notify_reference).to eq "confirmation-email-ref"
+      end
+
+      it "includes the submission notification IDs in the logging context" do
+        expect(logging_context[:notification_ids]).to include(submission_email_id: "1111")
+      end
+
+      it "includes the confirmation notification IDs in the logging context" do
+        expect(logging_context[:notification_ids]).to include(confirmation_email_id: "2222")
       end
 
       include_examples "for notification references"

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -40,11 +40,10 @@ RSpec.describe FormSubmissionService do
   describe "#submit_form_to_processing_team" do
     it "calls FormSubmissionMailer" do
       freeze_time do
-        delivery = double
-        expect(delivery).to receive(:deliver_now).with(no_args)
-        allow(FormSubmissionMailer).to receive(:email_completed_form).and_return(delivery)
+        allow(FormSubmissionMailer).to receive(:email_completed_form).and_call_original
 
         service.submit_form_to_processing_team
+
         expect(FormSubmissionMailer).to have_received(:email_completed_form).with(
           { title: "Form 1",
             text_input: "# What is the meaning of life?\n42\n",
@@ -54,6 +53,20 @@ RSpec.describe FormSubmissionService do
             preview_mode: false },
         ).once
       end
+    end
+
+    it "adds the notification ID to the logging context" do
+      allow_mailer_to_return_mail_with_govuk_notify_response_with(
+        FormSubmissionMailer,
+        :email_completed_form,
+        id: "id-for-submission-email-notification",
+      )
+
+      service.submit_form_to_processing_team
+
+      expect(logging_context).to include(notification_ids: {
+        submission_email_id: "id-for-submission-email-notification",
+      })
     end
 
     it "logs submission" do
@@ -93,11 +106,10 @@ RSpec.describe FormSubmissionService do
 
       it "calls FormSubmissionMailer" do
         freeze_time do
-          delivery = double
-          expect(delivery).to receive(:deliver_now).with(no_args)
-          allow(FormSubmissionMailer).to receive(:email_completed_form).and_return(delivery)
+          allow(FormSubmissionMailer).to receive(:email_completed_form).and_call_original
 
           service.submit_form_to_processing_team
+
           expect(FormSubmissionMailer).to have_received(:email_completed_form).with(
             { title: "Form 1",
               text_input: "# What is the meaning of life?\n42\n",
@@ -154,9 +166,7 @@ RSpec.describe FormSubmissionService do
   describe "#submit_confirmation_email_to_user" do
     it "calls FormSubmissionConfirmationMailer" do
       freeze_time do
-        delivery = double
-        expect(delivery).to receive(:deliver_now).with(no_args)
-        allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email).and_return(delivery)
+        allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email).and_call_original
 
         service.submit_confirmation_email_to_user
         expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(

--- a/spec/support/govuk_notify_rails_helpers.rb
+++ b/spec/support/govuk_notify_rails_helpers.rb
@@ -1,0 +1,14 @@
+module GovukNotifyRailsHelpers
+  def allow_mailer_to_return_mail_with_govuk_notify_response_with(mailer, method_name, **response_notification_stubs)
+    allow(mailer).to receive(method_name).and_wrap_original do |original_method, *args, **kwargs|
+      GovukNotifyRails::TestMailer.govuk_notify_responses <<
+        instance_double(Notifications::Client::ResponseNotification, response_notification_stubs)
+
+      original_method.call(*args, **kwargs)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include GovukNotifyRailsHelpers
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/SSMzBdHj/1338-improve-logging-of-notify-calls-in-forms-runner <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Log notification IDs after call to GOV.UK Notify is made, to make it easier to lookup the notification in their database.

To make it possible to have this code run under test, I had to introduce a new test mailer, as with the default Rails test mailer `govuk_notify_response` attribute isn't populated.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?