### PR TITLE
Add reference numbers to email

### DIFF
--- a/app/form_objects/email_confirmation_form.rb
+++ b/app/form_objects/email_confirmation_form.rb
@@ -11,7 +11,7 @@ class EmailConfirmationForm
 
   def initialize(...)
     super(...)
-    generate_submission_references! unless @confirmation_email_reference || @submission_email_reference
+    generate_notify_response_ids! unless @confirmation_email_reference || @submission_email_reference
   end
 
   def validate_email?
@@ -20,11 +20,11 @@ class EmailConfirmationForm
 
 private
 
-  def generate_submission_references!
-    reference = SecureRandom.uuid
+  def generate_notify_response_ids!
+    uuid = SecureRandom.uuid
     self.attributes = {
-      confirmation_email_reference: "#{reference}-confirmation-email",
-      submission_email_reference: "#{reference}-submission-email",
+      confirmation_email_reference: "#{uuid}-confirmation-email",
+      submission_email_reference: "#{uuid}-submission-email",
     }
   end
 end

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -1,5 +1,5 @@
 class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
-  def send_confirmation_email(title:, what_happens_next_markdown:, support_contact_details:, submission_timestamp:, preview_mode:, reference:, confirmation_email_address:)
+  def send_confirmation_email(title:, what_happens_next_markdown:, support_contact_details:, submission_timestamp:, preview_mode:, reference:, confirmation_email_address:, submission_reference:)
     set_template(Settings.govuk_notify.form_filler_confirmation_email_template_id)
 
     set_personalisation(
@@ -12,6 +12,8 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
       # conditionals, so to simulate negative conditionals we add two boolean
       # flags; but they must always have opposite values!
       test: make_notify_boolean(preview_mode),
+      include_submission_reference: make_notify_boolean(FeatureService.enabled?(:reference_numbers_enabled)),
+      submission_reference: FeatureService.enabled?(:reference_numbers_enabled) ? submission_reference : "",
     )
 
     set_reference(reference)

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -1,19 +1,19 @@
 class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
-  def send_confirmation_email(title:, what_happens_next_markdown:, support_contact_details:, submission_timestamp:, preview_mode:, reference:, confirmation_email_address:, submission_reference:)
+  def send_confirmation_email(what_happens_next_markdown:, support_contact_details:, reference:, confirmation_email_address:, mailer_options:)
     set_template(Settings.govuk_notify.form_filler_confirmation_email_template_id)
 
     set_personalisation(
-      title:,
+      title: mailer_options.title,
       what_happens_next_text: what_happens_next_markdown,
       support_contact_details:,
-      submission_time: submission_timestamp.strftime("%l:%M%P").strip,
-      submission_date: submission_timestamp.strftime("%-d %B %Y"),
+      submission_time: mailer_options.timestamp.strftime("%l:%M%P").strip,
+      submission_date: mailer_options.timestamp.strftime("%-d %B %Y"),
       # GOV.UK Notify's templates have conditionals, but only positive
       # conditionals, so to simulate negative conditionals we add two boolean
       # flags; but they must always have opposite values!
-      test: make_notify_boolean(preview_mode),
+      test: make_notify_boolean(mailer_options.preview_mode),
       include_submission_reference: make_notify_boolean(FeatureService.enabled?(:reference_numbers_enabled)),
-      submission_reference: FeatureService.enabled?(:reference_numbers_enabled) ? submission_reference : "",
+      submission_reference: FeatureService.enabled?(:reference_numbers_enabled) ? mailer_options.submission_reference : "",
     )
 
     set_reference(reference)

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -1,5 +1,5 @@
 class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
-  def send_confirmation_email(what_happens_next_markdown:, support_contact_details:, reference:, confirmation_email_address:, mailer_options:)
+  def send_confirmation_email(what_happens_next_markdown:, support_contact_details:, notify_response_id:, confirmation_email_address:, mailer_options:)
     set_template(Settings.govuk_notify.form_filler_confirmation_email_template_id)
 
     set_personalisation(
@@ -16,7 +16,7 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
       submission_reference: FeatureService.enabled?(:reference_numbers_enabled) ? mailer_options.submission_reference : "",
     )
 
