### PR TITLE
Allow FeatureService to switch features per form

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,18 @@ features:
 
 And check with `FeatureService.enabled?("some.nested_feature")`.
 
+You can also set a feature for a specific form:
+
+```yaml
+features:
+  some_feature:
+    enabled: false
+    forms:
+      "123": true
+```
+
+The `features.some_features.enabled` key sets the default for the flag, and then you can override for a form by adding a key for the form id. And then check the flag for a form with `FeatureService.enabled?(:some_feature, form)`.
+
 ### Testing with features
 
 You can also tag RSpec tests with `feature_{name}: true`. This will turn that feature on just for the duration of that test.

--- a/app/services/feature_service.rb
+++ b/app/services/feature_service.rb
@@ -1,10 +1,21 @@
-class FeatureService
-  class << self
-    def enabled?(feature_name)
-      return false if Settings.features.blank?
+module FeatureService
+  class FormRequiredError < StandardError; end
 
-      segments = feature_name.to_s.split(".")
-      segments.reduce(Settings.features) { |config, segment| config[segment] }
+  def self.enabled?(feature_name, form = nil)
+    return false if Settings.features.blank?
+
+    segments = feature_name.to_s.split(".")
+    feature = Settings.features.dig(*segments)
+
+    return feature unless feature.is_a? Config::Options
+
+    if feature.forms.present?
+      raise FormRequiredError, "Feature #{feature_name} requires form to be provided" if form.blank?
+
+      form_key = form.id.to_s.underscore.to_sym
+      return feature.forms[form_key] if feature.forms.key?(form_key)
     end
+
+    feature.enabled
   end
 end

--- a/spec/services/feature_service_spec.rb
+++ b/spec/services/feature_service_spec.rb
@@ -1,52 +1,145 @@
 require "rails_helper"
 
 describe FeatureService do
-  describe ".enabled?" do
-    context "when feature is enabled" do
-      before do
-        Settings.features[:some_feature] = true
+  describe "#enabled?" do
+    subject :feature_service do
+      described_class
+    end
+
+    let(:form) { build :form, id: 123 }
+
+    context "when the feature key has a boolean value" do
+      context "when feature key has value true" do
+        before do
+          Settings.features[:some_feature] = true
+        end
+
+        it "is enabled" do
+          expect(feature_service).to be_enabled(:some_feature, form)
+        end
       end
 
-      it "returns true" do
-        response = described_class.enabled?(:some_feature)
+      context "when feature key has value false" do
+        before do
+          Settings.features[:some_feature] = false
+        end
 
-        expect(response).to be_truthy
+        it "is not enabled" do
+          expect(feature_service).not_to be_enabled(:some_feature, form)
+        end
+      end
+
+      context "when empty features" do
+        before do
+          allow(Settings).to receive(:features).and_return(nil)
+        end
+
+        it "is not enabled" do
+          expect(feature_service).not_to be_enabled(:some_feature, form)
+        end
+      end
+
+      context "when nested features" do
+        before do
+          Settings.features[:some] = OpenStruct.new(nested_feature: true)
+        end
+
+        it "is enabled" do
+          expect(feature_service).to be_enabled("some.nested_feature")
+        end
       end
     end
 
-    context "when feature is disabled" do
-      before do
-        Settings.features[:some_feature] = false
+    context "when the feature key has an object value" do
+      context "when the enabled key exists and is set to true" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: true)
+        end
+
+        it "is enabled" do
+          expect(feature_service).to be_enabled(:some_feature, form)
+        end
       end
 
-      it "returns false" do
-        response = described_class.enabled?(:some_feature)
+      context "when the enabled key exists and is set to false" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: false)
+        end
 
-        expect(response).to be_falsey
-      end
-    end
-
-    context "when empty features" do
-      before do
-        allow(Settings).to receive(:features).and_return(nil)
+        it "is not enabled" do
+          expect(feature_service).not_to be_enabled(:some_feature, form)
+        end
       end
 
-      it "returns false" do
-        response = described_class.enabled?(:some_feature)
+      context "when the enabled key does not exist" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new
+        end
 
-        expect(response).to be_falsey
-      end
-    end
-
-    context "when nested features" do
-      before do
-        Settings.features[:some] = OpenStruct.new(nested_feature: true)
+        it "is not enabled" do
+          expect(feature_service).not_to be_enabled(:some_feature, form)
+        end
       end
 
-      it "returns true" do
-        response = described_class.enabled?("some.nested_feature")
+      context "when a key exists for the form overriding the feature to be enabled" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: false, forms: { "123": true })
+        end
 
-        expect(response).to be_truthy
+        it "is enabled" do
+          expect(feature_service).to be_enabled(:some_feature, form)
+        end
+      end
+
+      context "when a key exists for the form overriding the feature to be disabled" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: true, forms: { "123": false })
+        end
+
+        it "is not enabled" do
+          expect(feature_service).not_to be_enabled(:some_feature, form)
+        end
+      end
+
+      context "when a key exists for the form overriding the feature and the form has not been provided to the service" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: false, forms: { "123": true })
+        end
+
+        it "raises an error" do
+          expect { feature_service.enabled?(:some_feature) }.to raise_error described_class::FormRequiredError
+        end
+      end
+
+      context "when a key exists for a different form" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: false, forms: { "another_form": true })
+        end
+
+        it "returns the value of the enabled flag" do
+          expect(feature_service).not_to be_enabled(:some_feature, form)
+        end
+      end
+
+      context "when the forms object is empty" do
+        before do
+          Settings.features[:some_feature] = Config::Options.new(enabled: true, forms: {})
+        end
+
+        it "returns the value of the enabled flag" do
+          expect(feature_service).to be_enabled(:some_feature, form)
+        end
+      end
+
+      context "when the form does not have a form id set" do
+        before do
+          form.id = nil
+          Settings.features[:some_feature] = Config::Options.new(enabled: false, forms: { "123": true })
+        end
+
+        it "returns the value of the enabled flag" do
+          expect(feature_service).not_to be_enabled(:some_feature, form)
+        end
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

This commit allows features to be toggled on a per form basis in addition to the global feature flag. This is done in a similar way as per org switching in forms-admin. You can override the default value of a feature flag by providing key value pairs under a forms object, where the key is the form ID. For example:

```
features:
  flag_test:
    enabled: false
    forms:
      "123": true
```

We'd like to use this to do some user research for additional submission types with specific forms.

Trello card: https://trello.com/c/5xPfvcTJ

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
