### PR TITLE
1358 enable taking payments in forms via runner

### DIFF
--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -5,3 +5,4 @@ $govuk-global-styles: true;
 @import "@govuk/all";
 @import "../../components/form_header_component/";
 @import "../../components/main_component/";
+@import "../styles/app-panel";

--- a/app/frontend/styles/_app-panel.scss
+++ b/app/frontend/styles/_app-panel.scss
@@ -1,0 +1,3 @@
+.app-panel--payment-required {
+    background-color:  govuk-colour("blue");
+}

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -14,6 +14,8 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
       test: make_notify_boolean(mailer_options.preview_mode),
       include_submission_reference: make_notify_boolean(FeatureService.enabled?(:reference_numbers_enabled)),
       submission_reference: FeatureService.enabled?(:reference_numbers_enabled) ? mailer_options.submission_reference : "",
+      include_payment_link: make_notify_boolean(mailer_options.payment_url.present?),
+      payment_link: mailer_options.payment_url || "",
     )
 
     set_reference(notify_response_id)

--- a/app/mailers/form_submission_mailer.rb
+++ b/app/mailers/form_submission_mailer.rb
@@ -14,6 +14,7 @@ class FormSubmissionMailer < GovukNotifyRails::Mailer
       not_test: make_notify_boolean(!mailer_options.preview_mode),
       include_submission_reference: make_notify_boolean(FeatureService.enabled?(:reference_numbers_enabled)),
       submission_reference: FeatureService.enabled?(:reference_numbers_enabled) ? mailer_options.submission_reference : "",
+      include_payment_link: make_notify_boolean(mailer_options.payment_url.present?),
     )
 
     set_reference(notify_response_id)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -32,4 +32,10 @@ class Form < ActiveResource::Base
   def live_at_date
     try(:live_at).try(:to_time)
   end
+
+  def payment_url_with_reference(reference)
+    return nil if payment_url.blank?
+
+    "#{payment_url}?reference=#{reference}"
+  end
 end

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -5,7 +5,7 @@ class FormSubmissionService
     end
   end
 
-  MailerOptions = Data.define(:title, :preview_mode, :timestamp, :submission_reference)
+  MailerOptions = Data.define(:title, :preview_mode, :timestamp, :submission_reference, :payment_url)
 
   def initialize(logging_context:, current_context:, request:, email_confirmation_form:, preview_mode:)
     @logging_context = logging_context
@@ -21,7 +21,8 @@ class FormSubmissionService
     @mailer_options = MailerOptions.new(title: form_title,
                                         preview_mode: @preview_mode,
                                         timestamp: @timestamp,
-                                        submission_reference: @submission_reference)
+                                        submission_reference: @submission_reference,
+                                        payment_url: @form.payment_url_with_reference(@submission_reference))
 
     if FeatureService.enabled?(:reference_numbers_enabled)
       @logging_context[:submission_reference] = @submission_reference

--- a/app/views/forms/submitted/_submitted_panel.html.erb
+++ b/app/views/forms/submitted/_submitted_panel.html.erb
@@ -1,0 +1,12 @@
+<%= govuk_panel(
+    title_text: current_context.form.payment_url.present? ? t('form.submitted.need_to_pay') : t('form.submitted.title'),
+    classes: class_names(
+      "govuk-!-margin-bottom-7",
+      { "app-panel--payment-required": current_context.form.payment_url.present? }
+    )
+) do %>
+  <% if FeatureService.enabled?(:reference_numbers_enabled) && current_context.get_submission_reference.present? %>
+    <%= t('form.submitted.your_reference') %><br>
+    <strong><%= current_context.get_submission_reference %></strong>
+  <% end %>
+<% end %>

--- a/app/views/forms/submitted/submitted.html.erb
+++ b/app/views/forms/submitted/submitted.html.erb
@@ -2,12 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_panel(title_text: t('form.submitted.title'), classes: ["govuk-!-margin-bottom-7"], ) do %>
-      <% if FeatureService.enabled?(:reference_numbers_enabled) && @current_context.get_submission_reference.present? %>
-        <%= t('form.submitted.your_reference') %><br>
-        <strong><%= @current_context.get_submission_reference %></strong>
-      <% end %>
-    <% end %>
+    <%= render partial: "forms/submitted/submitted_panel", locals: {current_context: @current_context, } %>
 
     <% if @current_context.requested_email_confirmation? %>
       <p><%= t('form.submitted.email_sent') %></p>
