### PR TITLE
Rake tasks for pushing commits to the dev environment

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -1,0 +1,77 @@
+require "English"
+require "json"
+require "net/http"
+require "shellwords"
+
+desc "Push the commit at the tip of the current branch to the dev environment"
+task push_to_dev: :environment do
+  puts "Getting Git commit..."
+  git_hash = `git rev-parse HEAD`.chomp
+  $CHILD_STATUS.success? or raise
+
+  puts "Will use Git commit: #{git_hash}"
+  puts "Checking commit has been pushed..."
+
+  resp = Net::HTTP.get_response URI("https://api.github.com/repos/alphagov/forms-runner/commits/#{git_hash}")
+  if resp.code != "200"
+    puts "Commit has not been pushed. The pipelines will not be able to find it."
+    puts "Push the commit and run the command again."
+    raise
+  end
+  puts "The commit is present in the remote"
+
+  push_commit_to_dev(git_hash)
+end
+
+desc "Push the commit at the tip of origin/main to the dev environment"
+task reset_dev_to_main: :environment do
+  puts "Updating Git remotes"
+  sh "git", "fetch", verbose: false
+
+  git_hash = `git rev-parse origin/main`.chomp
+  $CHILD_STATUS.success? or raise
+
+  puts "Will use Git commit from tip of origin/main: #{git_hash}"
+
+  push_commit_to_dev(git_hash)
+end
+
+def push_commit_to_dev(git_hash)
+  json_input = {
+    name: "forms-runner-image-builder",
+    sourceRevisions: [
+      {
+        actionName: "get-forms-runner",
+        revisionType: "COMMIT_ID",
+        revisionValue: git_hash,
+      },
+    ],
+    variables: [
+      {
+        name: "tag_prefix",
+        value: "dev-",
+      },
+    ],
+  }
+
+  puts ""
+  puts "Starting pipeline 'forms-runner-image-builder' in the 'deploy' account"
+  pp json_input
+
+  cli_input = JSON.dump(json_input)
+  command_args = [
+    "aws",
+    "codepipeline",
+    "start-pipeline-execution",
+    "--name",
+    "forms-runner-image-builder",
+    "--cli-input-json",
+    cli_input,
+  ]
+  sh_aws(*command_args)
+end
+
+def sh_aws(*cmd)
+  all_args = ["gds", "aws", "forms-deploy-support", "--", *cmd]
+  system({ **ENV, "AWS_VAULT" => nil }, *all_args, exception: true)
+end


### PR DESCRIPTION
What problem does this pull request solve?

 [Trello card](https://trello.com/c/Z8G6L6zt/388-add-dev-environment-support-tooling-to-all-repos)

To push a commit to a dev environment, we invoke an image building pipeline to produce an image with a specific prefix ("dev-"), which triggers the dev deployment pipelines.

This commit adds two Rake tasks:

push_to_dev
reset_dev_to_main

The former deploys the commit at the tip of the current branch to dev. The latter deploys the commit at the tip of main, after updating the remotes to get the very latest commits.