### PR TITLE
WIP: Refactor Form model to abstract away source of forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,8 @@ group :development, :test do
 
   # For detecting security vulnerabilities in Ruby on Rails applications via static analysis.
   gem "brakeman", "~> 6.1"
+
+  gem "webmock", "~> 3.23"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,9 @@ GEM
     config (5.5.1)
       deep_merge (~> 1.2, >= 1.2.1)
     connection_pool (2.4.1)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     date (3.3.4)
     debug (1.9.2)
@@ -180,6 +183,7 @@ GEM
     govuk_notify_rails (2.2.0)
       notifications-ruby-client (~> 5.1)
       rails (>= 4.1.0)
+    hashdiff (1.1.0)
     highline (3.0.1)
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
@@ -414,6 +418,10 @@ GEM
       dry-cli (>= 0.7, < 2)
       rack-proxy (~> 0.6, >= 0.6.1)
       zeitwerk (~> 2.2)
+    webmock (3.23.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
     websocket (1.2.10)
     websocket-driver (0.7.6)
@@ -468,9 +476,10 @@ DEPENDENCIES
   tzinfo-data
   uk_postcode
   vite_rails
+  webmock (~> 3.23)
 
 RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.5.3
+   2.5.9

--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -46,4 +46,3 @@ module Forms
     end
   end
 end
-

--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -24,7 +24,7 @@ module Forms
   private
 
     def current_form
-      @current_form ||= Form.find_with_mode(id: params.require(:form_id), mode:)
+      @current_form ||= FormService.find_with_mode(id: params.require(:form_id), mode:)
     end
 
     def current_context
@@ -46,3 +46,4 @@ module Forms
     end
   end
 end
+

--- a/app/lib/form_service.rb
+++ b/app/lib/form_service.rb
@@ -5,6 +5,7 @@ class FormService
 
   def self.find_with_mode(id:, mode:)
     raise ActiveResource::ResourceNotFound.new(404, "Not Found") unless id.to_s =~ /^[[:alnum:]]+$/
+
     find_from_repository(id:, mode:)
   end
 
@@ -17,8 +18,9 @@ class FormService
   end
 
   def self.mode_string(mode)
-    return 'draft' if mode.preview_draft?
-    return 'archived' if mode.preview_archived?
-    return 'live' if mode.live? || mode.preview_live?
+    return "draft" if mode.preview_draft?
+    return "archived" if mode.preview_archived?
+
+    "live" if mode.live? || mode.preview_live?
   end
 end

--- a/app/lib/form_service.rb
+++ b/app/lib/form_service.rb
@@ -1,0 +1,24 @@
+class FormService
+  def self.find(id)
+    repository.find(id)
+  end
+
+  def self.find_with_mode(id:, mode:)
+    raise ActiveResource::ResourceNotFound.new(404, "Not Found") unless id.to_s =~ /^[[:alnum:]]+$/
+    find_from_repository(id:, mode:)
+  end
+
+  def self.find_from_repository(id:, mode:)
+    repository.find_with_mode(id:, mode: mode_string(mode))
+  end
+
+  def self.repository
+    Settings.features.direct_api_enabled ? FormDirect : FormResource
+  end
+
+  def self.mode_string(mode)
+    return 'draft' if mode.preview_draft?
+    return 'archived' if mode.preview_archived?
+    return 'live' if mode.live? || mode.preview_live?
+  end
+end

--- a/app/models/answer_settings.rb
+++ b/app/models/answer_settings.rb
@@ -1,0 +1,27 @@
+class AddressInputType
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :international_address
+  attribute :uk_address
+end
+
+class AnswerSettings
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :selection_options, default: []
+  attribute :only_one_option
+  attribute :input_type
+  attribute :title_needed
+
+  def initialize(attributes = {})
+    attributes["selection_options"] ||= []
+    attributes["selection_options"] = attributes["selection_options"].map do |so|
+      SelectionOption.new(so)
+    end
+
+    attributes["input_type"] = AddressInputType.new(attributes["input_type"]) if attributes["answer_type"] == "address"
+    super(attributes)
+  end
+end

--- a/app/models/answer_settings.rb
+++ b/app/models/answer_settings.rb
@@ -1,27 +1,45 @@
 class AddressInputType
   include ActiveModel::Model
   include ActiveModel::Attributes
+  include ActiveModel::Serializers::JSON
 
   attribute :international_address
   attribute :uk_address
+
+  def self.from_json(json)
+    attributes = HashWithIndifferentAccess.new(json)
+
+    extracted_attributes = {
+      international_address: attributes[:international_address],
+      uk_address: attributes[:uk_address],
+    }
+
+    new(extracted_attributes)
+  end
 end
 
 class AnswerSettings
   include ActiveModel::Model
   include ActiveModel::Attributes
+  include ActiveModel::Serializers::JSON
 
   attribute :selection_options, default: []
   attribute :only_one_option
   attribute :input_type
   attribute :title_needed
 
-  def initialize(attributes = {})
-    attributes["selection_options"] ||= []
-    attributes["selection_options"] = attributes["selection_options"].map do |so|
-      SelectionOption.new(so)
-    end
+  def self.from_json(json, answer_type)
+    attributes = HashWithIndifferentAccess.new(json)
 
-    attributes["input_type"] = AddressInputType.new(attributes["input_type"]) if attributes["answer_type"] == "address"
-    super(attributes)
+    extracted_attributes = {
+      selection_options: Array(attributes[:selection_options]).map do |so|
+        SelectionOption.new(so)
+      end,
+      only_one_option: attributes[:only_one_option],
+      input_type: answer_type == "address" ? AddressInputType.from_json(attributes[:input_type]) : attributes[:input_type],
+      title_needed: attributes[:title_needed],
+    }
+
+    new(extracted_attributes)
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,32 +1,78 @@
-class Form < ActiveResource::Base
-  self.site = Settings.forms_api.base_url
-  self.prefix = "/api/v1/"
-  self.include_format_in_path = false
-  headers["X-API-Token"] = Settings.forms_api.auth_key
+class Form
+  include ActiveModel::Model
+  include ActiveModel::Attributes
 
-  has_many :pages
+  class FormRecord < ActiveResource::Base
+    self.site = Settings.forms_api.base_url
+    self.element_name = "form"
+    self.prefix = "/api/v1/"
+    self.include_format_in_path = false
+    headers["X-API-Token"] = Settings.forms_api.auth_key
+
+    has_many :pages
+
+    def self.find_with_mode(id:, mode:)
+      raise ActiveResource::ResourceNotFound.new(404, "Not Found") unless id.to_s =~ /^[[:alnum:]]+$/
+
+      return find_draft(id) if mode.preview_draft?
+      return find_archived(id) if mode.preview_archived?
+      return find_live(id) if mode.live?
+
+      find_live(id) if mode.preview_live?
+    end
+
+    def self.find_live(id)
+      find(:one, from: "#{prefix}forms/#{id}/live")
+    end
+
+    def self.find_draft(id)
+      find(:one, from: "#{prefix}forms/#{id}/draft")
+    end
+
+    def self.find_archived(id)
+      find(:one, from: "#{prefix}forms/#{id}/archived")
+    end
+
+    def to_form
+      Form.new(attributes)
+    end
+  end
+
+  def self.find(id)
+    FormRecord.find(id)&.to_form
+  end
 
   def self.find_with_mode(id:, mode:)
-    raise ActiveResource::ResourceNotFound.new(404, "Not Found") unless id.to_s =~ /^[[:alnum:]]+$/
-
-    return find_draft(id) if mode.preview_draft?
-    return find_archived(id) if mode.preview_archived?
-    return find_live(id) if mode.live?
-
-    find_live(id) if mode.preview_live?
+    FormRecord.find_with_mode(id: id, mode: mode)&.to_form
   end
 
-  def self.find_live(id)
-    find(:one, from: "#{prefix}forms/#{id}/live")
-  end
-
-  def self.find_draft(id)
-    find(:one, from: "#{prefix}forms/#{id}/draft")
-  end
-
-  def self.find_archived(id)
-    find(:one, from: "#{prefix}forms/#{id}/archived")
-  end
+  attribute :created_at, :datetime
+  attribute :creator_id
+  attribute :declaration_section_completed
+  attribute :declaration_text
+  attribute :form_slug
+  attribute :has_draft_version
+  attribute :has_live_version
+  attribute :has_routing_errors
+  attribute :id
+  attribute :incomplete_tasks
+  attribute :live_at, default: 'invalid_date'
+  attribute :name
+  attribute :organisation_id
+  attribute :pages
+  attribute :payment_url
+  attribute :privacy_policy_url
+  attribute :question_section_completed
+  attribute :ready_for_live
+  attribute :start_page
+  attribute :submission_email
+  attribute :support_email
+  attribute :support_phone
+  attribute :support_url
+  attribute :support_url_text
+  attribute :task_statuses
+  attribute :updated_at
+  attribute :what_happens_next_markdown
 
   def last_page
     pages.find { |p| !p.has_next_page? }

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -2,42 +2,6 @@ class Form
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  class FormRecord < ActiveResource::Base
-    self.site = Settings.forms_api.base_url
-    self.element_name = "form"
-    self.prefix = "/api/v1/"
-    self.include_format_in_path = false
-    headers["X-API-Token"] = Settings.forms_api.auth_key
-
-    has_many :pages
-
-    def self.find_with_mode(id:, mode:)
-      raise ActiveResource::ResourceNotFound.new(404, "Not Found") unless id.to_s =~ /^[[:alnum:]]+$/
-
-      return find_draft(id) if mode.preview_draft?
-      return find_archived(id) if mode.preview_archived?
-      return find_live(id) if mode.live?
-
-      find_live(id) if mode.preview_live?
-    end
-
-    def self.find_live(id)
-      find(:one, from: "#{prefix}forms/#{id}/live")
-    end
-
-    def self.find_draft(id)
-      find(:one, from: "#{prefix}forms/#{id}/draft")
-    end
-
-    def self.find_archived(id)
-      find(:one, from: "#{prefix}forms/#{id}/archived")
-    end
-
-    def to_form
-      Form.new(attributes)
-    end
-  end
-
   def self.find(id)
     repository.find(id)&.to_form
   end
@@ -56,7 +20,7 @@ class Form
   attribute :has_routing_errors
   attribute :id
   attribute :incomplete_tasks
-  attribute :live_at, default: 'invalid_date'
+  attribute :live_at, default: "invalid_date"
   attribute :name
   attribute :organisation_id
   attribute :pages
@@ -73,6 +37,7 @@ class Form
   attribute :task_statuses
   attribute :updated_at
   attribute :what_happens_next_markdown
+  attribute :state
 
   def last_page
     pages.find { |p| !p.has_next_page? }

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -39,11 +39,11 @@ class Form
   end
 
   def self.find(id)
-    FormRecord.find(id)&.to_form
+    repository.find(id)&.to_form
   end
 
   def self.find_with_mode(id:, mode:)
-    FormRecord.find_with_mode(id: id, mode: mode)&.to_form
+    repository.find_with_mode(id:, mode:)&.to_form
   end
 
   attribute :created_at, :datetime
@@ -97,5 +97,9 @@ class Form
     return nil if payment_url.blank?
 
     "#{payment_url}?reference=#{reference}"
+  end
+
+  def self.repository
+    Settings.features.direct_api_enabled ? FormDirect : FormResource
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -2,14 +2,6 @@ class Form
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  def self.find(id)
-    repository.find(id)&.to_form
-  end
-
-  def self.find_with_mode(id:, mode:)
-    repository.find_with_mode(id:, mode:)&.to_form
-  end
-
   attribute :created_at, :datetime
   attribute :creator_id
   attribute :declaration_section_completed
@@ -62,9 +54,5 @@ class Form
     return nil if payment_url.blank?
 
     "#{payment_url}?reference=#{reference}"
-  end
-
-  def self.repository
-    Settings.features.direct_api_enabled ? FormDirect : FormResource
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,22 +1,40 @@
-class Page < ActiveResource::Base
+class Page
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
   PAGE_ID_REGEX = /\d+/
 
-  self.site = Settings.forms_api.base_url
-  self.prefix = "/api/v1/forms/:form_id/"
-  self.include_format_in_path = false
-  headers["X-API-Token"] = Settings.forms_api.auth_key
+  def initialize(attributes = {}, persisted = true)
+    attributes["answer_settings"] = AnswerSettings.new(attributes["answer_settings"]) if attributes["answer_settings"].present?
 
-  belongs_to :form
+    attributes["routing_conditions"] ||= []
+    attributes["routing_conditions"] = attributes["routing_conditions"]&.map do |rc|
+      RoutingCondition.new(rc)
+    end
 
-  def form_id
-    @prefix_options[:form_id]
+    super(attributes)
   end
+
+  attribute :id
+  attribute :question_text
+  attribute :hint_text
+  attribute :answer_type
+  attribute :next_page
+  attribute :is_optional
+  attribute :answer_settings
+  attribute :created_at
+  attribute :updated_at
+  attribute :form_id
+  attribute :position
+  attribute :page_heading
+  attribute :guidance_markdown
+  attribute :routing_conditions, default: []
 
   def has_next_page?
-    @attributes.include?("next_page") && !@attributes["next_page"].nil?
+    next_page.present?
   end
 
-  def answer_settings
-    @attributes["answer_settings"] || {}
+  def as_json(*args)
+    super.as_json["attributes"]
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -48,7 +48,7 @@ class Page
 
     if attributes[:routing_conditions].present?
       extracted_attributes[:routing_conditions] = attributes[:routing_conditions].map do |rc|
-        RoutingCondition.new(rc)
+        RoutingCondition.from_json(rc)
       end
     end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -39,7 +39,7 @@ class Page
       form_id: attributes[:form_id],
       position: attributes[:position],
       page_heading: attributes[:page_heading],
-      guidance_markdown: attributes[:guidance_markdown]
+      guidance_markdown: attributes[:guidance_markdown],
     }
 
     if attributes[:answer_settings].present?