@@ -16,6 +11,10 @@
     <%if @current_context.form.what_happens_next_markdown.present? %>
       <h2 class="govuk-heading-m"><%= t('form.submitted.what_happens_next') %></h2>
       <%= HtmlMarkdownSanitizer.new.render_scrubbed_markdown(@current_context.form.what_happens_next_markdown) %>
+    <% end %>
+
+    <% if @current_context.form.payment_url.present? && FeatureService.enabled?(:reference_numbers_enabled) && @current_context.get_submission_reference.present? %>
+      <%= govuk_button_to(t('form.submitted.continue_to_pay'), @current_context.form.payment_url_with_reference(@current_context.get_submission_reference))%>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,7 +98,9 @@ en:
       submit: Submit
       title: Check your answers before submitting your form
     submitted:
+      continue_to_pay: Continue to pay
       email_sent: We’ve sent you a confirmation email.
+      need_to_pay: You still need to pay
       title: Your form has been submitted
       what_happens_next: What happens next
       your_reference: 'Your form reference number is:'

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     support_phone { nil }
     support_url { nil }
     support_url_text { nil }
+    payment_url { nil }
 
     declaration_text { nil }
     declaration_section_completed { false }
@@ -62,6 +63,10 @@ FactoryBot.define do
       pages do
         Array.new(pages_count) { association(:page, :with_selections_settings) }
       end
+    end
+
+    trait :with_payment_url do
+      payment_url { "https://www.gov.uk/payments/test-service/pay-for-licence" }
     end
   end
 end

--- a/spec/mailers/form_submission_mailer_spec.rb
+++ b/spec/mailers/form_submission_mailer_spec.rb
@@ -8,11 +8,13 @@ describe FormSubmissionMailer, type: :mailer do
   let(:submission_email) { "testing@gov.uk" }
   let(:submission_timestamp) { Time.zone.now }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+  let(:payment_url) { nil }
   let(:mailer_options) do
     FormSubmissionService::MailerOptions.new(title:,
                                              preview_mode:,
                                              timestamp: submission_timestamp,
-                                             submission_reference:)
+                                             submission_reference:,
+                                             payment_url:)
   end
 
   context "when form filler submits a completed form" do
@@ -40,6 +42,22 @@ describe FormSubmissionMailer, type: :mailer do
     it "does not use the preview personalisation" do
       expect(mail.govuk_notify_personalisation[:test]).to eq("no")
       expect(mail.govuk_notify_personalisation[:not_test]).to eq("yes")
+    end
+
+    context "when a payment url is in" do
+      let(:payment_url) { "https://www.gov.uk/payments/test-service/pay-for-licence?reference=#{submission_reference}" }
+
+      it "sets the boolean for the payment content to 'yes'" do
+        expect(mail.govuk_notify_personalisation[:include_payment_link]).to eq("yes")
+      end
+    end
+
+    context "when a payment link is not set" do
+      let(:payment_url) { nil }
+
+      it "sets the boolean for the payment content to 'no'" do
+        expect(mail.govuk_notify_personalisation[:include_payment_link]).to eq("no")
+      end
     end
 
     it "does include an email-reply-to" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -94,4 +94,25 @@ RSpec.describe Form, type: :model do
       end
     end
   end
+
+  describe "#payment_url_with_reference" do
+    let(:response_data) { { id: 1, name: "form name", payment_url:, start_page: 1 }.to_json }
+    let(:reference) { SecureRandom.base58(8).upcase }
+
+    context "when there is a payment_url" do
+      let(:payment_url) { "https://www.gov.uk/payments/test-service/pay-for-licence" }
+
+      it "returns a full payment link" do
+        expect(described_class.find(1).payment_url_with_reference(reference)).to eq("#{payment_url}?reference=#{reference}")
+      end
+    end
+
+    context "when there is no payment_url" do
+      let(:payment_url) { nil }
+
+      it "returns nil" do
+        expect(described_class.find(1).payment_url_with_reference(reference)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -283,6 +283,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
             not_test: "no",
             include_submission_reference: "no",
             submission_reference: "",
+            include_payment_link: "no",
           }
 
           expect(mail.body.raw_source).to match(expected_personalisation.to_s)
