### PR TITLE
Log event if form submission occurs with incomplete session

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -17,6 +17,12 @@ module Forms
         if current_context.form_submitted?
           redirect_to error_repeat_submission_path(current_form.id)
         else
+          unless current_context.can_visit?(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)
+            message = "current_context.can_visit? is false, about to do incomplete or repeat submission?"
+            EventLogger.log_form_event(logging_context, "incomplete_or_repeat_submission_error")
+            Sentry.capture_message(message)
+          end
+
           submission_reference = FormSubmissionService.call(logging_context:,
                                                             current_context:,
                                                             request:,


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/x8aQr5Y6/ <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We have found that in some scenarios users can POST to the check answers page with an incomplete session. We're not yet sure how best to deal with these scenarios, but adding specific logging will let us get an idea of how often this is happening.

This has been tested in dev, see [Splunk][1], [Sentry][2].

[1]: https://gds.splunkcloud.com/en-GB/app/gds-543-forms/search?q=search%20index%3D%22gds_dsp_dev_forms%22%20source%3D%22*forms-runner*%22%20time%3D%222024-04-26T08%3A06%3A45.268%2B00%3A00%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-30m%40m&latest=now&sid=1714119042.839292
[2]: https://govuk-forms.sentry.io/issues/5259524304/

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?