### PR TITLE
Generate CSV data for a submission

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,9 @@ gem "lograge"
 gem "aws-sdk-cloudwatch"
 gem "aws-sdk-codepipeline", "~> 1.78"
 
+# For sending submissions as CSV
+gem "csv"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
       deep_merge (~> 1.2, >= 1.2.1)
     connection_pool (2.4.1)
     crass (1.0.6)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -444,6 +445,7 @@ DEPENDENCIES
   bundler-audit (~> 0.9.0)
   capybara
   config
+  csv
   debug
   factory_bot_rails
   faker

--- a/app/services/submission_csv_service.rb
+++ b/app/services/submission_csv_service.rb
@@ -1,0 +1,24 @@
+require "csv"
+require "tempfile"
+
+class SubmissionCsvService
+  def initialize(current_context:, submission_reference:, output_file_path:)
+    @current_context = current_context
+    @submission_reference = submission_reference
+    @output_file_path = output_file_path
+  end
+
+  def write
+    headers = %w[Reference]
+    values = [@submission_reference]
+    @current_context.completed_steps.map do |page|
+      headers << page.question_text
+      values << page.show_answer
+    end
+
+    CSV.open(@output_file_path, "w") do |csv|
+      csv << headers
+      csv << values
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,5 @@
-features: {}
+features:
+  attach_csv_to_submission_email: false
 
 forms_admin:
   # URL to form-admin

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -19,11 +19,9 @@ describe "Settings" do
   end
 
   describe ".features" do
-    it "has a default value" do
-      features = settings[:features]
+    features = settings[:features]
 
-      expect(features).to eq({})
-    end
+    include_examples expected_value_test, :attach_csv_to_submission_email, features, false
   end
 
   describe ".forms_api" do

--- a/spec/services/submission_csv_service_spec.rb
+++ b/spec/services/submission_csv_service_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe SubmissionCsvService do
+  subject(:service) { described_class.new(current_context:, submission_reference:, output_file_path: test_file.path) }
+
+  let(:form) { build(:form, id: 1) }
+  let(:first_step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer: "42" }) }
+  let(:second_step) { OpenStruct.new({ question_text: "What is your email address?", show_answer: "someone@example.com" }) }
+  let(:current_context) { OpenStruct.new(form:, completed_steps: [first_step, second_step], support_details: OpenStruct.new(call_back_url: "http://gov.uk")) }
+  let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+
+  let(:test_file) { Tempfile.new("csv") }
+
+  after do
+    test_file.unlink
+  end
+
+  describe "#write" do
+    it "writes submission to CSV file" do
+      service.write
+      expect(CSV.open(test_file.path).readlines).to eq(
+        [
+          ["Reference", "What is the meaning of life?", "What is your email address?"],
+          [submission_reference, "42", "someone@example.com"],
+        ],
+      )
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/BjjG6uTU/1666-generate-csv-data-for-a-submission

If the `attach_csv_to_submission_email` feature flag is enabled, write the submission to a CSV in a temporary file.

In future, we will send the CSV to form processors using Notify.

We will also enhance the feature flag so it can be enabled on a form by form basis later.

The first column is the form reference, followed by a column per question where the header is the question name.

This uses the Ruby "csv" library, which offers basic CSV reading/writing functionality.

The outputted CSV file will use the default unix line endings and UTF-8 encoding.

### How to test

1. Comment out the `file.unlink` line in `app/services/form_submission_service.rb` locally so the temporary file we write the CSV to is not immediately deleted
2. Enable the `attach_csv_to_submission_email` feature flag
3. Make a form submission.
4. Look for the `"Wrote submission CSV"` log line. Copy the `path` field from the log line to get the path to the CSV file.
5. Inspect the CSV file by running `open <path_to_csv` or `cat <path_to_csv>`

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
