### PR TITLE
Rename form objects to have suffix "Input"

### DIFF
--- a/app/input_objects/email_confirmation_input.rb
+++ b/app/input_objects/email_confirmation_input.rb
@@ -1,4 +1,4 @@
-class EmailConfirmationForm
+class EmailConfirmationInput
   include ActiveModel::Model
   include ActiveModel::Validations
 

--- a/app/mailers/form_submission_mailer.rb
+++ b/app/mailers/form_submission_mailer.rb
@@ -1,5 +1,5 @@
 class FormSubmissionMailer < GovukNotifyRails::Mailer
-  def email_completed_form(text_input:, notify_response_id:, submission_email:, mailer_options:)
+  def email_confirmation_input(text_input:, notify_response_id:, submission_email:, mailer_options:)
     set_template(Settings.govuk_notify.form_submission_email_template_id)
 
     set_personalisation(

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -7,13 +7,13 @@ class FormSubmissionService
 
   MailerOptions = Data.define(:title, :preview_mode, :timestamp, :submission_reference, :payment_url)
 
-  def initialize(logging_context:, current_context:, request:, email_confirmation_form:, preview_mode:)
+  def initialize(logging_context:, current_context:, request:, email_confirmation_input:, preview_mode:)
     @logging_context = logging_context
     @current_context = current_context
     @request = request
     @form = current_context.form
-    @email_confirmation_form = email_confirmation_form
-    @requested_email_confirmation = @email_confirmation_form.send_confirmation == "send_email"
+    @email_confirmation_input = email_confirmation_input
+    @requested_email_confirmation = @email_confirmation_input.send_confirmation == "send_email"
     @preview_mode = preview_mode
     @timestamp = submission_timestamp
     @submission_reference = ReferenceNumberService.generate
@@ -45,10 +45,10 @@ class FormSubmissionService
     unless @form.submission_email.blank? && @preview_mode
 
       mail = FormSubmissionMailer
-      .email_completed_form(text_input: email_body,
-                            notify_response_id: @email_confirmation_form.submission_email_reference,
-                            submission_email: @form.submission_email,
-                            mailer_options: @mailer_options).deliver_now
+      .email_confirmation_input(text_input: email_body,
+                                notify_response_id: @email_confirmation_input.submission_email_reference,
+                                submission_email: @form.submission_email,
+                                mailer_options: @mailer_options).deliver_now
 
       @logging_context[:notification_ids] ||= {}
       @logging_context[:notification_ids][:submission_email_id] = mail.govuk_notify_response.id
@@ -64,8 +64,8 @@ class FormSubmissionService
     mail = FormSubmissionConfirmationMailer.send_confirmation_email(
       what_happens_next_markdown: @form.what_happens_next_markdown,
       support_contact_details: formatted_support_details,
-      notify_response_id: @email_confirmation_form.confirmation_email_reference,
-      confirmation_email_address: @email_confirmation_form.confirmation_email_address,
+      notify_response_id: @email_confirmation_input.confirmation_email_reference,
+      confirmation_email_address: @email_confirmation_input.confirmation_email_address,
       mailer_options: @mailer_options,
     ).deliver_now
 

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -6,10 +6,10 @@
   <% end %>
 <% end %>
 
-<%= form_with model: email_confirmation_form, url: @form_submit_path do |form| %>
+<%= form_with model: email_confirmation_input, url: @form_submit_path do |form| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <% if email_confirmation_form&.errors&.any? %>
+      <% if email_confirmation_input&.errors&.any? %>
         <%= form.govuk_error_summary %>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
   activemodel:
     errors:
       models:
-        email_confirmation_form:
+        email_confirmation_input:
           attributes:
             confirmation_email_address:
               blank: Enter an email address
@@ -106,16 +106,16 @@ en:
       your_reference: 'Your form reference number is:'
   helpers:
     hint:
-      email_confirmation_form:
+      email_confirmation_input:
         send_confirmation: We’ll only use the email address you provide here to send a confirmation that your form’s been successfully submitted. It will not contain a copy of your answers.
     label:
-      email_confirmation_form:
+      email_confirmation_input:
         confirmation_email_address: What email address do you want us to send your confirmation to?
         send_confirmation_options:
           send_email: 'Yes'
           skip_confirmation: 'No'
     legend:
-      email_confirmation_form:
+      email_confirmation_input:
         send_confirmation: Do you want to get an email confirming your form has been submitted?
   mode:
     phase_banner_tag_preview-archived: Archived preview

--- a/spec/factories/input_objects/email_confirmation_input.rb
+++ b/spec/factories/input_objects/email_confirmation_input.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
-  factory :email_confirmation_form, class: "EmailConfirmationForm" do
+  factory :email_confirmation_input, class: "EmailConfirmationInput" do
     send_confirmation { nil }
     confirmation_email_address { nil }
     submission_email_reference { "ffffffff-submission-email" }
     confirmation_email_reference { "ffffffff-confirmation-email" }
 
-    factory :email_confirmation_form_opted_in do
+    factory :email_confirmation_input_opted_in do
       send_confirmation { "send_email" }
       confirmation_email_address { Faker::Internet.email }
     end

--- a/spec/input_objects/email_confirmation_input_spec.rb
+++ b/spec/input_objects/email_confirmation_input_spec.rb
@@ -1,45 +1,45 @@
 require "rails_helper"
 
-RSpec.describe EmailConfirmationForm, type: :model do
-  let(:email_confirmation_form) { build :email_confirmation_form }
+RSpec.describe EmailConfirmationInput, type: :model do
+  let(:email_confirmation_input) { build :email_confirmation_input }
 
   context "when the email confirmations flag is enabled" do
     context "when given an empty string or nil" do
       it "returns invalid with blank email" do
-        expect(email_confirmation_form).not_to be_valid
-        expect(email_confirmation_form.errors[:send_confirmation]).to include(I18n.t("activemodel.errors.models.email_confirmation_form.attributes.send_confirmation.blank"))
+        expect(email_confirmation_input).not_to be_valid
+        expect(email_confirmation_input.errors[:send_confirmation]).to include(I18n.t("activemodel.errors.models.email_confirmation_input.attributes.send_confirmation.blank"))
       end
     end
 
     context "when user opts in and provides a valid email address" do
-      let(:email_confirmation_form) { build :email_confirmation_form_opted_in }
+      let(:email_confirmation_input) { build :email_confirmation_input_opted_in }
 
       it "validates" do
-        expect(email_confirmation_form).to be_valid
-        expect(email_confirmation_form.errors[:confirmation_email_address]).to be_empty
+        expect(email_confirmation_input).to be_valid
+        expect(email_confirmation_input.errors[:confirmation_email_address]).to be_empty
       end
     end
 
     context "when user opts in and provides an invalid email address" do
-      let(:email_confirmation_form) { build :email_confirmation_form_opted_in, confirmation_email_address: "not an email address" }
+      let(:email_confirmation_input) { build :email_confirmation_input_opted_in, confirmation_email_address: "not an email address" }
 
       it "does not validate an address without an @" do
-        expect(email_confirmation_form).not_to be_valid
-        expect(email_confirmation_form.errors[:confirmation_email_address]).to include(I18n.t("activemodel.errors.models.email_confirmation_form.attributes.confirmation_email_address.invalid_email"))
+        expect(email_confirmation_input).not_to be_valid
+        expect(email_confirmation_input.errors[:confirmation_email_address]).to include(I18n.t("activemodel.errors.models.email_confirmation_input.attributes.confirmation_email_address.invalid_email"))
       end
     end
 
     context "when send_confirmation is false" do
-      let(:email_confirmation_form) { build :email_confirmation_form, send_confirmation: "skip_confirmation" }
+      let(:email_confirmation_input) { build :email_confirmation_input, send_confirmation: "skip_confirmation" }
 
       it "returns valid with blank email" do
-        expect(email_confirmation_form).to be_valid
-        expect(email_confirmation_form.errors[:confirmation_email_address]).to be_empty
+        expect(email_confirmation_input).to be_valid
+        expect(email_confirmation_input.errors[:confirmation_email_address]).to be_empty
       end
 
       it "returns valid with empty string" do
-        email_confirmation_form.confirmation_email_address = ""
-        expect(email_confirmation_form).to be_valid
+        email_confirmation_input.confirmation_email_address = ""
+        expect(email_confirmation_input).to be_valid
       end
     end
   end
@@ -47,12 +47,12 @@ RSpec.describe EmailConfirmationForm, type: :model do
   describe "submission references" do
     uuid = /[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}/
 
-    let(:email_confirmation_form) do
+    let(:email_confirmation_input) do
       described_class.new
     end
 
-    let(:submission_email_reference) { email_confirmation_form.submission_email_reference }
-    let(:confirmation_email_reference) { email_confirmation_form.confirmation_email_reference }
+    let(:submission_email_reference) { email_confirmation_input.submission_email_reference }
+    let(:confirmation_email_reference) { email_confirmation_input.confirmation_email_reference }
 
     it "generates a random submission notification reference" do
       expect(submission_email_reference)
@@ -75,7 +75,7 @@ RSpec.describe EmailConfirmationForm, type: :model do
     end
 
     context "when intialised with references" do
-      let(:email_confirmation_form) do
+      let(:email_confirmation_input) do
         described_class.new(
           confirmation_email_reference: "foo",
           submission_email_reference: "bar",

--- a/spec/mailers/form_submission_mailer_spec.rb
+++ b/spec/mailers/form_submission_mailer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe FormSubmissionMailer, type: :mailer do
-  let(:mail) { described_class.email_completed_form(text_input:, notify_response_id: "for-my-ref", submission_email:, mailer_options:) }
+  let(:mail) { described_class.email_confirmation_input(text_input:, notify_response_id: "for-my-ref", submission_email:, mailer_options:) }
   let(:title) { "Form 1" }
   let(:text_input) { "My question: My answer" }
   let(:preview_mode) { false }

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe ErrorsController, type: :request do
         mode: "form",
         form_id: 2,
         form_slug: "form-name",
-        email_confirmation_form: {
+        email_confirmation_input: {
           send_confirmation: "skip_confirmation",
           notify_reference: "test-ref",
         },

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           pages: pages_data)
   end
 
-  let(:email_confirmation_form) do
+  let(:email_confirmation_input) do
     { send_confirmation: "send_email",
       confirmation_email_address: Faker::Internet.email,
       confirmation_email_reference: "confirmation-email-ref",
@@ -94,7 +94,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
   describe "#show" do
     shared_examples "for notification references" do
       prepend_before do
-        allow(EmailConfirmationForm).to receive(:new).and_wrap_original do |original_method, *args|
+        allow(EmailConfirmationInput).to receive(:new).and_wrap_original do |original_method, *args|
           double = original_method.call(*args)
           allow(double).to receive(:confirmation_email_reference).and_return("00000000-confirmation-email")
           allow(double).to receive(:submission_email_reference).and_return("00000000-submission-email")
@@ -236,7 +236,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     before do
       allow_mailer_to_return_mail_with_govuk_notify_response_with(
         FormSubmissionMailer,
-        :email_completed_form,
+        :email_confirmation_input,
         id: "1111",
       )
       allow_mailer_to_return_mail_with_govuk_notify_response_with(
@@ -249,8 +249,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     shared_examples "for notification references" do
       it "includes the notification references in the logging_context" do
         expect(logging_context).to include(notification_references: {
-          confirmation_email_reference: email_confirmation_form[:confirmation_email_reference],
-          submission_email_reference: email_confirmation_form[:submission_email_reference],
+          confirmation_email_reference: email_confirmation_input[:confirmation_email_reference],
+          submission_email_reference: email_confirmation_input[:submission_email_reference],
         }.compact)
       end
     end
@@ -258,7 +258,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     context "with preview mode on" do
       before do
         travel_to frozen_time do
-          post form_submit_answers_path("preview-live", 2, "form-name", 1), params: { email_confirmation_form: }
+          post form_submit_answers_path("preview-live", 2, "form-name", 1), params: { email_confirmation_input: }
         end
       end
 
@@ -332,7 +332,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     context "with preview mode off" do
       before do
         travel_to frozen_time do
-          post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_form: }
+          post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_input: }
         end
       end
 
@@ -377,7 +377,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       let(:repeat_form_submission) { true }
 
       before do
-        post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_form: }
+        post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_input: }
       end
 
       it "redirects to repeat submission error page" do
