### PR TITLE
Add custom component generator

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module FormsRunner
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    config.autoload_lib(ignore: %w[assets tasks generators])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/lib/generators/custom_component/USAGE
+++ b/lib/generators/custom_component/USAGE
@@ -21,6 +21,10 @@ Example:
         app/components/thing_component/_index.scss
         spec/components/thing_component/thing_component_preview.rb
         spec/components/thing_component/view_spec.rb
+        
+    If you want your styles to be rendered, you'll need to import the generated 
+    .scss file in `app/frontend/entrypoints/application.scss` or one of the scss
+    files it imports.
 
 
     bin/rails generate custom_component Thing --javascript
@@ -32,3 +36,7 @@ Example:
         app/components/thing_component/index.test.js
         spec/components/thing_component/thing_component_preview.rb
         spec/components/thing_component/view_spec.rb
+        
+    If you want your JavaScript to work, you'll need to import the generated 
+    index.js file in `app/frontend/entrypoints/application.js` or one of the JS
+    files it imports.

--- a/lib/generators/custom_component/USAGE
+++ b/lib/generators/custom_component/USAGE
@@ -1,0 +1,12 @@
+Description:
+    Generates a custom ViewComponent in the components directory with a view.rb 
+    and a html template. Also creates a spec file and preview.
+
+Example:
+    bin/rails generate custom_component Thing
+
+    This will create:
+        app/components/thing_component/view.rb
+        app/components/thing_component/view.html.erb
+        spec/components/thing_component/thing_component_preview.rb
+        spec/components/thing_component/view_spec.rb

--- a/lib/generators/custom_component/USAGE
+++ b/lib/generators/custom_component/USAGE
@@ -1,7 +1,7 @@
 Description:
     Generates a custom ViewComponent in the components directory with a view.rb 
-    and a html template. Also creates a spec file and preview. Optionally adds a
-    sass partial.
+    and a html template. Also creates a spec file and preview. Can be configured
+    to add a ass partial, javascript file and javascript test.
 
 Example:
     bin/rails generate custom_component Thing
@@ -19,5 +19,16 @@ Example:
         app/components/thing_component/view.rb
         app/components/thing_component/view.html.erb
         app/components/thing_component/_index.scss
+        spec/components/thing_component/thing_component_preview.rb
+        spec/components/thing_component/view_spec.rb
+
+
+    bin/rails generate custom_component Thing --javascript
+
+    This will create:
+        app/components/thing_component/view.rb
+        app/components/thing_component/view.html.erb
+        app/components/thing_component/index.js
+        app/components/thing_component/index.test.js
         spec/components/thing_component/thing_component_preview.rb
         spec/components/thing_component/view_spec.rb

--- a/lib/generators/custom_component/USAGE
+++ b/lib/generators/custom_component/USAGE
@@ -1,6 +1,7 @@
 Description:
     Generates a custom ViewComponent in the components directory with a view.rb 
-    and a html template. Also creates a spec file and preview.
+    and a html template. Also creates a spec file and preview. Optionally adds a
+    sass partial.
 
 Example:
     bin/rails generate custom_component Thing
@@ -8,5 +9,15 @@ Example:
     This will create:
         app/components/thing_component/view.rb
         app/components/thing_component/view.html.erb
+        spec/components/thing_component/thing_component_preview.rb
+        spec/components/thing_component/view_spec.rb
+
+
+    bin/rails generate custom_component Thing --css
+
+    This will create:
+        app/components/thing_component/view.rb
+        app/components/thing_component/view.html.erb
+        app/components/thing_component/_index.scss
         spec/components/thing_component/thing_component_preview.rb
         spec/components/thing_component/view_spec.rb

--- a/lib/generators/custom_component/custom_component_generator.rb
+++ b/lib/generators/custom_component/custom_component_generator.rb
@@ -1,6 +1,7 @@
 class CustomComponentGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("templates", __dir__)
   class_option :css, type: :boolean, default: false
+  class_option :javascript, type: :boolean, default: false
 
   def copy_view_files
     template "view.rb", "app/components/#{file_name}_component/view.rb"
@@ -10,6 +11,11 @@ class CustomComponentGenerator < Rails::Generators::NamedBase
 
     if options[:css]
       copy_file "_index.scss", "app/components/#{file_name}_component/_index.scss"