-    set_reference(reference)
+    set_reference(notify_response_id)
 
     set_email_reply_to(Settings.govuk_notify.form_submission_email_reply_to_id)
 

--- a/app/mailers/form_submission_mailer.rb
+++ b/app/mailers/form_submission_mailer.rb
@@ -1,19 +1,19 @@
 class FormSubmissionMailer < GovukNotifyRails::Mailer
-  def email_completed_form(title:, text_input:, reference:, preview_mode:, timestamp:, submission_email:, submission_reference:)
+  def email_completed_form(text_input:, reference:, submission_email:, mailer_options:)
     set_template(Settings.govuk_notify.form_submission_email_template_id)
 
     set_personalisation(
-      title:,
+      title: mailer_options.title,
       text_input:,
-      submission_time: timestamp.strftime("%l:%M%P").strip,
-      submission_date: timestamp.strftime("%-d %B %Y"),
+      submission_time: mailer_options.timestamp.strftime("%l:%M%P").strip,
+      submission_date: mailer_options.timestamp.strftime("%-d %B %Y"),
       # GOV.UK Notify's templates have conditionals, but only positive
       # conditionals, so to simulate negative conditionals we add two boolean
       # flags; but they must always have opposite values!
-      test: make_notify_boolean(preview_mode),
-      not_test: make_notify_boolean(!preview_mode),
+      test: make_notify_boolean(mailer_options.preview_mode),
+      not_test: make_notify_boolean(!mailer_options.preview_mode),
       include_submission_reference: make_notify_boolean(FeatureService.enabled?(:reference_numbers_enabled)),
-      submission_reference: FeatureService.enabled?(:reference_numbers_enabled) ? submission_reference : "",
+      submission_reference: FeatureService.enabled?(:reference_numbers_enabled) ? mailer_options.submission_reference : "",
     )
 
     set_reference(reference)

--- a/app/mailers/form_submission_mailer.rb
+++ b/app/mailers/form_submission_mailer.rb
@@ -1,5 +1,5 @@
 class FormSubmissionMailer < GovukNotifyRails::Mailer
-  def email_completed_form(title:, text_input:, reference:, preview_mode:, timestamp:, submission_email:)
+  def email_completed_form(title:, text_input:, reference:, preview_mode:, timestamp:, submission_email:, submission_reference:)
     set_template(Settings.govuk_notify.form_submission_email_template_id)
 
     set_personalisation(
@@ -12,6 +12,8 @@ class FormSubmissionMailer < GovukNotifyRails::Mailer
       # flags; but they must always have opposite values!
       test: make_notify_boolean(preview_mode),
       not_test: make_notify_boolean(!preview_mode),
+      include_submission_reference: make_notify_boolean(FeatureService.enabled?(:reference_numbers_enabled)),
+      submission_reference: FeatureService.enabled?(:reference_numbers_enabled) ? submission_reference : "",
     )
 
     set_reference(reference)

--- a/app/mailers/form_submission_mailer.rb
+++ b/app/mailers/form_submission_mailer.rb
@@ -1,5 +1,5 @@
 class FormSubmissionMailer < GovukNotifyRails::Mailer
-  def email_completed_form(text_input:, reference:, submission_email:, mailer_options:)
+  def email_completed_form(text_input:, notify_response_id:, submission_email:, mailer_options:)
     set_template(Settings.govuk_notify.form_submission_email_template_id)
 
     set_personalisation(
@@ -16,7 +16,7 @@ class FormSubmissionMailer < GovukNotifyRails::Mailer
       submission_reference: FeatureService.enabled?(:reference_numbers_enabled) ? mailer_options.submission_reference : "",
     )
 
-    set_reference(reference)
+    set_reference(notify_response_id)
 
     set_email_reply_to(Settings.govuk_notify.form_submission_email_reply_to_id)
 

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -62,6 +62,7 @@ class FormSubmissionService
       preview_mode: @preview_mode,
       reference: @email_confirmation_form.confirmation_email_reference,
       confirmation_email_address: @email_confirmation_form.confirmation_email_address,