@@ -386,7 +386,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     end
 
     context "when user has not specified whether they want a confirmation email" do
-      let(:email_confirmation_form) do
+      let(:email_confirmation_input) do
         {
           send_confirmation: nil,
           confirmation_email_reference: "test-ref-for-confirmation-email",
@@ -395,7 +395,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       end
 
       before do
-        post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_form: }
+        post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_input: }
       end
 
       it "return 422 error code" do
@@ -413,7 +413,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     end
 
     context "when user has not specified the confirmation email address" do
-      let(:email_confirmation_form) do
+      let(:email_confirmation_input) do
         {
           send_confirmation: "send_email",
           confirmation_email_address: nil,
@@ -423,7 +423,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       end
 
       before do
-        post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_form: }
+        post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_input: }
       end
 
       it "return 422 error code" do
@@ -443,7 +443,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     end
 
     context "when user has not requested a confirmation email" do
-      let(:email_confirmation_form) do
+      let(:email_confirmation_input) do
         {
           send_confirmation: "skip_confirmation",
           confirmation_email_address: nil,
@@ -453,7 +453,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       end
 
       before do
-        post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_form: }
+        post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_input: }
       end
 
       it "redirects to confirmation page" do
@@ -478,7 +478,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     end
 
     context "when user has requested a confirmation email" do