+    end
+
+    if options[:javascript]
+      copy_file "index.js", "app/components/#{file_name}_component/index.js"
+      copy_file "index.test.js", "app/components/#{file_name}_component/index.test.js"
     end
   end
 end

--- a/lib/generators/custom_component/custom_component_generator.rb
+++ b/lib/generators/custom_component/custom_component_generator.rb
@@ -1,10 +1,15 @@
 class CustomComponentGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("templates", __dir__)
+  class_option :css, type: :boolean, default: false
 
   def copy_view_files
     template "view.rb", "app/components/#{file_name}_component/view.rb"
     copy_file "view.html.erb", "app/components/#{file_name}_component/view.html.erb"
     template "view_spec.rb", "spec/components/#{file_name}_component/view_spec.rb"
     template "preview.rb", "spec/components/#{file_name}_component/#{file_name}_component_preview.rb"
+
+    if options[:css]
+      copy_file "_index.scss", "app/components/#{file_name}_component/_index.scss"
+    end
   end
 end

--- a/lib/generators/custom_component/custom_component_generator.rb
+++ b/lib/generators/custom_component/custom_component_generator.rb
@@ -1,0 +1,10 @@
+class CustomComponentGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path("templates", __dir__)
+
+  def copy_view_files
+    template "view.rb", "app/components/#{file_name}_component/view.rb"
+    copy_file "view.html.erb", "app/components/#{file_name}_component/view.html.erb"
+    template "view_spec.rb", "spec/components/#{file_name}_component/view_spec.rb"
+    template "preview.rb", "spec/components/#{file_name}_component/#{file_name}_component_preview.rb"
+  end
+end

--- a/lib/generators/custom_component/templates/_index.scss
+++ b/lib/generators/custom_component/templates/_index.scss
@@ -1,0 +1,1 @@
+// Add styles here

--- a/lib/generators/custom_component/templates/index.js
+++ b/lib/generators/custom_component/templates/index.js
@@ -1,0 +1,1 @@
+// Add JS here

--- a/lib/generators/custom_component/templates/index.test.js
+++ b/lib/generators/custom_component/templates/index.test.js
@@ -1,0 +1,1 @@
+// Add JS tests here

--- a/lib/generators/custom_component/templates/preview.rb.tt
+++ b/lib/generators/custom_component/templates/preview.rb.tt
@@ -1,0 +1,5 @@
+class <%= class_name %>Component::<%= class_name %>ComponentPreview < ViewComponent::Preview
+  def default
+
+  end
+end

--- a/lib/generators/custom_component/templates/preview.rb.tt
+++ b/lib/generators/custom_component/templates/preview.rb.tt
@@ -1,5 +1,5 @@
 class <%= class_name %>Component::<%= class_name %>ComponentPreview < ViewComponent::Preview
   def default
-
+    render(<%= class_name %>Component::View.new)
   end
 end

--- a/lib/generators/custom_component/templates/view.html.erb
+++ b/lib/generators/custom_component/templates/view.html.erb
@@ -1,0 +1,1 @@
+<%# Add HTML here %>

--- a/lib/generators/custom_component/templates/view.rb.tt
+++ b/lib/generators/custom_component/templates/view.rb.tt
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module <%= class_name %>Component
+  class View < ViewComponent::Base
+  end
+end

--- a/lib/generators/custom_component/templates/view_spec.rb.tt
+++ b/lib/generators/custom_component/templates/view_spec.rb.tt
@@ -1,0 +1,4 @@
+require "rails_helper"
+
+RSpec.describe <%= class_name %>Component::View, type: :component do
+end

--- a/lib/generators/custom_component/templates/view_spec.rb.tt
+++ b/lib/generators/custom_component/templates/view_spec.rb.tt
@@ -1,4 +1,5 @@
 require "rails_helper"
 
 RSpec.describe <%= class_name %>Component::View, type: :component do
+  pending "Add tests for this component here"
 end