+      submission_reference: @submission_reference,
     ).deliver_now
 
     @logging_context[:notification_ids] ||= {}

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -45,7 +45,7 @@ class FormSubmissionService
 
       mail = FormSubmissionMailer
       .email_completed_form(text_input: email_body,
-                            reference: @email_confirmation_form.submission_email_reference,
+                            notify_response_id: @email_confirmation_form.submission_email_reference,
                             submission_email: @form.submission_email,
                             mailer_options: @mailer_options).deliver_now
 
@@ -63,7 +63,7 @@ class FormSubmissionService
     mail = FormSubmissionConfirmationMailer.send_confirmation_email(
       what_happens_next_markdown: @form.what_happens_next_markdown,
       support_contact_details: formatted_support_details,
-      reference: @email_confirmation_form.confirmation_email_reference,
+      notify_response_id: @email_confirmation_form.confirmation_email_reference,
       confirmation_email_address: @email_confirmation_form.confirmation_email_address,
       mailer_options: @mailer_options,
     ).deliver_now

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -41,7 +41,8 @@ class FormSubmissionService
                             preview_mode: @preview_mode,
                             reference: @email_confirmation_form.submission_email_reference,
                             timestamp: @timestamp,
-                            submission_email: @form.submission_email).deliver_now
+                            submission_email: @form.submission_email,
+                            submission_reference: @submission_reference).deliver_now
 
       @logging_context[:notification_ids] ||= {}
       @logging_context[:notification_ids][:submission_email_id] = mail.govuk_notify_response.id

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -5,6 +5,8 @@ class FormSubmissionService
     end
   end
 
+  MailerOptions = Data.define(:title, :preview_mode, :timestamp, :submission_reference)
+
   def initialize(logging_context:, current_context:, request:, email_confirmation_form:, preview_mode:)
     @logging_context = logging_context
     @current_context = current_context

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -42,14 +42,12 @@ class FormSubmissionService
     end
 
     unless @form.submission_email.blank? && @preview_mode
+
       mail = FormSubmissionMailer
-      .email_completed_form(title: form_title,
-                            text_input: email_body,
-                            preview_mode: @preview_mode,
+      .email_completed_form(text_input: email_body,
                             reference: @email_confirmation_form.submission_email_reference,
-                            timestamp: @timestamp,
                             submission_email: @form.submission_email,
-                            submission_reference: @submission_reference).deliver_now
+                            mailer_options: @mailer_options).deliver_now
 
       @logging_context[:notification_ids] ||= {}
       @logging_context[:notification_ids][:submission_email_id] = mail.govuk_notify_response.id

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -18,6 +18,11 @@ class FormSubmissionService
     @timestamp = submission_timestamp
     @submission_reference = generate_submission_reference
 
+    @mailer_options = MailerOptions.new(title: form_title,
+                                        preview_mode: @preview_mode,
+                                        timestamp: @timestamp,
+                                        submission_reference: @submission_reference)
+
     if FeatureService.enabled?(:reference_numbers_enabled)
       @logging_context[:submission_reference] = @submission_reference
     end
@@ -58,14 +63,11 @@ class FormSubmissionService
     return nil unless @requested_email_confirmation
 
     mail = FormSubmissionConfirmationMailer.send_confirmation_email(
-      title: form_title,
       what_happens_next_markdown: @form.what_happens_next_markdown,
       support_contact_details: formatted_support_details,
-      submission_timestamp: @timestamp,
-      preview_mode: @preview_mode,
       reference: @email_confirmation_form.confirmation_email_reference,
       confirmation_email_address: @email_confirmation_form.confirmation_email_address,
-      submission_reference: @submission_reference,
+      mailer_options: @mailer_options,
     ).deliver_now
 
     @logging_context[:notification_ids] ||= {}

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -4,7 +4,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
   let(:mail) do
     described_class.send_confirmation_email(what_happens_next_markdown:,
                                             support_contact_details:,
-                                            reference: "for-my-ref",
+                                            notify_response_id: "for-my-ref",
                                             confirmation_email_address:,
                                             mailer_options:)
   end

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -2,14 +2,17 @@ require "rails_helper"
 
 describe FormSubmissionConfirmationMailer, type: :mailer do
   let(:mail) do