--- a/app/models/routing_condition.rb
+++ b/app/models/routing_condition.rb
@@ -1,0 +1,24 @@
+class RoutingCondition
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :answer_value
+  attribute :check_page_id
+  attribute :created_at
+  attribute :goto_page_id
+  attribute :has_routing_errors
+  attribute :id
+  attribute :routing_page_id
+  attribute :skip_to_end
+  attribute :updated_at
+  attribute :validation_errors
+
+  def initialize(attributes = {})
+    attributes["validation_errors"] ||= []
+    attributes["validation_errors"] = attributes["validation_errors"]&.map do |ve|
+      ValidationError.new(ve)
+    end
+
+    super(attributes)
+  end
+end

--- a/app/models/routing_condition.rb
+++ b/app/models/routing_condition.rb
@@ -13,12 +13,13 @@ class RoutingCondition
   attribute :updated_at
   attribute :validation_errors
 
-  def initialize(attributes = {})
-    attributes["validation_errors"] ||= []
-    attributes["validation_errors"] = attributes["validation_errors"]&.map do |ve|
-      ValidationError.new(ve)
-    end
+  def from_json(json)
+    attributes = HashWithIndifferentAccess.new(json)
 
-    super(attributes)
+    extracted_attributes = {
+      validation_errors: Array(attributes["validation_errors"]).map do |ve|
+        ValidationError.new(ve)
+      end
+    }
   end
 end

--- a/app/models/routing_condition.rb
+++ b/app/models/routing_condition.rb
@@ -16,10 +16,10 @@ class RoutingCondition
   def from_json(json)
     attributes = HashWithIndifferentAccess.new(json)
 
