### PR TITLE
Fix Vite CommonJS deprecation warning

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/vendor/'],
   passWithNoTests: true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "app",
   "private": "true",
+  "type": "module",
   "browserslist": [
     ">0.1% and not dead",
     "last 2 Chrome versions",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
-const autoprefixer = require('autoprefixer')
-const cssnano = require('cssnano')
+import autoprefixer from 'autoprefixer'
+import cssnano from 'cssnano'
 
-module.exports = {
+export default {
   plugins: [autoprefixer({ grid: 'no-autoplace' }), cssnano()]
 }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/4WGWwZRU/1496-resolve-vite-deprecation-warning

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

The CommonJS build of Vite will no longer be supported as of v6.

None of our served JS files in this repo are CommonJS anyway, so we can safely add `"type": "module"` to our package.json file to fix this.

However, two of our config files (jest.config.js and postcss.config.js) were in CommonJS format. This change also updates them to use ES module format.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