-    described_class.send_confirmation_email(title:,
-                                            what_happens_next_markdown:,
+    described_class.send_confirmation_email(what_happens_next_markdown:,
                                             support_contact_details:,
-                                            submission_timestamp:,
-                                            preview_mode:,
                                             reference: "for-my-ref",
                                             confirmation_email_address:,
-                                            submission_reference:)
+                                            mailer_options:)
+  end
+  let(:mailer_options) do
+    FormSubmissionService::MailerOptions.new(title:,
+                                             preview_mode:,
+                                             timestamp: submission_timestamp,
+                                             submission_reference:)
   end
   let(:title) { "Form 1" }
   let(:what_happens_next_markdown) { "Please wait for a response" }

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -8,7 +8,8 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
                                             submission_timestamp:,
                                             preview_mode:,
                                             reference: "for-my-ref",
-                                            confirmation_email_address:)
+                                            confirmation_email_address:,
+                                            submission_reference:)
   end
   let(:title) { "Form 1" }
   let(:what_happens_next_markdown) { "Please wait for a response" }
@@ -16,6 +17,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
   let(:preview_mode) { false }
   let(:confirmation_email_address) { "testing@gov.uk" }
   let(:submission_timestamp) { Time.zone.now }
+  let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 
   context "when form filler wants an form submission confirmation email" do
     it "sends an email with the correct template" do

--- a/spec/mailers/form_submission_mailer_spec.rb
+++ b/spec/mailers/form_submission_mailer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe FormSubmissionMailer, type: :mailer do
-  let(:mail) { described_class.email_completed_form(text_input:, reference: "for-my-ref", submission_email:, mailer_options:) }
+  let(:mail) { described_class.email_completed_form(text_input:, notify_response_id: "for-my-ref", submission_email:, mailer_options:) }
   let(:title) { "Form 1" }
   let(:text_input) { "My question: My answer" }
   let(:preview_mode) { false }

--- a/spec/mailers/form_submission_mailer_spec.rb
+++ b/spec/mailers/form_submission_mailer_spec.rb
@@ -1,13 +1,19 @@
 require "rails_helper"
 
 describe FormSubmissionMailer, type: :mailer do
-  let(:mail) { described_class.email_completed_form(title:, text_input:, reference: "for-my-ref", preview_mode:, timestamp: submission_timestamp, submission_email:, submission_reference:) }
+  let(:mail) { described_class.email_completed_form(text_input:, reference: "for-my-ref", submission_email:, mailer_options:) }
   let(:title) { "Form 1" }
   let(:text_input) { "My question: My answer" }
   let(:preview_mode) { false }
   let(:submission_email) { "testing@gov.uk" }
   let(:submission_timestamp) { Time.zone.now }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+  let(:mailer_options) do
+    FormSubmissionService::MailerOptions.new(title:,
+                                             preview_mode:,
+                                             timestamp: submission_timestamp,
+                                             submission_reference:)
+  end
 
   context "when form filler submits a completed form" do
     it "sends an email with the correct template" do

--- a/spec/mailers/form_submission_mailer_spec.rb
+++ b/spec/mailers/form_submission_mailer_spec.rb
@@ -1,12 +1,13 @@
 require "rails_helper"
 
 describe FormSubmissionMailer, type: :mailer do
-  let(:mail) { described_class.email_completed_form(title:, text_input:, reference: "for-my-ref", preview_mode:, timestamp: submission_timestamp, submission_email:) }
+  let(:mail) { described_class.email_completed_form(title:, text_input:, reference: "for-my-ref", preview_mode:, timestamp: submission_timestamp, submission_email:, submission_reference:) }
   let(:title) { "Form 1" }
   let(:text_input) { "My question: My answer" }
   let(:preview_mode) { false }
   let(:submission_email) { "testing@gov.uk" }
   let(:submission_timestamp) { Time.zone.now }
+  let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 
   context "when form filler submits a completed form" do
     it "sends an email with the correct template" do

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -75,6 +75,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
   let(:repeat_form_submission) { false }
 
