### PR TITLE
Add analytics feature flag

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,5 @@
-features: {}
+features:
+  analytics_enabled: false
 
 forms_admin:
   # URL to form-admin

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -19,11 +19,9 @@ describe "Settings" do
   end
 
   describe ".features" do
-    it "has a default value" do
-      features = settings[:features]
+    features = settings[:features]
 
-      expect(features).to eq({})
-    end
+    include_examples expected_value_test, :analytics_enabled, features, false
   end
 
   describe ".forms_api" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/Meo1LbpG/1875-add-a-feature-flag-for-google-analytics-in-the-runner

Adds a new feature flag, ``analytics_enabled`. This will allow us to implement the cookie consent and the analytics snippet separately, and then turn them on at the same time.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
