### PR TITLE
Push pageview and external link events to GA

### DIFF
--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -6,7 +6,8 @@ import {
 
 import {
   installAnalyticsScript,
-  setDefaultConsent
+  setDefaultConsent,
+  sendPageViewEvent
 } from '../javascript/utils/google-analytics'
 import { CookieBanner } from '../../components/cookie_banner_component/cookie-banner'
 import { CookiePage } from '../../components/cookie_consent_form_component/cookie-consent-form'
@@ -37,6 +38,12 @@ if (document.body.dataset.googleAnalyticsEnabled === 'true') {
       allowAnalyticsCookies: analyticsConsentStatus === CONSENT_STATUS.GRANTED
     })
   }
+
+  // send pageview regardless of consent value - if consent has not been granted
+  // yet, GTM won't be loaded and no data is sent to Google analytics. Doing
+  // this  now means that if consent is granted later on this page, the event
+  // will be sent
+  sendPageViewEvent()
 }
 
 initAll()

--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -7,7 +7,8 @@ import {
 import {
   installAnalyticsScript,
   setDefaultConsent,
-  sendPageViewEvent
+  sendPageViewEvent,
+  attachExternalLinkTracker
 } from '../javascript/utils/google-analytics'
 import { CookieBanner } from '../../components/cookie_banner_component/cookie-banner'
 import { CookiePage } from '../../components/cookie_consent_form_component/cookie-consent-form'
@@ -39,11 +40,12 @@ if (document.body.dataset.googleAnalyticsEnabled === 'true') {
     })
   }
 
-  // send pageview regardless of consent value - if consent has not been granted
+  // push events regardless of consent value - if consent has not been granted
   // yet, GTM won't be loaded and no data is sent to Google analytics. Doing
   // this  now means that if consent is granted later on this page, the event
   // will be sent
   sendPageViewEvent()
+  attachExternalLinkTracker()
 }
 
 initAll()

--- a/app/frontend/javascript/utils/google-analytics/index.js
+++ b/app/frontend/javascript/utils/google-analytics/index.js
@@ -58,3 +58,19 @@ export function updateCookieConsent (consentedToAnalyticsCookies) {
     }
   ])
 }
+
+export function sendPageViewEvent () {
+  // Ideally this should be placed above the GTM container snippet and early within the <head> tags
+  window.dataLayer = window.dataLayer || []
+  window.dataLayer.push({
+    // Where a property value is not available, set it as undefined
+    event: 'page_view',
+    page_view: {
+      location: document.location,
+      referrer: document.referrer,
+      schema_name: 'simple_schema',
+      status_code: 200,
+      title: document.title
+    }
+  })
+}

--- a/app/frontend/javascript/utils/google-analytics/index.js
+++ b/app/frontend/javascript/utils/google-analytics/index.js
@@ -74,3 +74,25 @@ export function sendPageViewEvent () {
     }
   })
 }
+
+export function attachExternalLinkTracker () {
+  const externalLinks = document.querySelectorAll(
+    'a[href^="http"], a[href^="https"]'
+  )
+  externalLinks.forEach(function (externalLink) {
+    externalLink.addEventListener('click', function (event) {
+      const target = event.target
+      window.dataLayer.push({
+        event: 'event_data',
+        event_data: {
+          event_name: 'navigation',
+          external: true,
+          method: 'primary click',
+          text: target.textContent,
+          type: 'generic link',
+          url: target.href
+        }
+      })
+    })
+  })
+}

--- a/app/frontend/javascript/utils/google-analytics/index.test.js
+++ b/app/frontend/javascript/utils/google-analytics/index.test.js
@@ -125,7 +125,7 @@ describe('google_tag.mjs', () => {
       expect(window.dataLayer).toContainEqual(existingDataLayerObject)
     })
 
-    it('the pageView event is pushed to the dataLayer', function () {
+    it('the navigation event is pushed to the dataLayer', function () {
       attachExternalLinkTracker()
       document.querySelector('a').click()
       expect(window.dataLayer).toContainEqual({

--- a/app/frontend/javascript/utils/google-analytics/index.test.js
+++ b/app/frontend/javascript/utils/google-analytics/index.test.js
@@ -5,7 +5,8 @@
 import {
   installAnalyticsScript,
   deleteGoogleAnalyticsCookies,
-  sendPageViewEvent
+  sendPageViewEvent,
+  attachExternalLinkTracker
 } from '.'
 import { describe, beforeEach, afterEach, it, expect } from 'vitest'
 
@@ -101,6 +102,42 @@ describe('google_tag.mjs', () => {
             title: ''
           }
         })
+      })
+    })
+  })
+
+  describe('attachExternalLinkTracker()', () => {
+    const targetLinkText = 'A link to example.com'
+    const targetLinkUrl = 'http://example.com/'
+
+    const existingDataLayerObject = {
+      data: 'Some existing data in the dataLayer'
+    }
+
+    beforeEach(() => {
+      window.document.body.innerHTML = `<a href="${targetLinkUrl}">${targetLinkText}</a>`
+      window.dataLayer = [existingDataLayerObject]
+    })
+
+    it('the existing dataLayer content is preserved', function () {
+      attachExternalLinkTracker()
+      document.querySelector('a').click()
+      expect(window.dataLayer).toContainEqual(existingDataLayerObject)
+    })
+
+    it('the pageView event is pushed to the dataLayer', function () {
+      attachExternalLinkTracker()
+      document.querySelector('a').click()
+      expect(window.dataLayer).toContainEqual({
+        event: 'event_data',
+        event_data: {
+          event_name: 'navigation',
+          external: true,
+          method: 'primary click',
+          text: targetLinkText,
+          type: 'generic link',
+          url: targetLinkUrl
+        }
       })
     })
   })