+  let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+
   before do
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/api/v1/forms/2#{api_url_suffix}", req_headers, form_data.to_json, 200
@@ -85,6 +87,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       allow(context_spy).to receive(:form_submitted?).and_return(repeat_form_submission)
       context_spy
     end
+
+    allow(SecureRandom).to receive(:base58).with(8).and_return(reference)
   end
 
   describe "#show" do
@@ -457,25 +461,54 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(response).to redirect_to(form_submitted_path)
       end
 
-      it "sends a confirmation email" do
-        deliveries = ActionMailer::Base.deliveries
-        expect(deliveries.length).to eq 2
+      context "when submission references are enabled", feature_reference_numbers_enabled: true do
+        it "sends a confirmation email" do
+          deliveries = ActionMailer::Base.deliveries
+          expect(deliveries.length).to eq 2
 
-        mail = deliveries[1]
-        expect(mail.to).to eq([email_confirmation_form[:confirmation_email_address]])
+          mail = deliveries[1]
+          expect(mail.to).to eq([email_confirmation_form[:confirmation_email_address]])
 
-        expected_personalisation = {
-          title: form_data.name,
-          what_happens_next_text: form_data.what_happens_next_markdown,
-          support_contact_details: contact_support_details_format,
-          submission_time: "10:00am",
-          submission_date: "14 December 2022",
-          test: "no",
-        }
+          expected_personalisation = {
+            title: form_data.name,
+            what_happens_next_text: form_data.what_happens_next_markdown,
+            support_contact_details: contact_support_details_format,
+            submission_time: "10:00am",
+            submission_date: "14 December 2022",
+            test: "no",
+            include_submission_reference: "yes",
+            submission_reference: reference,
+          }
 
-        expect(mail.body.raw_source).to include(expected_personalisation.to_s)
+          expect(mail.body.raw_source).to include(expected_personalisation.to_s)
 
-        expect(mail.govuk_notify_reference).to eq "confirmation-email-ref"
+          expect(mail.govuk_notify_reference).to eq "confirmation-email-ref"
+        end
+      end
+
+      context "when submission references are not enabled", feature_reference_numbers_enabled: false do
+        it "sends a confirmation email" do
+          deliveries = ActionMailer::Base.deliveries
+          expect(deliveries.length).to eq 2
+
+          mail = deliveries[1]
+          expect(mail.to).to eq([email_confirmation_form[:confirmation_email_address]])
+
+          expected_personalisation = {
+            title: form_data.name,
+            what_happens_next_text: form_data.what_happens_next_markdown,
+            support_contact_details: contact_support_details_format,
+            submission_time: "10:00am",
+            submission_date: "14 December 2022",
+            test: "no",
+            include_submission_reference: "no",
+            submission_reference: "",
+          }
+
+          expect(mail.body.raw_source).to include(expected_personalisation.to_s)
+
+          expect(mail.govuk_notify_reference).to eq "confirmation-email-ref"
+        end
       end
 
       it "includes the submission notification IDs in the logging context" do

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -186,14 +186,11 @@ RSpec.describe FormSubmissionService do
 
         service.submit_confirmation_email_to_user
         expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
-          { title: "Form 1",
-            what_happens_next_markdown: form.what_happens_next_markdown,
+          { what_happens_next_markdown: form.what_happens_next_markdown,
             support_contact_details: contact_support_details_format,
-            submission_timestamp: Time.zone.now,
-            preview_mode:,
             reference: email_confirmation_form.confirmation_email_reference,
             confirmation_email_address: email_confirmation_form.confirmation_email_address,
-            submission_reference: reference },
+            mailer_options: instance_of(FormSubmissionService::MailerOptions) },
         ).once
       end
     end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -64,7 +64,8 @@ RSpec.describe FormSubmissionService do
             reference: email_confirmation_form.submission_email_reference,
             timestamp: Time.zone.now,
             submission_email: "testing@gov.uk",
-            preview_mode: false },
+            preview_mode: false,
+            submission_reference: reference },
         ).once
       end
     end
