### PR TITLE
Serve static files by default

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   # config.require_master_key = true
 
   # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  # config.public_file_server.enabled = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

For production environments we currently need to have RAILS_SERVE_STATIC_FILES=1 set in the environment, as Vite places the frontend assets in the public assets and we don't have another way of serving them. We don't have any plans to use a separate static asset server, so we don't really need the flexibility of the environment variable, and removing the need to set one would simplify our app deployment configuration and local testing.

This commit removes the line querying the environment variable from the environment config, so now the app will default to serving files from the public folder. Once this has been merged and deployed we can remove the configuration line from [forms-deploy](https://github.com/alphagov/forms-deploy/blob/0190f26e13080ad7f6c26131587a157a846add5d/infra/modules/forms-runner/main.tf#L78-L81).

This matches the default configuration for Rails 7.1 [[1], [2]].

[1]: https://github.com/rails/rails/pull/47137
[2]: https://github.com/rails/rails/blob/6f0d1ad14b92b9f5906e44740fce8b4f1c7075dc/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt#L25-L26

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?