### PR TITLE
Make google analytics feature into setting

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,4 @@
-features:
-  analytics_enabled: false
+features: {}
 
 forms_admin:
   # URL to form-admin

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,3 +37,5 @@ show_browser_during_tests: false
 
 # When set to true, the CloudWatch service will attempt to send data to CloudWatch
 cloudwatch_metrics_enabled: false
+
+analytics_enabled: false

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -72,4 +72,12 @@ describe "Settings" do
       expect(cloudwatch_metrics_enabled).to be(false)
     end
   end
+
+  describe "analytics_enabled" do
+    it "has a default value" do
+      analytics_enabled = settings[:analytics_enabled]
+
+      expect(analytics_enabled).to be(false)
+    end
+  end
 end

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -19,9 +19,11 @@ describe "Settings" do
   end
 
   describe ".features" do
-    features = settings[:features]
+    it "has a default value" do
+      features = settings[:features]
 
-    include_examples expected_value_test, :analytics_enabled, features, false
+      expect(features).to eq({})
+    end
   end
 
   describe ".forms_api" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/Meo1LbpG/1580-add-a-feature-flag-for-google-analytics-in-the-runner

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Reverts the previous PR (#784) and reimplements it as a top-level setting in settings.yml, rather than a feature flag. This is because we think it would be useful to retain the ability to turn this feature off later, even after the feature is mature, whereas we've typically treated our feature flags as temporary. We already do the same thing for switching Cloudwatch metrics on and off.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
