### PR TITLE
Generate user friendly reference numbers

### DIFF
--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -16,7 +16,7 @@ class FormSubmissionService
     @requested_email_confirmation = @email_confirmation_form.send_confirmation == "send_email"
     @preview_mode = preview_mode
     @timestamp = submission_timestamp
-    @submission_reference = generate_submission_reference
+    @submission_reference = ReferenceNumberService.generate
 
     @mailer_options = MailerOptions.new(title: form_title,
                                         preview_mode: @preview_mode,
@@ -177,9 +177,5 @@ private
     return nil if [@form.support_url, @form.support_url_text].all?(&:blank?)
 
     "[#{@form.support_url_text}](#{@form.support_url})"
-  end
-
-  def generate_submission_reference
-    SecureRandom.base58(8).upcase
   end
 end

--- a/app/services/reference_number_service.rb
+++ b/app/services/reference_number_service.rb
@@ -1,0 +1,17 @@
+class ReferenceNumberService
+  ALPHABETICAL_CHARACTER_SET = %w[A B C D E F G H J K L M N P R S T U V W X Y].freeze
+  NUMERIC_CHARACTER_SET = %w[2 3 4 5 6 7 8 9].freeze
+  ALPHANUMERIC_CHARACTER_SET = ALPHABETICAL_CHARACTER_SET + NUMERIC_CHARACTER_SET
+  REFERENCE_LENGTH = 8
+
+  def self.generate
+    (0...REFERENCE_LENGTH)
+      .map { |i|
+        if i % 3 == 2
+          NUMERIC_CHARACTER_SET.sample
+        else
+          ALPHANUMERIC_CHARACTER_SET.sample
+        end
+      }.join
+  end
+end

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       context_spy
     end
 
-    allow(SecureRandom).to receive(:base58).with(8).and_return(reference)
+    allow(ReferenceNumberService).to receive(:generate).and_return(reference)
   end
 
   describe "#show" do

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe FormSubmissionService do
   let(:submission_email)  { "testing@gov.uk" }
 
   before do
-    allow(SecureRandom).to receive(:base58).with(8).and_return(reference)
+    allow(ReferenceNumberService).to receive(:generate).and_return(reference)
   end
 
   describe "#submit" do

--- a/spec/services/reference_number_service_spec.rb
+++ b/spec/services/reference_number_service_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe ReferenceNumberService do
+  describe ".genereate" do
+    it "generates an 8 character string" do
+      expect(described_class.generate.length).to eq(8)
+    end
+
+    it "generates the 3rd and 6th characters as digits" do
+      result = described_class.generate
+      digit_regex = /\d/
+      expect(result[2]).to match(digit_regex)
+      expect(result[5]).to match(digit_regex)
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?
https://trello.com/c/4lWx25f7/1426-update-form-reference-number-generation-logic

We want to try and match [GOV.UK Pay's reference number generation](https://github.com/alphagov/pay-products/blob/master/src/main/java/uk/gov/pay/products/util/RandomIdGenerator.java#L34), as these will be user facing numbers and we want to avoid any user unfriendly results. 

This should generate a 10 character reference, with the 3rd and 7th character always being a number. The characters `Z, I, 1, O and 0` are excluded as they're too confusable with each other (Z and 2 except keeping 2 is alright). 

Suggestions on how to make this more readable are welcome!

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