@@ -130,7 +131,8 @@ RSpec.describe FormSubmissionService do
               reference: email_confirmation_form.submission_email_reference,
               timestamp: Time.zone.now,
               submission_email: "testing@gov.uk",
-              preview_mode: true },
+              preview_mode: true,
+              submission_reference: reference },
           ).once
         end
       end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe FormSubmissionService do
 
         expect(FormSubmissionMailer).to have_received(:email_completed_form).with(
           { text_input: "# What is the meaning of life?\n42\n",
-            reference: email_confirmation_form.submission_email_reference,
+            notify_response_id: email_confirmation_form.submission_email_reference,
             submission_email: "testing@gov.uk",
             mailer_options: instance_of(FormSubmissionService::MailerOptions) },
         ).once
@@ -124,7 +124,7 @@ RSpec.describe FormSubmissionService do
 
           expect(FormSubmissionMailer).to have_received(:email_completed_form).with(
             { text_input: "# What is the meaning of life?\n42\n",
-              reference: email_confirmation_form.submission_email_reference,
+              notify_response_id: email_confirmation_form.submission_email_reference,
               submission_email: "testing@gov.uk",
               mailer_options: instance_of(FormSubmissionService::MailerOptions) },
           ).once
@@ -182,7 +182,7 @@ RSpec.describe FormSubmissionService do
         expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
           { what_happens_next_markdown: form.what_happens_next_markdown,
             support_contact_details: contact_support_details_format,
-            reference: email_confirmation_form.confirmation_email_reference,
+            notify_response_id: email_confirmation_form.confirmation_email_reference,
             confirmation_email_address: email_confirmation_form.confirmation_email_address,
             mailer_options: instance_of(FormSubmissionService::MailerOptions) },
         ).once

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -59,13 +59,10 @@ RSpec.describe FormSubmissionService do
         service.submit_form_to_processing_team
 
         expect(FormSubmissionMailer).to have_received(:email_completed_form).with(
-          { title: "Form 1",
-            text_input: "# What is the meaning of life?\n42\n",
+          { text_input: "# What is the meaning of life?\n42\n",
             reference: email_confirmation_form.submission_email_reference,
-            timestamp: Time.zone.now,
             submission_email: "testing@gov.uk",
-            preview_mode: false,
-            submission_reference: reference },
+            mailer_options: instance_of(FormSubmissionService::MailerOptions) },
         ).once
       end
     end
@@ -126,13 +123,10 @@ RSpec.describe FormSubmissionService do
           service.submit_form_to_processing_team
 
           expect(FormSubmissionMailer).to have_received(:email_completed_form).with(
-            { title: "Form 1",
-              text_input: "# What is the meaning of life?\n42\n",
+            { text_input: "# What is the meaning of life?\n42\n",
               reference: email_confirmation_form.submission_email_reference,
-              timestamp: Time.zone.now,
               submission_email: "testing@gov.uk",
-              preview_mode: true,
-              submission_reference: reference },
+              mailer_options: instance_of(FormSubmissionService::MailerOptions) },
           ).once
         end
       end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -190,7 +190,8 @@ RSpec.describe FormSubmissionService do
             submission_timestamp: Time.zone.now,
             preview_mode:,
             reference: email_confirmation_form.confirmation_email_reference,
-            confirmation_email_address: email_confirmation_form.confirmation_email_address },
+            confirmation_email_address: email_confirmation_form.confirmation_email_address,
+            submission_reference: reference },
         ).once
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/dm8jKunt/1361-generate-a-reference-for-form-submissions-email-work

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Adds two new variables to the Notify personalisation for the submission email (sent to processors) and confirmation email (sent to form fillers, if requested):

- include_submission_reference: this is a boolean controlled by the `reference_numbers_enabled` feature flag.
- submission_reference: the reference number itself.

This means that once this is merged and deployed, we can add the variable to the Notify templates in the format `((INCLUDE_SUBMISSION_REFERENCE??Your reference number is ))((SUBMISSION_REFERENCE))`. When the feature flag is off, this will return nothing, so the email will be the same as it was previously. But when the flag is on, it will return `Your reference is R34R3NC3`.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