-    extracted_attributes = {
+    {
       validation_errors: Array(attributes["validation_errors"]).map do |ve|
         ValidationError.new(ve)
-      end
+      end,
     }
   end
 end

--- a/app/models/selection_option.rb
+++ b/app/models/selection_option.rb
@@ -1,0 +1,6 @@
+class SelectionOption
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :name
+end

--- a/app/models/validation_error.rb
+++ b/app/models/validation_error.rb
@@ -1,0 +1,9 @@
+class ValidationError
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  # { name: "goto_page_doesnt_exist" }
+  # { name: "answer_value_doesnt_exist" }
+  # { name: "cannot_route_to_next_page" }
+  # { name: "cannot_have_goto_page_before_routing_page" }
+  attribute :name
+end

--- a/app/repositories/form_direct.rb
+++ b/app/repositories/form_direct.rb
@@ -1,0 +1,56 @@
+class FormDirect
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include FormRepository
+
+  def initialize(attributes = {})
+    @attributes = attributes
+
+    @attributes["pages"] = attributes["pages"].map { |page_data| Page.new(page_data) }
+  end
+
+  def self.find_with_mode(id:, mode:)
+    raise ActiveResource::ResourceNotFound.new(404, "Not Found") unless id.to_s =~ /^[[:alnum:]]+$/
+
+    return find_draft(id) if mode.preview_draft?
+    return find_archived(id) if mode.preview_archived?
+    return find_live(id) if mode.live?
+
+    find_live(id) if mode.preview_live?
+  end
+
+  def self.find_live(id)
+    find_request(id, "live")
+  end
+
+  def self.find_draft(id)
+    find_request(id, "draft")
+  end
+
+  def self.find_archived(id)
+    find_request(id, "archived")
+  end
+
+  def self.find_request(id, mode)
+    url = URI.parse("#{Settings.forms_api.base_url}/api/v1/forms/#{id}/#{mode}")
+
+    # Create the HTTP GET request
+    request = Net::HTTP::Get.new(url.to_s)
+    request["X-API-Token"] = Settings.forms_api.auth_key
+
+    # Create an HTTP session
+    response = Net::HTTP.start(url.host, url.port) do |http|
+      http.request(request)
+    end
+
+    # Check the response status code
+    case response
+    when Net::HTTPSuccess
+      # Parse and return the JSON response
+      FormDirect.new(JSON.parse(response.body))
+    else
+      # Handle non-successful responses
+      raise "HTTP request failed with code #{response.code}: #{response.message}"
+    end
+  end
+end

--- a/app/repositories/form_repository.rb
+++ b/app/repositories/form_repository.rb
@@ -2,12 +2,4 @@ module FormRepository
   def self.find_with_mode(id:, mode:)
     raise NotImplementedError, "This #{self.class} cannot respond to:"
   end
-
-  def self.find(id)
-    raise NotImplementedError, "This #{self.class} cannot respond to:"
-  end
-
-  def to_form
-    Form.new(attributes)
-  end
 end

--- a/app/repositories/form_repository.rb
+++ b/app/repositories/form_repository.rb
@@ -1,0 +1,13 @@
+module FormRepository
+  def self.find_with_mode(id:, mode:)
+    raise NotImplementedError, "This #{self.class} cannot respond to:"
+  end
+
+  def self.find(id)
+    raise NotImplementedError, "This #{self.class} cannot respond to:"
+  end
+
+  def to_form
+    Form.new(attributes)
+  end
+end

--- a/app/repositories/form_resource.rb
+++ b/app/repositories/form_resource.rb
@@ -1,33 +1,22 @@
 class FormResource < ActiveResource::Base
-  include FormRepository
-
-  has_many :pages
-
-  def self.find_with_mode(id:, mode:)
-    raise ActiveResource::ResourceNotFound.new(404, "Not Found") unless id.to_s =~ /^[[:alnum:]]+$/
-
-    return find_draft(id) if mode.preview_draft?
-    return find_archived(id) if mode.preview_archived?
-    return find_live(id) if mode.live?
-
-    find_live(id) if mode.preview_live?
-  end
-
   self.site = Settings.forms_api.base_url
   self.element_name = "form"
   self.prefix = "/api/v1/"
   self.include_format_in_path = false
   headers["X-API-Token"] = Settings.forms_api.auth_key
 
-  def self.find_live(id)
-    find(:one, from: "#{prefix}forms/#{id}/live")
+  # needed to convert pages using ActiveResource
+  class PageResource
+    def self.new(attributes, persisted, &block)
+      Page.from_json(attributes)
+    end
   end
 
-  def self.find_draft(id)
-    find(:one, from: "#{prefix}forms/#{id}/draft")
-  end
+  include FormRepository
 
-  def self.find_archived(id)
-    find(:one, from: "#{prefix}forms/#{id}/archived")
+  has_many :pages, class_name: PageResource
+
+  def self.find_with_mode(id:, mode:)
+    Form.new(find(:one, from: "#{prefix}forms/#{id}/#{mode}").attributes)
   end
 end

--- a/app/repositories/form_resource.rb
+++ b/app/repositories/form_resource.rb
@@ -1,16 +1,16 @@
+# needed to convert pages using ActiveResource
+class PageResource
+  def self.new(attributes, _persisted)
+    Page.from_json(attributes)
+  end
+end
+
 class FormResource < ActiveResource::Base
   self.site = Settings.forms_api.base_url
   self.element_name = "form"
   self.prefix = "/api/v1/"
   self.include_format_in_path = false
   headers["X-API-Token"] = Settings.forms_api.auth_key
-
-  # needed to convert pages using ActiveResource
-  class PageResource
-    def self.new(attributes, persisted, &block)
-      Page.from_json(attributes)
-    end
-  end
 
   include FormRepository
 

--- a/app/repositories/form_resource.rb
+++ b/app/repositories/form_resource.rb
@@ -1,0 +1,33 @@
+class FormResource < ActiveResource::Base
+  include FormRepository
+
+  has_many :pages
+
+  def self.find_with_mode(id:, mode:)
+    raise ActiveResource::ResourceNotFound.new(404, "Not Found") unless id.to_s =~ /^[[:alnum:]]+$/
+
+    return find_draft(id) if mode.preview_draft?
+    return find_archived(id) if mode.preview_archived?
+    return find_live(id) if mode.live?
+
+    find_live(id) if mode.preview_live?
+  end
+
+  self.site = Settings.forms_api.base_url
+  self.element_name = "form"
+  self.prefix = "/api/v1/"
+  self.include_format_in_path = false
+  headers["X-API-Token"] = Settings.forms_api.auth_key
+
+  def self.find_live(id)
+    find(:one, from: "#{prefix}forms/#{id}/live")
+  end
+
+  def self.find_draft(id)
+    find(:one, from: "#{prefix}forms/#{id}/draft")
+  end
+
+  def self.find_archived(id)
+    find(:one, from: "#{prefix}forms/#{id}/archived")
+  end
+end

--- a/app/repositories/form_resource.rb
+++ b/app/repositories/form_resource.rb
@@ -14,7 +14,7 @@ class FormResource < ActiveResource::Base
 
   include FormRepository
 
-  has_many :pages, class_name: PageResource
+  has_many :pages, class_name: "PageResource"
 
   def self.find_with_mode(id:, mode:)
     Form.new(find(:one, from: "#{prefix}forms/#{id}/#{mode}").attributes)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,6 @@
-features: {}
+features: {
+    direct_api_enabled: false
+  }
 
 forms_admin:
   # URL to form-admin

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -19,11 +19,9 @@ describe "Settings" do
   end
 
   describe ".features" do
-    it "has a default value" do
-      features = settings[:features]
+    features = settings[:features]
 
-      expect(features).to eq({})
-    end
+    include_examples expected_value_test, :direct_api_enabled, features, false
   end
 
   describe ".forms_api" do

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     has_live_version { false }
     submission_email { Faker::Internet.email(domain: "example.gov.uk") }
     privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
-    org { "test-org" }
     live_at { nil }
     what_happens_next_markdown { nil }
     support_email { nil }

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :form, class: "Form" do
+    id { Faker::Number.number(digits: 2) }
     sequence(:name) { |n| "Form #{n}" }
     sequence(:form_slug) { |n| "form-#{n}" }
     has_draft_version { true }
@@ -45,6 +46,7 @@ FactoryBot.define do
       end
 
       question_section_completed { true }
+      start_page { pages.first.id }
     end
 
     trait :with_support do

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
   factory :page, class: "Page" do
     id { Faker::Number.number(digits: 2) }
     question_text { Faker::Lorem.question }
-    answer_type { 'email' }
+    answer_type { "email" }
     is_optional { nil }
     answer_settings { nil }
     page_heading { nil }

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
   factory :page, class: "Page" do
     id { Faker::Number.number(digits: 2) }
     question_text { Faker::Lorem.question }
-    answer_type { Page::ANSWER_TYPES.reject { |item| Page::ANSWER_TYPES_WITH_SETTINGS.include? item }.sample }
+    answer_type { 'email' }
     is_optional { nil }
     answer_settings { nil }
     page_heading { nil }
@@ -37,11 +37,11 @@ FactoryBot.define do
     trait :with_selections_settings do
       transient do
         only_one_option { "true" }
-        selection_options { [DataStruct.new(name: "Option 1"), DataStruct.new(name: "Option 2")] }
+        selection_options { [SelectionOption.new(name: "Option 1"), SelectionOption.new(name: "Option 2")] }
       end
 
       answer_type { "selection" }
-      answer_settings { DataStruct.new(only_one_option:, selection_options:) }
+      answer_settings { AnswerSettings.new(only_one_option:, selection_options:) }
     end
 
     trait :with_text_settings do
@@ -50,7 +50,7 @@ FactoryBot.define do
       end
 
       answer_type { "text" }
-      answer_settings { DataStruct.new(input_type:) }
+      answer_settings { AnswerSettings.new(input_type:) }
     end
 
     trait :with_date_settings do
@@ -59,7 +59,7 @@ FactoryBot.define do
       end
 
       answer_type { "date" }
-      answer_settings { DataStruct.new(input_type:) }
+      answer_settings { AnswerSettings.new(input_type:) }
     end
 
     trait :with_address_settings do
@@ -69,7 +69,7 @@ FactoryBot.define do
       end
 
       answer_type { "address" }
-      answer_settings { DataStruct.new(input_type: DataStruct.new(uk_address:, international_address:)) }
+      answer_settings { AnswerSettings.new(input_type: AddressInputType.new(uk_address:, international_address:)) }
     end
 
     trait :with_name_settings do
@@ -79,7 +79,7 @@ FactoryBot.define do
       end
 
       answer_type { "name" }
-      answer_settings { DataStruct.new(input_type:, title_needed:) }
+      answer_settings { AnswerSettings.new(input_type:, title_needed:) }
     end
   end
 end

--- a/spec/features/email_confirmation_spec.rb
+++ b/spec/features/email_confirmation_spec.rb
@@ -20,7 +20,7 @@ feature "Email confirmation", type: :feature do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1/live", req_headers, form.to_json(include: [:pages]), 200
+      mock.get "/api/v1/forms/1/live", req_headers, form.to_json, 200
     end
   end
 

--- a/spec/features/email_confirmation_spec.rb
+++ b/spec/features/email_confirmation_spec.rb
@@ -5,23 +5,9 @@ feature "Email confirmation", type: :feature do
   let(:form) { build :form, :live?, id: 1, name: "Apply for a juggling license", pages:, start_page: 1 }
   let(:text_answer) { Faker::Lorem.sentence }
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
-  let(:post_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Content-Type" => "application/json",
-    }
-  end
-
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1/live", req_headers, form.to_json, 200
-    end
+    allow(FormService).to receive(:find_with_mode).with(any_args).and_raise(ActiveResource::ResourceNotFound.new(404, "Not Found"))
+    allow(FormService).to receive(:find_with_mode).with(id: '1', mode: kind_of(Mode)).and_return(form)
   end
 
   scenario "opting out of email submission returns the confirmation page without confirmation email text" do

--- a/spec/features/email_confirmation_spec.rb
+++ b/spec/features/email_confirmation_spec.rb
@@ -7,7 +7,7 @@ feature "Email confirmation", type: :feature do
 
   before do
     allow(FormService).to receive(:find_with_mode).with(any_args).and_raise(ActiveResource::ResourceNotFound.new(404, "Not Found"))
-    allow(FormService).to receive(:find_with_mode).with(id: '1', mode: kind_of(Mode)).and_return(form)
+    allow(FormService).to receive(:find_with_mode).with(id: "1", mode: kind_of(Mode)).and_return(form)
   end
 
   scenario "opting out of email submission returns the confirmation page without confirmation email text" do

--- a/spec/features/email_confirmation_spec.rb
+++ b/spec/features/email_confirmation_spec.rb
@@ -20,7 +20,6 @@ feature "Email confirmation", type: :feature do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
       mock.get "/api/v1/forms/1/live", req_headers, form.to_json(include: [:pages]), 200
     end
   end

--- a/spec/features/fill_in_and_submit_form_spec.rb
+++ b/spec/features/fill_in_and_submit_form_spec.rb
@@ -7,26 +7,12 @@ feature "Fill in and submit a form", type: :feature do
   let(:answer_text) { "Answer text" }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
-
-  let(:post_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Content-Type" => "application/json",
-    }
-  end
-
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1/live", req_headers, form.to_json, 200
-    end
-
     allow(ReferenceNumberService).to receive(:generate).and_return(reference)
+    # allow(FormService).to receive(:find_with_mode).with(any_args).and_raise(ActiveResource::ResourceNotFound.new(404, "Not Found"))
+    # allow(FormService).to receive(:find_from_repository).with(id: '2', mode: kind_of(Mode)).and_return(form)
+    mock_repository = class_double(FormRepository, find_with_mode: form)
+    allow(FormService).to receive(:repository).and_return(mock_repository)
   end
 
   scenario "As a form filler" do

--- a/spec/features/fill_in_and_submit_form_spec.rb
+++ b/spec/features/fill_in_and_submit_form_spec.rb
@@ -23,7 +23,6 @@ feature "Fill in and submit a form", type: :feature do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
       mock.get "/api/v1/forms/1/live", req_headers, form.to_json(include: [:pages]), 200
     end
 

--- a/spec/features/fill_in_and_submit_form_spec.rb
+++ b/spec/features/fill_in_and_submit_form_spec.rb
@@ -23,7 +23,7 @@ feature "Fill in and submit a form", type: :feature do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1/live", req_headers, form.to_json(include: [:pages]), 200
+      mock.get "/api/v1/forms/1/live", req_headers, form.to_json, 200
     end
 
     allow(ReferenceNumberService).to receive(:generate).and_return(reference)

--- a/spec/lib/flow/context_spec.rb
+++ b/spec/lib/flow/context_spec.rb
@@ -2,10 +2,6 @@ require "rails_helper"
 
 # rubocop:disable RSpec/InstanceVariable
 RSpec.describe Flow::Context do
-  before do
-    ActiveResource::HttpMock.disable_net_connection!
-  end
-
   let(:pages) do
     [
       (build :page, :with_text_settings,

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,135 +1,49 @@
 require "rails_helper"
 
 RSpec.describe Form, type: :model, feature_direct_api_enabled: false do
-  let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", start_page: 1 }.to_json }
-
-  let(:pages_data) do
-    [
-      { id: 9, next_page: 10, answer_type: "date", question_text: "Question one" },
-      { id: 10, answer_type: "address", question_text: "Question two" },
-    ].to_json
-  end
-
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
-
-  before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1", req_headers, response_data, 200
-      mock.get "/api/v1/forms/1/pages", req_headers, pages_data, 200
-    end
-  end
-
   describe "#live?" do
-    it "when live_at is not set raises an error" do
-      expect { described_class.new({ id: 1, name: "form name", submission_email: "user@example.com", start_page: 1 }).live? }.to raise_error(Date::Error)
-    end
+    let(:form) { build :form }
 
     it "when no live_at is set to empty string returns false" do
-      expect(described_class.new({ id: 1, name: "form name", live_at: "", submission_email: "user@example.com", start_page: 1 }).live?).to be false
+      form.live_at = ''
+      expect(form.live?).to be false
     end
 
     it "when live_at is a string which isn't a valid date raises an error" do
-      expect {
-        described_class.new({ id: 1, name: "form name", live_at: "not a date!", submission_email: "user@example.com", start_page: 1 }).live?
-      }.to raise_error(Date::Error)
+      form.live_at = 'invalid date'
+      expect { form.live? }.to raise_error(Date::Error)
     end
 
     it "when live_at is not a string raises an error" do
-      expect { described_class.new({ id: 1, name: "form name", live_at: 1, submission_email: "user@example.com", start_page: 1 }).live? }.to raise_error(Date::Error)
+      form.live_at = 1
+      expect { form.live? }.to raise_error(Date::Error)
     end
 
     it "when live_at is a date in the future returns false" do
-      expect(described_class.new({ id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z", submission_email: "user@example.com", start_page: 1 }).live?("2022-01-01 10:00:00Z")).to be false
+      form.live_at = "2022-08-18 09:16:50Z"
+      expect(form.live?("2022-01-01 10:00:00Z")).to be false
     end
 
     it "when live_at is a date in the past returns true" do
-      expect(described_class.new({ id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z", submission_email: "user@example.com", start_page: 1 }).live?("2023-01-01 10:00:00Z")).to be true
+      form.live_at = "2022-08-18 09:16:50Z"
+      expect(form.live?("2023-01-01 10:00:00Z")).to be true
     end
 
     it "when dates are the same returns false" do
-      expect(described_class.new({ id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z", submission_email: "user@example.com", start_page: 1 }).live?("2022-08-18 09:16:50Z")).to be false
-    end
-  end
-
-  describe "#find_with_mode" do
-    context "when mode is live" do
-      let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z" }.to_json }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/1/live", req_headers, response_data, 200
-        end
-      end
-
-      it "returns a live form" do
-        form = described_class.find_with_mode(id: 1, mode: Mode.new("live"))
-
-        expect(form).to have_attributes(id: 1, name: "form name")
-        expect(form.live?).to be(true)
-      end
-    end
-
-    context "when mode is draft" do
-      let(:response_data) { { id: 1, name: "form name", live_at: nil }.to_json }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/1/draft", req_headers, response_data, 200
-        end
-      end
-
-      it "returns a draft form" do
-        form = described_class.find_with_mode(id: 1, mode: Mode.new("preview-draft"))
-
-        expect(form).to have_attributes(id: 1, name: "form name")
-        expect(form.live?).to be(false)
-      end
-    end
-
-    context "when validating the provided form id" do
-      let(:response_data) { { id: "Alpha123", name: "form name", live_at: nil }.to_json }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/Alpha123/draft", req_headers, response_data, 200
-        end
-      end
-
-      it "returns ResourceNotFound when the id contains non-alpha-numeric chars" do
-        expect {
-          described_class.find_with_mode(id: "<id>", mode: Mode.new("preview-draft"))
-        }.to raise_error(ActiveResource::ResourceNotFound)
-      end
-
-      it "returns ResourceNotFound when the id is blank" do
-        expect {
-          described_class.find_with_mode(id: "", mode: Mode.new("preview-draft"))
-        }.to raise_error(ActiveResource::ResourceNotFound)
-      end
-
-      it "returns the form when the id is alphanumeric" do
-        form = described_class.find_with_mode(id: "Alpha123", mode: Mode.new("preview-draft"))
-
-        expect(form).to have_attributes(id: "Alpha123", name: "form name")
-        expect(form.live?).to be(false)
-      end
+      form.live_at = "2022-08-18 09:16:50Z"
+      expect(form.live?("2022-08-18 09:16:50Z")).to be false
     end
   end
 
   describe "#payment_url_with_reference" do
-    let(:response_data) { { id: 1, name: "form name", payment_url:, start_page: 1 }.to_json }
+    let(:form) { build :form, payment_url: }
     let(:reference) { SecureRandom.base58(8).upcase }
 
     context "when there is a payment_url" do
       let(:payment_url) { "https://www.gov.uk/payments/test-service/pay-for-licence" }
 
       it "returns a full payment link" do
-        expect(described_class.find(1).payment_url_with_reference(reference)).to eq("#{payment_url}?reference=#{reference}")
+        expect(form.payment_url_with_reference(reference)).to eq("#{payment_url}?reference=#{reference}")
       end
     end
 
@@ -137,7 +51,7 @@ RSpec.describe Form, type: :model, feature_direct_api_enabled: false do
       let(:payment_url) { nil }
 
       it "returns nil" do
-        expect(described_class.find(1).payment_url_with_reference(reference)).to be_nil
+        expect(form.payment_url_with_reference(reference)).to be_nil
       end
     end
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -25,60 +25,34 @@ RSpec.describe Form, type: :model, feature_direct_api_enabled: false do
   end
 
   describe "#live?" do
-    context "when live_at is not set" do
-      let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", start_page: 1 }.to_json }
-
-      it "raises an error" do
-        expect { described_class.find(1).live? }.to raise_error(Date::Error)
-      end
+    it "when live_at is not set raises an error" do
+      expect { described_class.new({ id: 1, name: "form name", submission_email: "user@example.com", start_page: 1 }).live? }.to raise_error(Date::Error)
     end
 
-    context "when no live_at is set to empty string" do
-      let(:response_data) { { id: 1, name: "form name", live_at: "", submission_email: "user@example.com", start_page: 1 }.to_json }
-
-      it "returns false" do
-        expect(described_class.find(1).live?).to be false
-      end
+    it "when no live_at is set to empty string returns false" do
+      expect(described_class.new({ id: 1, name: "form name", live_at: "", submission_email: "user@example.com", start_page: 1 }).live?).to be false
     end
 
-    context "when live_at is a string which isn't a valid date" do
-      let(:response_data) { { id: 1, name: "form name", live_at: "not a date!", submission_email: "user@example.com", start_page: 1 }.to_json }
-
-      it "raises an error" do
-        expect { described_class.find(1).live? }.to raise_error(Date::Error)
-      end
+    it "when live_at is a string which isn't a valid date raises an error" do
+      expect {
+        described_class.new({ id: 1, name: "form name", live_at: "not a date!", submission_email: "user@example.com", start_page: 1 }).live?
+      }.to raise_error(Date::Error)
     end
 
-    context "when live_at is not a string" do
-      let(:response_data) { { id: 1, name: "form name", live_at: 1, submission_email: "user@example.com", start_page: 1 }.to_json }
-
-      it "raises an error" do
-        expect { described_class.find(1).live? }.to raise_error(Date::Error)
-      end
+    it "when live_at is not a string raises an error" do
+      expect { described_class.new({ id: 1, name: "form name", live_at: 1, submission_email: "user@example.com", start_page: 1 }).live? }.to raise_error(Date::Error)
     end
 
-    context "when live_at is a date in the future" do
-      let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z", submission_email: "user@example.com", start_page: 1 }.to_json }
-
-      it "returns false" do
-        expect(described_class.find(1).live?("2022-01-01 10:00:00Z")).to be false
-      end
+    it "when live_at is a date in the future returns false" do
+      expect(described_class.new({ id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z", submission_email: "user@example.com", start_page: 1 }).live?("2022-01-01 10:00:00Z")).to be false
     end
 
-    context "when live_at is a date in the past" do
-      let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z", submission_email: "user@example.com", start_page: 1 }.to_json }
-
-      it "returns true" do
-        expect(described_class.find(1).live?("2023-01-01 10:00:00Z")).to be true
-      end
+    it "when live_at is a date in the past returns true" do
+      expect(described_class.new({ id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z", submission_email: "user@example.com", start_page: 1 }).live?("2023-01-01 10:00:00Z")).to be true
     end
 
-    context "when dates are the same" do
-      let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z", submission_email: "user@example.com", start_page: 1 }.to_json }
-
-      it "returns false" do
-        expect(described_class.find(1).live?("2022-08-18 09:16:50Z")).to be false
-      end
+    it "when dates are the same returns false" do
+      expect(described_class.new({ id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z", submission_email: "user@example.com", start_page: 1 }).live?("2022-08-18 09:16:50Z")).to be false
     end
   end
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Form, type: :model do
+RSpec.describe Form, type: :model, feature_direct_api_enabled: false do
   let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", start_page: 1 }.to_json }
 
   let(:pages_data) do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -24,19 +24,6 @@ RSpec.describe Form, type: :model do
     end
   end
 
-  it "returns a simple form" do
-    expect(described_class.find(1)).to have_attributes(id: 1, name: "form name", submission_email: "user@example.com")
-  end
-
-  describe "Getting the pages for a form" do
-    it "returns the pages for a form" do
-      pages = described_class.find(1).pages
-      expect(pages.length).to eq(2)
-      expect(pages[0]).to have_attributes(id: 9, next_page: 10, answer_type: "date", question_text: "Question one")
-      expect(pages[1]).to have_attributes(id: 10, answer_type: "address", question_text: "Question two")
-    end
-  end
-
   describe "#live?" do
     context "when live_at is not set" do
       let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", start_page: 1 }.to_json }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
-RSpec.describe Form, type: :model, feature_direct_api_enabled: false do
+RSpec.describe Form, feature_direct_api_enabled: false, type: :model do
   describe "#live?" do
     let(:form) { build :form }
 
     it "when no live_at is set to empty string returns false" do
-      form.live_at = ''
+      form.live_at = ""
       expect(form.live?).to be false
     end
 
     it "when live_at is a string which isn't a valid date raises an error" do
-      form.live_at = 'invalid date'
+      form.live_at = "invalid date"
       expect { form.live? }.to raise_error(Date::Error)
     end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -2,6 +2,6 @@ require "rails_helper"
 
 RSpec.describe Page, type: :model do
   it "returns the page given a hash" do
-    expect(described_class.from_json({ "answer_settings" => { "input_type" => 'text' }, routing_conditions: []}).answer_settings.input_type).to eq('text')
+    expect(described_class.from_json({ "answer_settings" => { "input_type" => "text" }, routing_conditions: [] }).answer_settings.input_type).to eq("text")
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,49 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Page, type: :model do
-  let(:response_data) do
-    {
-      id: 1,
-      question_text: "Question text",
-      answer_type: "date",
-    }.to_json
-  end
-
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
-
-  before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2/pages/1", req_headers, response_data, 200
-    end
-  end
-
-  it "returns the page for a form" do
-    expect(described_class.find(1, params: { form_id: 2 })).to have_attributes(id: 1, question_text: "Question text", answer_type: "date")
-  end
-
-  context "when answer_settings is not present" do
-    it "returns an empty object for answer_settings" do
-      expect(described_class.find(1, params: { form_id: 2 })).to have_attributes(answer_settings: {})
-    end
-  end
-
-  context "when answer_settings is present" do
-    let(:response_data) do
-      {
-        id: 1,
-        question_text: "Question text",
-        answer_type: "selection",
-        answer_settings: { only_one_option: "true" },
-      }.to_json
-    end
-
-    it "returns an answer settings object for answer_settings" do
-      expect(described_class.find(1, params: { form_id: 2 }).answer_settings.attributes).to eq({ "only_one_option" => "true" })
-    end
+  it "returns the page given a hash" do
+    expect(described_class.new({ "answer_settings" => { "input_type" => 'text' }, routing_conditions: []}).answer_settings.input_type).to eq('text')
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -2,6 +2,6 @@ require "rails_helper"
 
 RSpec.describe Page, type: :model do
   it "returns the page given a hash" do
-    expect(described_class.new({ "answer_settings" => { "input_type" => 'text' }, routing_conditions: []}).answer_settings.input_type).to eq('text')
+    expect(described_class.from_json({ "answer_settings" => { "input_type" => 'text' }, routing_conditions: []}).answer_settings.input_type).to eq('text')
   end
 end

--- a/spec/repositories/form_direct_spec.rb
+++ b/spec/repositories/form_direct_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+require_relative "./shared_examples/repository_examples"
+
+describe FormDirect do
+  subject(:repository) { described_class }
+
+  it_behaves_like "a form repository"
+end

--- a/spec/repositories/form_resource_spec.rb
+++ b/spec/repositories/form_resource_spec.rb
@@ -1,45 +1,8 @@
 require "rails_helper"
+require_relative "./shared_examples/repository_examples"
 
 describe FormResource do
-  describe "#find_with_mode" do
-    let(:req_headers) do
-      {
-        "X-API-Token" => Settings.forms_api.auth_key,
-        "Accept" => "application/json",
-      }
-    end
+  subject(:repository) { described_class }
 
-    context "when mode is live" do
-      let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z" }.to_json }
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/1/live", req_headers, response_data, 200
-        end
-      end
-
-      it "returns a live form" do
-        form = described_class.find_with_mode(id: 1, mode: 'live')
-
-        expect(form).to have_attributes(id: 1, name: "form name")
-        expect(form.live?).to eq(true)
-      end
-    end
-
-    context "when mode is draft" do
-      let(:response_data) { { id: 1, name: "form name", live_at: nil }.to_json }
-
-      before do
-        ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/1/draft", req_headers, response_data, 200
-        end
-      end
-
-      it "returns a draft form" do
-        form = described_class.find_with_mode(id: 1, mode: "draft")
-
-        expect(form).to have_attributes(id: 1, name: "form name")
-        expect(form.live?).to eq(false)
-      end
-    end
-  end
+  it_behaves_like "a form repository"
 end

--- a/spec/repositories/form_resource_spec.rb
+++ b/spec/repositories/form_resource_spec.rb
@@ -1,0 +1,37 @@
+describe FormResource do
+  describe "#find_with_mode" do
+    context "when mode is live" do
+      let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z" }.to_json }
+
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/forms/1/live", req_headers, response_data, 200
+        end
+      end
+
+      it "returns a live form" do
+        form = described_class.find_with_mode(id: 1, mode: Mode.new("live"))
+
+        expect(form).to have_attributes(id: 1, name: "form name")
+        expect(form.live?).to eq(true)
+      end
+    end
+
+    context "when mode is draft" do
+      let(:response_data) { { id: 1, name: "form name", live_at: nil }.to_json }
+
+      before do
+        ActiveResource::HttpMock.respond_to do |mock|
+          mock.get "/api/v1/forms/1/draft", req_headers, response_data, 200
+        end
+      end
+
+      it "returns a draft form" do
+        form = described_class.find_with_mode(id: 1, mode: Mode.new("preview-draft"))
+
+        expect(form).to have_attributes(id: 1, name: "form name")
+        expect(form.live?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/repositories/form_resource_spec.rb
+++ b/spec/repositories/form_resource_spec.rb
@@ -1,8 +1,16 @@
+require "rails_helper"
+
 describe FormResource do
   describe "#find_with_mode" do
+    let(:req_headers) do
+      {
+        "X-API-Token" => Settings.forms_api.auth_key,
+        "Accept" => "application/json",
+      }
+    end
+
     context "when mode is live" do
       let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z" }.to_json }
-
       before do
         ActiveResource::HttpMock.respond_to do |mock|
           mock.get "/api/v1/forms/1/live", req_headers, response_data, 200
@@ -10,7 +18,7 @@ describe FormResource do
       end
 
       it "returns a live form" do
-        form = described_class.find_with_mode(id: 1, mode: Mode.new("live"))
+        form = described_class.find_with_mode(id: 1, mode: 'live')
 
         expect(form).to have_attributes(id: 1, name: "form name")
         expect(form.live?).to eq(true)
@@ -27,7 +35,7 @@ describe FormResource do
       end
 
       it "returns a draft form" do
-        form = described_class.find_with_mode(id: 1, mode: Mode.new("preview-draft"))
+        form = described_class.find_with_mode(id: 1, mode: "draft")
 
         expect(form).to have_attributes(id: 1, name: "form name")
         expect(form.live?).to eq(false)

--- a/spec/repositories/shared_examples/repository_examples.rb
+++ b/spec/repositories/shared_examples/repository_examples.rb
@@ -1,0 +1,44 @@
+RSpec.shared_examples "a form repository" do |_parameter|
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  describe "#find_with_mode" do
+    context "when mode is live" do
+      let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z" }.to_json }
+
+      before do
+        stub_request(:get, "#{Settings.forms_api.base_url}/api/v1/forms/1/live")
+          .with(headers: req_headers)
+          .to_return_json(body: response_data)
+      end
+
+      it "returns a live form" do
+        form = described_class.find_with_mode(id: 1, mode: "live")
+
+        expect(form).to have_attributes(id: 1, name: "form name")
+        expect(form.live?).to eq(true)
+      end
+    end
+
+    context "when mode is draft" do
+      let(:response_data) { { id: 1, name: "form name", live_at: nil }.to_json }
+
+      before do
+        stub_request(:get, "#{Settings.forms_api.base_url}/api/v1/forms/1/draft")
+          .with(headers: req_headers)
+          .to_return_json(body: response_data)
+      end
+
+      it "returns a draft form" do
+        form = described_class.find_with_mode(id: 1, mode: "draft")
+
+        expect(form).to have_attributes(id: 1, name: "form name")
+        expect(form.live?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/repositories/shared_examples/repository_examples.rb
+++ b/spec/repositories/shared_examples/repository_examples.rb
@@ -20,7 +20,7 @@ RSpec.shared_examples "a form repository" do |_parameter|
         form = described_class.find_with_mode(id: 1, mode: "live")
 
         expect(form).to have_attributes(id: 1, name: "form name")
-        expect(form.live?).to eq(true)
+        expect(form.live?).to be(true)
       end
     end
 
@@ -37,7 +37,7 @@ RSpec.shared_examples "a form repository" do |_parameter|
         form = described_class.find_with_mode(id: 1, mode: "draft")
 
         expect(form).to have_attributes(id: 1, name: "form name")
-        expect(form.live?).to eq(false)
+        expect(form.live?).to be(false)
       end
     end
   end

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ErrorsController, type: :request do
   end
 
   describe "Submission error" do
-    let(:form_data) do
+    let(:form) do
       build(
         :form,
         :with_support,
@@ -46,22 +46,13 @@ RSpec.describe ErrorsController, type: :request do
         submission_email: "submission@email.com",
         start_page: 1,
         pages: [
-          (build :page, id: 1, answer_type: "text", answer_settings: { input_type: "single_line" }),
+          (build :page, :with_text_settings, id: 1, input_type: "single_line")
         ],
       )
     end
 
-    let(:req_headers) do
-      {
-        "X-API-Token" => Settings.forms_api.auth_key,
-        "Accept" => "application/json",
-      }
-    end
-
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/2/live", req_headers, form_data.to_json, 200
-      end
+      allow(FormService).to receive(:find_with_mode).with(id: '2', mode: kind_of(Mode)).and_return(form)
 
       # setup the context in the session
       get form_page_path(mode: "form", form_id: 2, form_slug: "form-name", page_slug: 1)

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe ErrorsController, type: :request do
         submission_email: "submission@email.com",
         start_page: 1,
         pages: [
-          (build :page, :with_text_settings, id: 1, input_type: "single_line")
+          (build :page, :with_text_settings, id: 1, input_type: "single_line"),
         ],
       )
     end
 
     before do
-      allow(FormService).to receive(:find_with_mode).with(id: '2', mode: kind_of(Mode)).and_return(form)
+      allow(FormService).to receive(:find_with_mode).with(id: "2", mode: kind_of(Mode)).and_return(form)
 
       # setup the context in the session
       get form_page_path(mode: "form", form_id: 2, form_slug: "form-name", page_slug: 1)

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -45,20 +45,18 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
   let(:pages_data) do
     [
       build(:page,
-        id: 1,
-        position: 1,
-        question_text: "Question one",
-        answer_type: "date",
-        next_page: 2,
-        is_optional: nil,
-      ),
+            id: 1,
+            position: 1,
+            question_text: "Question one",
+            answer_type: "date",
+            next_page: 2,
+            is_optional: nil),
       build(:page,
-        id: 2,
-        position: 2,
-        question_text: "Question two",
-        answer_type: "date",
-        is_optional: nil,
-      ),
+            id: 2,
+            position: 2,
+            question_text: "Question two",
+            answer_type: "date",
+            is_optional: nil),
     ]
   end
 

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe Forms::PageController, type: :request do
   let(:timestamp_of_request) { Time.utc(2022, 12, 14, 10, 0o0, 0o0) }
 
-  let(:form_data) do
+  let(:form) do
     build(:form, :with_support,
           id: 2,
           live_at:,
@@ -33,7 +33,7 @@ RSpec.describe Forms::PageController, type: :request do
     build :page, :with_selections_settings,
           id: 1,
           next_page: 2,
-          routing_conditions: [DataStruct.new(id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3, answer_value: "Option 1", validation_errors:)],
+          routing_conditions: [RoutingCondition.new(id: 1, routing_page_id: 1, check_page_id: 1, goto_page_id: 3, answer_value: "Option 1", validation_errors:)],
           is_optional: false
   end
 
@@ -41,27 +41,18 @@ RSpec.describe Forms::PageController, type: :request do
 
   let(:is_optional) { false }
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
-
   let(:api_url_suffix) { "/live" }
 
   let(:output) { StringIO.new }
   let(:logger) { ActiveSupport::Logger.new(output) }
 
   before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2#{api_url_suffix}", req_headers, form_data.to_json, 200
-    end
+    allow(FormService).to receive(:find_with_mode).with(id: form.id.to_s, mode: kind_of(Mode)).and_return(form)
   end
 
   context "when setting logging context" do
     let(:page_id) { 101 }
-    let(:form_data) do
+    let(:form) do
       build(:form, :with_support,
             id: 200,
             live_at:,
@@ -79,11 +70,7 @@ RSpec.describe Forms::PageController, type: :request do
       # Intercept the request logs so we can do assertions on them
       allow(Lograge).to receive(:logger).and_return(logger)
 
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/200#{api_url_suffix}", req_headers, form_data.to_json, 200
-      end
-
-      get form_page_path("form", 200, form_data.form_slug, page_id)
+      get form_page_path("form", 200, form.form_slug, page_id)
     end
 
     it "adds the page ID to the instrumentation payload" do
@@ -100,32 +87,32 @@ RSpec.describe Forms::PageController, type: :request do
       let(:api_url_suffix) { "/draft" }
 
       it "Returns a 200" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+        get form_page_path("preview-draft", 2, form.form_slug, 1)
         expect(response).to have_http_status(:ok)
       end
 
       it "redirects to first page if second request before first complete" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 2)
-        expect(response).to redirect_to(form_page_path(2, form_data.form_slug, 1))
+        get form_page_path("preview-draft", 2, form.form_slug, 2)
+        expect(response).to redirect_to(form_page_path(2, form.form_slug, 1))
       end
 
       it "Displays the question text on the page" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
-        expect(response.body).to include(form_data.pages.first.question_text)
+        get form_page_path("preview-draft", 2, form.form_slug, 1)
+        expect(response.body).to include(form.pages.first.question_text)
       end
 
       it "Displays the privacy policy link on the page" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+        get form_page_path("preview-draft", 2, form.form_slug, 1)
         expect(response.body).to include("Privacy")
       end
 
       it "Displays the accessibility statement link on the page" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+        get form_page_path("preview-draft", 2, form.form_slug, 1)
         expect(response.body).to include("Accessibility statement")
       end
 
       it "Displays the Cookies link on the page" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+        get form_page_path("preview-draft", 2, form.form_slug, 1)
         expect(response.body).to include("Cookies")
       end
 
@@ -134,33 +121,33 @@ RSpec.describe Forms::PageController, type: :request do
           allow_any_instance_of(Flow::Context).to receive(:can_visit?)
                                               .and_return(true)
           allow_any_instance_of(Flow::Context).to receive(:previous_step).and_return(1)
-          get form_page_path("preview-draft", 2, form_data.form_slug, 2)
-          expect(response.body).to include(form_page_path(2, form_data.form_slug, 1))
+          get form_page_path("preview-draft", 2, form.form_slug, 2)
+          expect(response.body).to include(form_page_path(2, form.form_slug, 1))
         end
       end
 
       context "with a change answers page" do
         it "Displays a back link to the check your answers page" do
-          get form_change_answer_path("preview-draft", 2, form_data.form_slug, 1)
-          expect(response.body).to include(check_your_answers_path("preview-draft", 2, form_data.form_slug))
+          get form_change_answer_path("preview-draft", 2, form.form_slug, 1)
+          expect(response.body).to include(check_your_answers_path("preview-draft", 2, form.form_slug))
         end
 
         it "Passes the changing answers parameter in its submit request" do
-          get form_change_answer_path("preview-draft", 2, form_data.form_slug, 1)
-          expect(response.body).to include(save_form_page_path("preview-draft", 2, form_data.form_slug, 1, changing_existing_answer: true))
+          get form_change_answer_path("preview-draft", 2, form.form_slug, 1)
+          expect(response.body).to include(save_form_page_path("preview-draft", 2, form.form_slug, 1, changing_existing_answer: true))
         end
       end
 
       it "Returns the correct X-Robots-Tag header" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+        get form_page_path("preview-draft", 2, form.form_slug, 1)
         expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
       end
 
       context "with no questions answered" do
         it "redirects if a later page is requested" do
-          get check_your_answers_path("preview-draft", 2, form_data.form_slug)
+          get check_your_answers_path("preview-draft", 2, form.form_slug)
           expect(response).to have_http_status(:found)
-          expect(response.location).to eq(form_page_url("preview-draft", 2, form_data.form_slug, 1))
+          expect(response.location).to eq(form_page_url("preview-draft", 2, form.form_slug, 1))
         end
       end
     end
@@ -198,32 +185,32 @@ RSpec.describe Forms::PageController, type: :request do
       end
 
       it "Returns a 200" do
-        get form_page_path("form", 2, form_data.form_slug, 1)
+        get form_page_path("form", 2, form.form_slug, 1)
         expect(response).to have_http_status(:ok)
       end
 
       it "redirects to first page if second request before first complete" do
-        get form_page_path("form", 2, form_data.form_slug, 2)
-        expect(response).to redirect_to(form_page_path(2, form_data.form_slug, 1))
+        get form_page_path("form", 2, form.form_slug, 2)
+        expect(response).to redirect_to(form_page_path(2, form.form_slug, 1))
       end
 
       it "Displays the question text on the page" do
-        get form_page_path("form", 2, form_data.form_slug, 1)
-        expect(response.body).to include(form_data.pages.first.question_text)
+        get form_page_path("form", 2, form.form_slug, 1)
+        expect(response.body).to include(form.pages.first.question_text)
       end
 
       it "Displays the privacy policy link on the page" do
-        get form_page_path("form", 2, form_data.form_slug, 1)
+        get form_page_path("form", 2, form.form_slug, 1)
         expect(response.body).to include("Privacy")
       end
 
       it "Displays the accessibility statement link on the page" do
-        get form_page_path("form", 2, form_data.form_slug, 1)
+        get form_page_path("form", 2, form.form_slug, 1)
         expect(response.body).to include("Accessibility statement")
       end
 
       it "Displays the Cookies link on the page" do
-        get form_page_path("form", 2, form_data.form_slug, 1)
+        get form_page_path("form", 2, form.form_slug, 1)
         expect(response.body).to include("Cookies")
       end
 
@@ -232,33 +219,33 @@ RSpec.describe Forms::PageController, type: :request do
           allow_any_instance_of(Flow::Context).to receive(:can_visit?)
                                               .and_return(true)
           allow_any_instance_of(Flow::Context).to receive(:previous_step).and_return(1)
-          get form_page_path("form", 2, form_data.form_slug, 2)
-          expect(response.body).to include(form_page_path(2, form_data.form_slug, 1))
+          get form_page_path("form", 2, form.form_slug, 2)
+          expect(response.body).to include(form_page_path(2, form.form_slug, 1))
         end
       end
 
       context "with a change answers page" do
         it "Displays a back link to the check your answers page" do
-          get form_change_answer_path("form", 2, form_data.form_slug, 1)
-          expect(response.body).to include(check_your_answers_path("form", 2, form_data.form_slug))
+          get form_change_answer_path("form", 2, form.form_slug, 1)
+          expect(response.body).to include(check_your_answers_path("form", 2, form.form_slug))
         end
 
         it "Passes the changing answers parameter in its submit request" do
-          get form_change_answer_path("form", 2, form_data.form_slug, 1)
-          expect(response.body).to include(save_form_page_path("form", 2, form_data.form_slug, 1, changing_existing_answer: true))
+          get form_change_answer_path("form", 2, form.form_slug, 1)
+          expect(response.body).to include(save_form_page_path("form", 2, form.form_slug, 1, changing_existing_answer: true))
         end
       end
 
       it "Returns the correct X-Robots-Tag header" do
-        get form_page_path("form", 2, form_data.form_slug, 1)
+        get form_page_path("form", 2, form.form_slug, 1)
         expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
       end
 
       context "with no questions answered" do
         it "redirects if a later page is requested" do
-          get check_your_answers_path("form", 2, form_data.form_slug)
+          get check_your_answers_path("form", 2, form.form_slug)
           expect(response).to have_http_status(:found)
-          expect(response.location).to eq(form_page_url("form", 2, form_data.form_slug, 1))
+          expect(response.location).to eq(form_page_url("form", 2, form.form_slug, 1))
         end
       end
 
@@ -267,7 +254,7 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "returns 404" do
           travel_to timestamp_of_request do
-            get form_page_path("form", 2, form_data.form_slug, 1)
+            get form_page_path("form", 2, form.form_slug, 1)
           end
 
           expect(response).to have_http_status(:not_found)
@@ -286,7 +273,7 @@ RSpec.describe Forms::PageController, type: :request do
       end
 
       it "Returns a 200" do
-        get form_page_path("preview-live", 2, form_data.form_slug, 1)
+        get form_page_path("preview-live", 2, form.form_slug, 1)
         expect(response).to have_http_status(:ok)
       end
     end
@@ -317,15 +304,15 @@ RSpec.describe Forms::PageController, type: :request do
 
       context "when the routing has a cannot_have_goto_page_before_routing_page error" do
         let(:pages_data) { [first_page_in_form, second_page_in_form, third_page_in_form] }
-        let(:validation_errors) { [{ name: "cannot_have_goto_page_before_routing_page" }] }
+        let(:validation_errors) { [ValidationError.new(name: "cannot_have_goto_page_before_routing_page")] }
 
         it "returns a 422 response" do
-          get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+          get form_page_path("preview-draft", 2, form.form_slug, 1)
           expect(response).to have_http_status(:unprocessable_entity)
         end
 
         it "shows the error page" do
-          get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+          get form_page_path("preview-draft", 2, form.form_slug, 1)
           link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/conditions/1"
           question_number = first_page_in_form.position
           expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))
@@ -343,50 +330,50 @@ RSpec.describe Forms::PageController, type: :request do
       let(:api_url_suffix) { "/draft" }
 
       it "Redirects to the next page" do
-        post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path("preview-draft", 2, form_data.form_slug, 2))
+        post save_form_page_path("preview-draft", 2, form.form_slug, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path("preview-draft", 2, form.form_slug, 2))
       end
 
       context "when changing an existing answer" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
-          expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, form_data.form_slug))
+          post save_form_page_path("preview-draft", 2, form.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, form.form_slug))
         end
 
         it "does not log the change_answer_page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          post save_form_page_path("preview-draft", 2, form.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
         end
       end
 
       context "with the first page" do
         it "Logs the first_page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "answer text" } }
+          post save_form_page_path("preview-draft", 2, form.form_slug, 1), params: { question: { text: "answer text" } }
         end
 
         it "clears the submission reference from the session" do
           expect_any_instance_of(Flow::Context).to receive(:clear_submission_details).once
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "answer text" } }
+          post save_form_page_path("preview-draft", 2, form.form_slug, 1), params: { question: { text: "answer text" } }
         end
       end
 
       context "with a subsequent page" do
         it "Logs the page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+          post save_form_page_path("preview-draft", 2, form.form_slug, 2), params: { question: { text: "answer text" } }
         end
 
         it "does not clear the submission reference from the session" do
           expect_any_instance_of(Flow::Context).not_to receive(:clear_submission_details)
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+          post save_form_page_path("preview-draft", 2, form.form_slug, 2), params: { question: { text: "answer text" } }
         end
       end
 
       context "with the final page" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
-          expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, form_data.form_slug))
+          post save_form_page_path("preview-draft", 2, form.form_slug, 2), params: { question: { text: "answer text" } }
+          expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, form.form_slug))
         end
       end
 
@@ -395,7 +382,7 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "does not return 404" do
           travel_to timestamp_of_request do
-            post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+            post save_form_page_path("preview-draft", 2, form.form_slug, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
           end
           expect(response).not_to have_http_status(:not_found)
         end
@@ -403,7 +390,7 @@ RSpec.describe Forms::PageController, type: :request do
 
       context "when the form is invalid" do
         before do
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "" }, changing_existing_answer: false }
+          post save_form_page_path("preview-draft", 2, form.form_slug, 1), params: { question: { text: "" }, changing_existing_answer: false }
         end
 
         it "renders the show page template" do
@@ -418,40 +405,40 @@ RSpec.describe Forms::PageController, type: :request do
 
     context "with preview mode off" do
       it "Redirects to the next page" do
-        post save_form_page_path("form", 2, form_data.form_slug, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path("form", 2, form_data.form_slug, 2))
+        post save_form_page_path("form", 2, form.form_slug, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path("form", 2, form.form_slug, 2))
       end
 
       context "when changing an existing answer" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("form", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
-          expect(response).to redirect_to(check_your_answers_path("form", 2, form_data.form_slug))
+          post save_form_page_path("form", 2, form.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          expect(response).to redirect_to(check_your_answers_path("form", 2, form.form_slug))
         end
 
         it "Logs the change_answer_page_save event" do
           expect(EventLogger).to receive(:log_page_event).with("change_answer_page_save", first_page_in_form.question_text, nil)
-          post save_form_page_path("form", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          post save_form_page_path("form", 2, form.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
         end
       end
 
       context "with the first page" do
         it "Logs the first_page_save event" do
           expect(EventLogger).to receive(:log_page_event).with("first_page_save", first_page_in_form.question_text, nil)
-          post save_form_page_path("form", 2, form_data.form_slug, 1), params: { question: { text: "answer text" } }
+          post save_form_page_path("form", 2, form.form_slug, 1), params: { question: { text: "answer text" } }
         end
       end
 
       context "with a subsequent page" do
         it "Logs the page_save event" do
           expect(EventLogger).to receive(:log_page_event).with("page_save", second_page_in_form.question_text, nil)
-          post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+          post save_form_page_path("form", 2, form.form_slug, 2), params: { question: { text: "answer text" } }
         end
       end
 
       context "with the final page" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
-          expect(response).to redirect_to(check_your_answers_path("form", 2, form_data.form_slug))
+          post save_form_page_path("form", 2, form.form_slug, 2), params: { question: { text: "answer text" } }
+          expect(response).to redirect_to(check_your_answers_path("form", 2, form.form_slug))
         end
       end
 
@@ -461,21 +448,21 @@ RSpec.describe Forms::PageController, type: :request do
         context "when an optional question is completed" do
           it "Logs the optional_save event with skipped_question as true" do
             expect(EventLogger).to receive(:log_page_event).with("optional_save", second_page_in_form.question_text, true)
-            post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "" } }
+            post save_form_page_path("form", 2, form.form_slug, 2), params: { question: { text: "" } }
           end
         end
 
         context "when an optional question is skipped" do
           it "Logs the optional_save event with skipped_question as false" do
             expect(EventLogger).to receive(:log_page_event).with("optional_save", second_page_in_form.question_text, false)
-            post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+            post save_form_page_path("form", 2, form.form_slug, 2), params: { question: { text: "answer text" } }
           end
         end
       end
 
       context "when the form is invalid" do
         before do
-          post save_form_page_path("form", 2, form_data.form_slug, 1), params: { question: { text: "" }, changing_existing_answer: false }
+          post save_form_page_path("form", 2, form.form_slug, 1), params: { question: { text: "" }, changing_existing_answer: false }
         end
 
         it "renders the show page template" do
@@ -513,28 +500,28 @@ RSpec.describe Forms::PageController, type: :request do
       let(:api_url_suffix) { "/draft" }
 
       it "redirects to the goto page if answer value matches condition" do
-        post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { selection: "Option 1" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path("preview-draft", 2, form_data.form_slug, 3))
+        post save_form_page_path("preview-draft", 2, form.form_slug, 1), params: { question: { selection: "Option 1" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path("preview-draft", 2, form.form_slug, 3))
       end
 
       context "when the answer_value does not match the condition" do
         it "redirects to the next page in the journey" do
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
-          expect(response).to redirect_to(form_page_path("preview-draft", 2, form_data.form_slug, 2))
+          post save_form_page_path("preview-draft", 2, form.form_slug, 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
+          expect(response).to redirect_to(form_page_path("preview-draft", 2, form.form_slug, 2))
         end
       end
 
       context "when the routing has a cannot_have_goto_page_before_routing_page error" do
         let(:pages_data) { [first_page_in_form, second_page_in_form, third_page_in_form] }
-        let(:validation_errors) { [{ name: "cannot_have_goto_page_before_routing_page" }] }
+        let(:validation_errors) { [ValidationError.new(name: "cannot_have_goto_page_before_routing_page")] }
 
         it "returns a 422 response" do
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
+          post save_form_page_path("preview-draft", 2, form.form_slug, 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
           expect(response).to have_http_status(:unprocessable_entity)
         end
 
         it "shows the error page" do
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
+          post save_form_page_path("preview-draft", 2, form.form_slug, 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
           link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/conditions/1"
           question_number = first_page_in_form.position
           expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))

--- a/spec/requests/forms/privacy_page_controller_spec.rb
+++ b/spec/requests/forms/privacy_page_controller_spec.rb
@@ -1,54 +1,18 @@
 require "rails_helper"
 
 RSpec.describe Forms::PrivacyPageController, type: :request do
-  let(:form_data) do
-    build(:form, :with_support,
-          id: 2,
-          start_page: 1,
-          privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-          what_happens_next_markdown: "Good things come to those that wait",
-          declaration_text: "agree to the declaration",
-          pages: pages_data)
-  end
-
-  let(:pages_data) do
-    [
-      {
-        id: 1,
-        position: 1,
-        question_text: "Question one",
-        answer_type: "date",
-        next_page: 2,
-        is_optional: nil,
-      },
-      {
-        id: 2,
-        position: 2,
-        question_text: "Question two",
-        answer_type: "date",
-        is_optional: nil,
-      },
-    ]
-  end
-
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
+  let(:form) do
+    build(:form, :with_pages)
   end
 
   describe "#show" do
     before do
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/2/draft", req_headers, form_data.to_json, 200
-      end
-
-      get form_privacy_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug)
+      allow(FormService).to receive(:find_with_mode).with(id: form.id.to_s, mode: kind_of(Mode)).and_return(form)
+      get form_privacy_path(mode: "preview-draft", form_id: form.id, form_slug: form.form_slug)
     end
 
     it "includes the privacy policy URL" do
-      expect(response.body).to include(form_data.privacy_policy_url)
+      expect(response.body).to include(form.privacy_policy_url)
     end
 
     it "renders the show privacy page template" do

--- a/spec/requests/forms/submitted_controller_spec.rb
+++ b/spec/requests/forms/submitted_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Forms::SubmittedController, type: :request do
-  let(:context) { Flow::Context.new(form: form, store:) }
+  let(:context) { Flow::Context.new(form:, store:) }
 
   let(:form) do
     build(:form, :with_support,

--- a/spec/services/form_service_spec.rb
+++ b/spec/services/form_service_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe FormService do
+  context "when validating the provided form id" do
+
+    it "returns ResourceNotFound when the id contains non-alpha-numeric chars" do
+      expect {
+        described_class.find_with_mode(id: "<id>", mode: Mode.new("preview-draft"))
+      }.to raise_error(ActiveResource::ResourceNotFound)
+    end
+
+    it "returns ResourceNotFound when the id is blank" do
+      expect {
+        described_class.find_with_mode(id: "", mode: Mode.new("preview-draft"))
+      }.to raise_error(ActiveResource::ResourceNotFound)
+    end
+
+    context "when id is alphanumeric and form exists in repository" do
+      let(:form) { build :form,  id: "Alpha123", name: "form name", live_at: nil }
+
+      before do
+        mock_repository = class_double(FormRepository, find_with_mode: form)
+        allow(FormService).to receive(:repository).and_return(mock_repository)
+      end
+
+      it "returns the form" do
+        form = described_class.find_with_mode(id: "Alpha123", mode: Mode.new("preview-draft"))
+
+        expect(form).to have_attributes(id: "Alpha123", name: "form name")
+        expect(form.live?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/services/form_service_spec.rb
+++ b/spec/services/form_service_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 describe FormService do
   context "when validating the provided form id" do
-
     it "returns ResourceNotFound when the id contains non-alpha-numeric chars" do
       expect {
         described_class.find_with_mode(id: "<id>", mode: Mode.new("preview-draft"))
@@ -16,18 +15,18 @@ describe FormService do
     end
 
     context "when id is alphanumeric and form exists in repository" do
-      let(:form) { build :form,  id: "Alpha123", name: "form name", live_at: nil }
+      let(:form) { build :form, id: "Alpha123", name: "form name", live_at: nil }
 
       before do
         mock_repository = class_double(FormRepository, find_with_mode: form)
-        allow(FormService).to receive(:repository).and_return(mock_repository)
+        allow(described_class).to receive(:repository).and_return(mock_repository)
       end
 
       it "returns the form" do
         form = described_class.find_with_mode(id: "Alpha123", mode: Mode.new("preview-draft"))
 
         expect(form).to have_attributes(id: "Alpha123", name: "form name")
-        expect(form.live?).to eq(false)
+        expect(form.live?).to be(false)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "simplecov"
+require 'webmock/rspec'
 
 SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
@@ -9,6 +10,8 @@ SimpleCov.minimum_coverage 80
 SimpleCov.start "rails" do
   enable_coverage :branch
 end
+
+WebMock.disable_net_connect!(allow_localhost: true)
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "simplecov"
-require 'webmock/rspec'
+require "webmock/rspec"
 
 SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,


### PR DESCRIPTION
### What problem does this pull request solve?

This contains the first steps towards merging forms-admin with forms-api. This step abstracts away the source of forms, such that we can switch between using ActiveResource and directly making requests to the API via a feature flag.

Trello card: https://trello.com/c/DKW2M1eK

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