-      let(:email_confirmation_form) do
+      let(:email_confirmation_input) do
         { send_confirmation: "send_email",
           confirmation_email_address: Faker::Internet.email,
           confirmation_email_reference: "confirmation-email-ref",
@@ -487,7 +487,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
       before do
         travel_to timestamp_of_request do
-          post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_form: }
+          post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_input: }
         end
       end
 
@@ -501,7 +501,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           expect(deliveries.length).to eq 2
 
           mail = deliveries[1]
-          expect(mail.to).to eq([email_confirmation_form[:confirmation_email_address]])
+          expect(mail.to).to eq([email_confirmation_input[:confirmation_email_address]])
 
           expected_personalisation = {
             title: form_data.name,
@@ -528,7 +528,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           expect(deliveries.length).to eq 2
 
           mail = deliveries[1]
-          expect(mail.to).to eq([email_confirmation_form[:confirmation_email_address]])
+          expect(mail.to).to eq([email_confirmation_input[:confirmation_email_address]])
 
           expected_personalisation = {
             title: form_data.name,
@@ -561,7 +561,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     end
 
     context "when there is a submission error" do
-      let(:email_confirmation_form) do
+      let(:email_confirmation_input) do
         { send_confirmation: "send_email",
           confirmation_email_address: Faker::Internet.email,
           confirmation_email_reference: "confirmation-email-ref",
@@ -573,7 +573,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         allow(Sentry).to receive(:capture_exception)
 
         travel_to timestamp_of_request do
-          post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_form: }
+          post form_submit_answers_path("form", 2, "form-name", 1), params: { email_confirmation_input: }
         end
       end
 

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe FormSubmissionService do
-  let(:service) { described_class.call(logging_context:, current_context:, request:, email_confirmation_form:, preview_mode:) }
+  let(:service) { described_class.call(logging_context:, current_context:, request:, email_confirmation_input:, preview_mode:) }
   let(:form) do
     build(:form,
           id: 1,
@@ -24,7 +24,7 @@ RSpec.describe FormSubmissionService do
   let(:request) { OpenStruct.new({ url: "url", method: "method" }) }
   let(:step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer_in_email: "42" }) }
   let(:preview_mode) { false }
-  let(:email_confirmation_form) { build :email_confirmation_form_opted_in }
+  let(:email_confirmation_input) { build :email_confirmation_input_opted_in }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
   let(:payment_url) { nil }
   let(:submission_email)  { "testing@gov.uk" }
@@ -57,13 +57,13 @@ RSpec.describe FormSubmissionService do
   describe "#submit_form_to_processing_team" do
     it "calls FormSubmissionMailer" do
       freeze_time do
-        allow(FormSubmissionMailer).to receive(:email_completed_form).and_call_original
+        allow(FormSubmissionMailer).to receive(:email_confirmation_input).and_call_original
 
         service.submit_form_to_processing_team
 
-        expect(FormSubmissionMailer).to have_received(:email_completed_form).with(
+        expect(FormSubmissionMailer).to have_received(:email_confirmation_input).with(
           { text_input: "# What is the meaning of life?\n42\n",
-            notify_response_id: email_confirmation_form.submission_email_reference,
+            notify_response_id: email_confirmation_input.submission_email_reference,
             submission_email: "testing@gov.uk",
             mailer_options: instance_of(FormSubmissionService::MailerOptions) },
         ).once
@@ -73,7 +73,7 @@ RSpec.describe FormSubmissionService do
     it "adds the notification ID to the logging context" do
       allow_mailer_to_return_mail_with_govuk_notify_response_with(
         FormSubmissionMailer,
-        :email_completed_form,
+        :email_confirmation_input,
         id: "id-for-submission-email-notification",
       )
 
@@ -121,13 +121,13 @@ RSpec.describe FormSubmissionService do
 
       it "calls FormSubmissionMailer" do
         freeze_time do
-          allow(FormSubmissionMailer).to receive(:email_completed_form).and_call_original
+          allow(FormSubmissionMailer).to receive(:email_confirmation_input).and_call_original
 
           service.submit_form_to_processing_team
 
-          expect(FormSubmissionMailer).to have_received(:email_completed_form).with(
+          expect(FormSubmissionMailer).to have_received(:email_confirmation_input).with(
             { text_input: "# What is the meaning of life?\n42\n",
-              notify_response_id: email_confirmation_form.submission_email_reference,
+              notify_response_id: email_confirmation_input.submission_email_reference,
               submission_email: "testing@gov.uk",
               mailer_options: instance_of(FormSubmissionService::MailerOptions) },
           ).once
@@ -156,11 +156,11 @@ RSpec.describe FormSubmissionService do
           end
 
           it "does not call the FormSubmissionMailer" do
-            allow(FormSubmissionMailer).to receive(:email_completed_form).at_least(:once)
+            allow(FormSubmissionMailer).to receive(:email_confirmation_input).at_least(:once)
 
             service.submit_form_to_processing_team
 
-            expect(FormSubmissionMailer).not_to have_received(:email_completed_form)
+            expect(FormSubmissionMailer).not_to have_received(:email_confirmation_input)
           end
         end
 
@@ -185,15 +185,15 @@ RSpec.describe FormSubmissionService do
         expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
           { what_happens_next_markdown: form.what_happens_next_markdown,
             support_contact_details: contact_support_details_format,
-            notify_response_id: email_confirmation_form.confirmation_email_reference,
-            confirmation_email_address: email_confirmation_form.confirmation_email_address,
+            notify_response_id: email_confirmation_input.confirmation_email_reference,
+            confirmation_email_address: email_confirmation_input.confirmation_email_address,
             mailer_options: instance_of(FormSubmissionService::MailerOptions) },
         ).once
       end
     end
 
     context "when user does not want a confirmation email" do
-      let(:email_confirmation_form) { build :email_confirmation_form }
+      let(:email_confirmation_input) { build :email_confirmation_input }
 
       it "does not call FormSubmissionConfirmationMailer" do
         allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email)

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -5,7 +5,7 @@ describe "forms/check_your_answers/show.html.erb" do
   let(:context) { OpenStruct.new(form:) }
   let(:full_width) { false }
   let(:declaration_text) { nil }
-  let(:email_confirmation_form) { build :email_confirmation_form }
+  let(:email_confirmation_input) { build :email_confirmation_input }
   let(:rows) do
     [
       { key: { text: "Do you want to remain anonymous?" },
@@ -20,7 +20,7 @@ describe "forms/check_your_answers/show.html.erb" do
     assign(:form_submit_path, "/")
     assign(:full_width, full_width)
     assign(:rows, rows)
-    render template: "forms/check_your_answers/show", locals: { email_confirmation_form: }
+    render template: "forms/check_your_answers/show", locals: { email_confirmation_input: }
   end
 
   context "when the form does not have a declaration" do
@@ -78,28 +78,28 @@ describe "forms/check_your_answers/show.html.erb" do
   end
 
   it "contains a hidden notify reference for the submission email" do
-    expect(rendered).to have_field("submission-email-reference", type: :hidden, with: email_confirmation_form.submission_email_reference)
+    expect(rendered).to have_field("submission-email-reference", type: :hidden, with: email_confirmation_input.submission_email_reference)
   end
 
   it "displays the email radio buttons" do
-    expect(rendered).to have_text(I18n.t("helpers.legend.email_confirmation_form.send_confirmation"))
-    expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_form.send_confirmation_options.send_email"))
-    expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_form.send_confirmation_options.skip_confirmation"))
+    expect(rendered).to have_text(I18n.t("helpers.legend.email_confirmation_input.send_confirmation"))
+    expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_input.send_confirmation_options.send_email"))
+    expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_input.send_confirmation_options.skip_confirmation"))
   end
 
   it "displays the email field" do
     expect(rendered).to have_field(
-      I18n.t("helpers.label.email_confirmation_form.confirmation_email_address"),
+      I18n.t("helpers.label.email_confirmation_input.confirmation_email_address"),
       type: "email",
     )
   end
 
   it "email field has correct atttributes set" do
-    expect(rendered).to have_selector("input[name='email_confirmation_form[confirmation_email_address]'][autocomplete='email'][spellcheck='false']")
+    expect(rendered).to have_selector("input[name='email_confirmation_input[confirmation_email_address]'][autocomplete='email'][spellcheck='false']")
   end
 
   it "contains a hidden notify reference for the confirmation email" do
-    expect(rendered).to have_field("confirmation-email-reference", type: "hidden", with: email_confirmation_form.confirmation_email_reference)
+    expect(rendered).to have_field("confirmation-email-reference", type: "hidden", with: email_confirmation_input.confirmation_email_reference)
   end
 
   # TODO: add view tests for playing back questions and Answers


### PR DESCRIPTION
### What problem does this pull request solve?

The suffix "Form" for form objects which represent the input fields on a HTML form was difficult to work with, as we have a "Form" entity represing a GOV.UK Forms form, which is used throughout the application.

Use the suffix "Input" for form objects, to hopefully avoid this point of confusion.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