--- a/spec/generator/custom_component_generator_spec.rb
+++ b/spec/generator/custom_component_generator_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "generators/custom_component/custom_component_generator"
+
+RSpec.describe "CustomComponentGenerator", type: :generator do
+  tests CustomComponentGenerator
+  destination Rails.root.join("tmp/generators")
+  arguments %w[my]
+
+  before do
+    run_generator
+  end
+
+  after do
+    FileUtils.rm_rf(destination_root)
+  end
+
+  context "when no arguments are supplied" do
+    it "creates the component files" do
+      expect(File.read(File.join(destination_root, "app/components/my_component/view.rb"))).to include("module MyComponent")
+      expect(File.read(File.join(destination_root, "app/components/my_component/view.html.erb"))).to include("<%# Add HTML here %>")
+    end
+
+    it "creates the spec files" do
+      expect(File.read(File.join(destination_root, "spec/components/my_component/my_component_preview.rb"))).to include("class MyComponent::MyComponentPreview < ViewComponent::Preview")
+      expect(File.read(File.join(destination_root, "spec/components/my_component/view_spec.rb"))).to include("RSpec.describe MyComponent::View, type: :component do")
+    end
+  end
+end

--- a/spec/generator/custom_component_generator_spec.rb
+++ b/spec/generator/custom_component_generator_spec.rb
@@ -33,4 +33,13 @@ RSpec.describe "CustomComponentGenerator", type: :generator do
       expect(File.read(File.join(destination_root, "app/components/my_component/_index.scss"))).to include("// Add styles here")
     end
   end
+
+  context "when the javascript argument is supplied" do
+    arguments ["my", "--javascript"]
+
+    it "creates the js file and test" do
+      expect(File.read(File.join(destination_root, "app/components/my_component/index.js"))).to include("// Add JS here")
+      expect(File.read(File.join(destination_root, "app/components/my_component/index.test.js"))).to include("// Add JS tests here")
+    end
+  end
 end

--- a/spec/generator/custom_component_generator_spec.rb
+++ b/spec/generator/custom_component_generator_spec.rb
@@ -16,15 +16,21 @@ RSpec.describe "CustomComponentGenerator", type: :generator do
     FileUtils.rm_rf(destination_root)
   end
 
-  context "when no arguments are supplied" do
-    it "creates the component files" do
-      expect(File.read(File.join(destination_root, "app/components/my_component/view.rb"))).to include("module MyComponent")
-      expect(File.read(File.join(destination_root, "app/components/my_component/view.html.erb"))).to include("<%# Add HTML here %>")
-    end
+  it "creates the component files" do
+    expect(File.read(File.join(destination_root, "app/components/my_component/view.rb"))).to include("module MyComponent")
+    expect(File.read(File.join(destination_root, "app/components/my_component/view.html.erb"))).to include("<%# Add HTML here %>")
+  end
 
-    it "creates the spec files" do
-      expect(File.read(File.join(destination_root, "spec/components/my_component/my_component_preview.rb"))).to include("class MyComponent::MyComponentPreview < ViewComponent::Preview")
-      expect(File.read(File.join(destination_root, "spec/components/my_component/view_spec.rb"))).to include("RSpec.describe MyComponent::View, type: :component do")
+  it "creates the spec files" do
+    expect(File.read(File.join(destination_root, "spec/components/my_component/my_component_preview.rb"))).to include("class MyComponent::MyComponentPreview < ViewComponent::Preview")
+    expect(File.read(File.join(destination_root, "spec/components/my_component/view_spec.rb"))).to include("RSpec.describe MyComponent::View, type: :component do")
+  end
+
+  context "when the css argument is supplied" do
+    arguments ["my", "--css"]
+
+    it "creates the sass partial" do
+      expect(File.read(File.join(destination_root, "app/components/my_component/_index.scss"))).to include("// Add styles here")
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ require "view_component/test_helpers"
 require "capybara/rspec"
 require "selenium/webdriver"
 require "axe-rspec"
+require "rails/generators/testing/behavior"
 
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
@@ -65,4 +66,5 @@ RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
   config.include Sentry::TestHelper
+  config.include Rails::Generators::Testing::Behavior, type: :generator
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/gEvClwPP/24-add-a-component-generator-utility

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Adds a new generator, `CustomComponentGenerator`, to the app to allow us to create new viewcomponents easily. Has flags for generating empty CSS and Javascript files in the componenty folder.

There's already a `ComponentGenerator` builtin to the ViewComponent gem, but it doesn't support the file structure we're using for our components.

Usage: `bin/rails generate custom_component Thing` with optional `--css` and `--javascript` flags.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