@@ -308,6 +309,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
             not_test: "no",
             include_submission_reference: "yes",
             submission_reference: reference,
+            include_payment_link: "no",
           }
 
           expect(mail.body.raw_source).to match(expected_personalisation.to_s)
@@ -354,6 +356,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           not_test: "yes",
           include_submission_reference: "no",
           submission_reference: "",
+          include_payment_link: "no",
         }
 
         expect(mail.body.raw_source).to match(expected_personalisation.to_s)
@@ -509,6 +512,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
             test: "no",
             include_submission_reference: "yes",
             submission_reference: reference,
+            include_payment_link: "no",
+            payment_link: "",
           }
 
           expect(mail.body.raw_source).to include(expected_personalisation.to_s)
@@ -534,6 +539,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
             test: "no",
             include_submission_reference: "no",
             submission_reference: "",
+            include_payment_link: "no",
+            payment_link: "",
           }
 
           expect(mail.body.raw_source).to include(expected_personalisation.to_s)

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe FormSubmissionService do
           support_phone:,
           support_url:,
           support_url_text:,
-          submission_email: "testing@gov.uk")
+          submission_email:,
+          payment_url:)
   end
   let(:what_happens_next_markdown) { "We usually respond to applications within 10 working days." }
   let(:support_email) { Faker::Internet.email(domain: "example.gov.uk") }
@@ -25,6 +26,8 @@ RSpec.describe FormSubmissionService do
   let(:preview_mode) { false }
   let(:email_confirmation_form) { build :email_confirmation_form_opted_in }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+  let(:payment_url) { nil }
+  let(:submission_email)  { "testing@gov.uk" }
 
   before do
     allow(SecureRandom).to receive(:base58).with(8).and_return(reference)
@@ -96,7 +99,7 @@ RSpec.describe FormSubmissionService do
 
     describe "validations" do
       context "when form has no submission email" do
-        let(:form) { OpenStruct.new(id: 1, form_name: "Form 1", submission_email: nil, steps: [step]) }
+        let(:submission_email) { nil }
 
         it "raises an error" do
           expect { service.submit_form_to_processing_team }.to raise_error("Form id(1) is missing a submission email address")
@@ -146,7 +149,7 @@ RSpec.describe FormSubmissionService do
 
       describe "validations" do
         context "when form has no submission email" do
-          let(:form) { OpenStruct.new(id: 1, form_name: "Form 1", submission_email: nil, steps: [step]) }
+          let(:submission_email) { nil }
 
           it "does not raise an error" do
             expect { service.submit_form_to_processing_team }.not_to raise_error

--- a/spec/views/forms/submitted/submitted.html.erb_spec.rb
+++ b/spec/views/forms/submitted/submitted.html.erb_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 describe "forms/submitted/submitted.html.erb" do
-  let(:form) { build :form, id: 1, what_happens_next_markdown: }
+  let(:form) { build :form, id: 1, what_happens_next_markdown:, payment_url: }
   let(:what_happens_next_markdown) { nil }
   let(:requested_email_confirmation) { false }
+  let(:payment_url) { nil }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 
   before do
@@ -22,6 +23,18 @@ describe "forms/submitted/submitted.html.erb" do
     it "displays the submission reference" do
       expect(rendered).to have_text(I18n.t("form.submitted.your_reference"))
       expect(rendered).to have_text(reference)
+    end
+
+    context "when there is a payment url for the form" do
+      let(:payment_url) { "https://www.gov.uk/payments/organisation/service" }
+
+      it "displays the need to pay panel" do
+        expect(rendered).to have_css(".app-panel--payment-required", text: I18n.t("form.submitted.need_to_pay"))
+      end
+
+      it "displays the payment button" do
+        expect(rendered).to have_button(I18n.t("form.submitted.continue_to_pay"))
+      end
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/Gfqxj8yV/1358-enable-taking-payments-in-forms-via-runner

Adds payment stuff when there is a `payment_url` for a given form. This adds content and modifies the `form_submitted` page. 

It also adds content to form submission and confirmation emails. This all relies on the reference number feature flag being turned on, as it's necessary for payments. When there isn't a `payment_url` for a given form, no content relating to payments should appear. 

In order for this to fully function, the gov.uk/notify templates will need to be updated so that they accept the additional fields. We have templates that contain the appropriate content, but they'll need to replace the main ones in order for this to fully go live!
