### PR TITLE
Introduce Rake tasks for pausing, unpausing, and getting the status of pipelines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,9 @@ gem "uk_postcode"
 # For structured logging
 gem "lograge"
 
+# For AWS interactions
 gem "aws-sdk-cloudwatch"
+gem "aws-sdk-codepipeline", "~> 1.72"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,9 @@ GEM
     aws-sdk-cloudwatch (1.91.0)
       aws-sdk-core (~> 3, >= 3.193.0)
       aws-sigv4 (~> 1.1)
+    aws-sdk-codepipeline (1.72.0)
+      aws-sdk-core (~> 3, >= 3.193.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-core (3.196.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
@@ -438,6 +441,7 @@ PLATFORMS
 DEPENDENCIES
   activeresource
   aws-sdk-cloudwatch
+  aws-sdk-codepipeline (~> 1.72)
   axe-core-rspec
   bootsnap
   brakeman (~> 6.1)

--- a/README.md
+++ b/README.md
@@ -217,6 +217,37 @@ To update the version of [Alpine Linux] and Ruby used in the Dockerfile, use the
 
 [Alpine Linux]: https://www.alpinelinux.org/
 
+### Working with pipelines
+You can work with the forms-runner pipelines in different environments using Rake tasks
+
+#### Pause
+To pause the pipeline in an environment, run
+
+```shell
+rake pipeline:ENV:pause
+```
+
+where `ENV` is the name of the environment you want to work with, for example `dev` or `prod`.
+
+#### Unpause
+To unpause the pipeline in an environment, run
+
+```shell
+rake pipeline:ENV:unpause
+```
+
+where `ENV` is the name of the environment you want to work with, for example `dev` or `prod`.
+
+#### Find out if a pipeline is paused
+To find out if the pipeline in an environment is paused, run
+
+```shell
+rake pipeline:ENV:status
+```
+
+where `ENV` is the name of the environment you want to work with, for example `dev` or `prod`.
+
+
 ## Support
 
 Raise a GitHub issue if you need support.

--- a/lib/tasks/pause_pipelines.rake
+++ b/lib/tasks/pause_pipelines.rake
@@ -1,0 +1,130 @@
+require "aws-sdk-codepipeline"
+
+namespace :pipeline do
+  %w[dev prod staging user-research].each do |env_name|
+    namespace env_name do
+      desc "Pause the pipeline in #{env_name}"
+      task pause: :environment do
+        pipeline_name = pipeline_name env_name
+
+        puts "Pausing pipeline #{pipeline_name}"
+
+        codepipeline = Aws::CodePipeline::Client.new
+        pipeline_definition = codepipeline.get_pipeline(name: pipeline_name)
+
+        unless pipeline_definition.pipeline.stages.any?
+          raise "Pipeline definition has no stages"
+        end
+
+        unless pipeline_definition.pipeline.stages.count > 1
+          raise "Pipeline has only one stage. It cannot be paused in a way that can be unpaused from the console if necessary."
+        end
+
+        second_stage = pipeline_definition.pipeline.stages[1]
+
+        default_reason = "Pipeline paused by #{ENV['USER']} using rake task"
+        reason = get_pause_reason(default_reason)
+        codepipeline.disable_stage_transition(
+          pipeline_name:,
+          stage_name: second_stage.name,
+          transition_type: "Inbound",
+          reason:,
+        )
+
+        puts "Pipeline paused at #{Time.zone.now.strftime('%Y-%m-%d %H:%M:%S %Z')} with reason\n\n'#{reason}'"
+      end
+
+      desc "Unpause the pipeline in #{env_name}"
+      task unpause: :environment do
+        pipeline_name = pipeline_name env_name
+
+        puts "Pausing pipeline #{pipeline_name}"
+
+        codepipeline = Aws::CodePipeline::Client.new
+        pipeline_definition = codepipeline.get_pipeline(name: pipeline_name)
+
+        unless pipeline_definition.pipeline.stages.any?
+          raise "Pipeline definition has no stages"
+        end
+
+        unless pipeline_definition.pipeline.stages.count > 1
+          raise "Pipeline has only one stage. It cannot be unpaused because there is no transition from the source stage to unpause."
+        end
+
+        second_stage = pipeline_definition.pipeline.stages[1]
+
+        codepipeline.enable_stage_transition(
+          pipeline_name:,
+          stage_name: second_stage.name,
+          transition_type: "Inbound",
+        )
+
+        puts "Pipeline unpaused at #{Time.zone.now.strftime('%Y-%m-%d %H:%M:%S %Z')}"
+      end
+
+      desc "Find out about the status of the pipeline in #{env_name}"
+      task status: :environment do
+        pipeline_name = pipeline_name env_name
+
+        codepipeline = Aws::CodePipeline::Client.new
+        pipeline_definition = codepipeline.get_pipeline_state(name: pipeline_name)
+
+        paused_transitions = pipeline_definition.stage_states.filter_map do |stage|
+          unless stage.inbound_transition_state.enabled
+            [stage.stage_name, "inbound", stage.inbound_transition_state.disabled_reason]
+          end
+        end
+
+        if paused_transitions.any?
+          puts "#{pipeline_name} is paused in at least 1 position"
+          puts ""
+          paused_transitions.each do |pause|
+            puts "Stage: #{pause[0]}, Transition: #{pause[1]}"
+            puts "Reason: #{pause[2]}"
+            puts ""
+          end
+        else
+          puts "#{pipeline_name} is not paused"
+        end
+      end
+    end
+  end
+end
+
+def pipeline_name(env)
+  "deploy-forms-runner-container-#{env}"
+end
+
+def get_pause_reason(default)
+  temp_file_content = <<~MSG
+    #{default}
+    # Write your reason for pausing the pipeline above.
+    # Any lines beginning with the hash character will
+    # be ignored.
+  MSG
+
+  temp_file = Tempfile.new("pausing-pipeline")
+  File.write(temp_file, temp_file_content)
+  temp_file.close(false) # Close so that other processes can write it
+
+  editor = ENV.fetch("EDITOR", "vim")
+
+  system(
+    ENV,
+    "#{editor} #{temp_file.path}",
+    chdir: Dir.pwd,
+    in: $stdin,
+    out: $stdout,
+    err: $stderr,
+  )
+
+  content =
+    # Can't use temp_file.read because we closed the stream
+    File.read(temp_file.path)
+        .split("\n")
+        .reject { |line| line.start_with? "#" }
+        .join("\n")
+
+  temp_file.delete
+  content
+end


### PR DESCRIPTION

### What problem does this pull request solve?

Trello card: https://trello.com/c/HFSmspAf/381-automatically-deploy-to-dev-environments-after-production

We're beginning to automatically deploy changes that are OK in production into dev environment(s). This means that dev environment pipelines will get run much more frequently, and the chances our test changes in the environment will get overridden are much higher. To counteract this we intend to pause the pipelines when we've deployed dev changes. 

This PR adds 3 Rake tasks to help with that:
* `rake pipeline:ENV:pause`
* `rake pipeline:ENV:unpause`
* `rake pipeline:ENV:status`

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