--- a/app/frontend/javascript/utils/google-analytics/index.test.js
+++ b/app/frontend/javascript/utils/google-analytics/index.test.js
@@ -2,7 +2,11 @@
  * @vitest-environment jsdom
  */
 
-import { installAnalyticsScript, deleteGoogleAnalyticsCookies } from '.'
+import {
+  installAnalyticsScript,
+  deleteGoogleAnalyticsCookies,
+  sendPageViewEvent
+} from '.'
 import { describe, beforeEach, afterEach, it, expect } from 'vitest'
 
 describe('google_tag.mjs', () => {
@@ -48,6 +52,56 @@ describe('google_tag.mjs', () => {
 
       deleteGoogleAnalyticsCookies()
       expect(document.cookie).toContain('analytics_consent=true')
+    })
+  })
+
+  describe('sendPageViewEvent()', () => {
+    describe('when the dataLayer array is not already present on the window object', () => {
+      beforeEach(() => {
+        window.dataLayer = undefined
+      })
+
+      it('creates the dataLayer array and pushes a pageView event', function () {
+        sendPageViewEvent()
+        expect(window.dataLayer).toContainEqual({
+          event: 'page_view',
+          page_view: {
+            location: window.location,
+            referrer: '',
+            schema_name: 'simple_schema',
+            status_code: 200,
+            title: ''
+          }
+        })
+      })
+    })
+    describe('when the dataLayer array is already present on the window object', () => {
+      const existingDataLayerObject = {
+        data: 'Some existing data in the dataLayer'
+      }
+
+      beforeEach(() => {
+        window.dataLayer = [existingDataLayerObject]
+      })
+
+      it('the existing dataLayer content is preserved', function () {
+        sendPageViewEvent()
+        expect(window.dataLayer).toContainEqual(existingDataLayerObject)
+      })
+
+      it('the pageView event is pushed to the dataLayer', function () {
+        sendPageViewEvent()
+        expect(window.dataLayer).toContainEqual({
+          event: 'page_view',
+          page_view: {
+            location: window.location,
+            referrer: '',
+            schema_name: 'simple_schema',
+            status_code: 200,
+            title: ''
+          }
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/qAojecL7/1602-enable-google-analytics-in-admin-and-runner

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
We previously added and enabled google analytics in admin and runner, but events aren't coming through in GA. THis is because we weren't actually pushing the events we care about into the dataLayer.

This PR does that. The events we're pushing are:
- page views - every time a user views a page, we push an event containing some basic data about the page to GA
- external link clicks - every time a user clicks a link without a relative URL, we log some information about that URL to GA

This should be essentially identical to https://github.com/alphagov/forms-admin/pull/1362. 

### How to test
Firstly:
- Set `analytics_enabled: true` in your `development.yml` file
- login as a non-super admin user
- open the broswer console

To test page views: 
- load any page on your local forms-admin
- enter `dataLayer` in the console and inspect the array that comes back
- you should see one object in the array that looks like this:
```js
{
  event:"page_view",
  page_view:{
    location:{
      href:"http://localhost:3000/",
      origin:"http://localhost:3000/",
      protocol:"http:",
      host:"localhost:3000",
      hostname:"localhost",
      port:"3000",
      pathname:"/",
      search:"",
      hash:""
    },
    referrer:"",
    schema_name:"simple_schema",
    status_code:200,
    title:"Your groups – GOV.UK Forms"
  },
  gtm.uniqueEventId":2
}
```

To test external link clicks:
- make your life easier by stopping links taking you to another page - run this snippet in your browser console:
  - `document.querySelectorAll('a').forEach((link)=>{link.addEventListener('click',(event)=>{event.preventDefault()})})`
- click an external link (e.g. the Open Government Licence link in the footer)
- enter `dataLayer` in the console and inspect the array that comes back
- you should see one object in the array that looks like this:
```js
{
  event:"event_data",
  event_data:{
    event_name:"navigation",
    external:true,
    method:"primary click",
    text:"Open Government Licence v3.0",
    type:"generic link",
    url:"https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
  },
  gtm.uniqueEventId":5
}
```

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
