### PR TITLE
Stop elements other than summary list going full width

### DIFF
--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -6,24 +6,32 @@
   <% end %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="<%= @full_width ? 'govuk-grid-column-full' : 'govuk-grid-column-two-thirds-from-desktop' %>">
-    <%= form_with model: email_confirmation_form, url: @form_submit_path do |form| %>
+<%= form_with model: email_confirmation_form, url: @form_submit_path do |form| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       <% if email_confirmation_form&.errors&.any? %>
         <%= form.govuk_error_summary %>
       <% end %>
 
       <h1 class="govuk-heading-l">Check your answers before submitting your form</h1>
+    </div>
+  </div>
 
+  <div class="govuk-grid-row">
+    <div class="<%= @full_width ? 'govuk-grid-column-full' : 'govuk-grid-column-two-thirds-from-desktop' %>">
       <%if @rows %>
         <%= govuk_summary_list(rows: @rows.map { |row|
-          { key: row[:key],
-            value: { text: format_paragraphs(row[:value][:text].present? ? row[:value][:text] : t('form.check_your_answers.not_completed')) },
-            actions: row[:actions]
-          } })
-        %>
+            { key: row[:key],
+              value: { text: format_paragraphs(row[:value][:text].present? ? row[:value][:text] : t('form.check_your_answers.not_completed')) },
+              actions: row[:actions]
+            } })
+          %>
       <% end %>
+    </div>
+  </div>
 
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       <%= form.govuk_radio_buttons_fieldset(:send_confirmation, legend: { size: 'm', tag: 'h2' }) do %>
         <%= form.govuk_radio_button :send_confirmation, 'send_email' do %>
           <%= form.govuk_email_field :confirmation_email_address, autocomplete: 'email', spellcheck: false  %>
@@ -41,6 +49,6 @@
       <%= form.hidden_field :submission_email_reference, id: 'submission-email-reference' %>
 
       <%= form.govuk_submit(@current_context.form.declaration_text.present? ? t('form.check_your_answers.agree_and_submit') : t('form.check_your_answers.submit')) %>
-    <% end %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -6,12 +6,20 @@ describe "forms/check_your_answers/show.html.erb" do
   let(:full_width) { false }
   let(:declaration_text) { nil }
   let(:email_confirmation_form) { build :email_confirmation_form }
+  let(:rows) do
+    [
+      { key: { text: "Do you want to remain anonymous?" },
+        value: { text: "Yes" },
+        actions: [{ href: "/change", visually_hidden_text: "Do you want to remain anonymous?" }] },
+    ]
+  end
 
   before do
     assign(:current_context, context)
     assign(:mode, OpenStruct.new(preview_draft?: false, preview_archived?: false, preview_live?: false))
     assign(:form_submit_path, "/")
     assign(:full_width, full_width)
+    assign(:rows, rows)
     render template: "forms/check_your_answers/show", locals: { email_confirmation_form: }
   end
 
@@ -35,15 +43,37 @@ describe "forms/check_your_answers/show.html.erb" do
     end
   end
 
-  it "displays two-thirds" do
-    expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop")
+  it "displays the summary list two-thirds width" do
+    expect(rendered).not_to have_css(".govuk-grid-column-full .govuk-summary-list")
+    expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop .govuk-summary-list")
   end
 
-  context "when full_width not set" do
+  it "displays the title at two-thirds width" do
+    expect(rendered).not_to have_css(".govuk-grid-column-full h1")
+    expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop h1")
+  end
+
+  it "displays the email confirmation form at two-thirds width" do
+    expect(rendered).not_to have_css(".govuk-grid-column-full input[type='radio']")
+    expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop input[type='radio']")
+  end
+
+  context "when full_width is true" do
     let(:full_width) { true }
 
-    it "displays full width when set" do
-      expect(rendered).to have_css(".govuk-grid-column-full")
+    it "displays the summary list full width" do
+      expect(rendered).not_to have_css(".govuk-grid-column-two-thirds-from-desktop .govuk-summary-list")
+      expect(rendered).to have_css(".govuk-grid-column-full .govuk-summary-list")
+    end
+
+    it "displays the title at two-thirds width" do
+      expect(rendered).not_to have_css(".govuk-grid-column-full h1")
+      expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop h1")
+    end
+
+    it "displays the email confirmation form at two-thirds width" do
+      expect(rendered).not_to have_css(".govuk-grid-column-full input[type='radio']")
+      expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop input[type='radio']")
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/hv6KQQUr/1224-check-your-answers-page-width

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
We have logic to make the summary list full width if the form contains a long text question. This is intended, but the original implementation made the _whole page_ full width, rather than just the summary list.

This PR puts the summary list in a separate grid row from the other elements on the page, and applies the full width logic to this row only. 

### Screenshots
#### Before
![Screenshot of the check your answers form, where one of the answers is a long piece of text describing the issue this PR fixes. The heading, summary list, confirmation email form and declaration all expand to the full width of the page wrapper.](https://github.com/alphagov/forms-runner/assets/5861235/53698077-4848-4b95-bba2-fc74da1cc2ad)

#### After
![Screenshot of the check your answers form, where one of the answers is a long piece of text describing the issue this PR fixes. The summary list expands to the full width of the page wrapper. The heading, confirmation email form and declaration all remain limited to two-thirds of the page wrapper's width.](https://github.com/alphagov/forms-runner/assets/5861235/a757df0b-3f68-4511-9fa5-922fc48f41f3)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
