### PR TITLE
Include submitted at timestamp in CSV

### DIFF
--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -77,7 +77,12 @@ private
     # For now, we're just writing to a Tempfile. We will send this file using Notify.
     file = Tempfile.new(%W[submission_#{@submission_reference}_ .csv])
     begin
-      SubmissionCsvService.new(current_context: @current_context, submission_reference: @submission_reference, output_file_path: file.path).write
+      SubmissionCsvService.new(
+        current_context: @current_context,
+        submission_reference: @submission_reference,
+        timestamp: @timestamp,
+        output_file_path: file.path,
+      ).write
       Rails.logger.info("Wrote submission CSV", { path: file.path })
     ensure
       file.close

--- a/app/services/submission_csv_service.rb
+++ b/app/services/submission_csv_service.rb
@@ -2,15 +2,16 @@ require "csv"
 require "tempfile"
 
 class SubmissionCsvService
-  def initialize(current_context:, submission_reference:, output_file_path:)
+  def initialize(current_context:, submission_reference:, timestamp:, output_file_path:)
     @current_context = current_context
     @submission_reference = submission_reference
+    @timestamp = timestamp
     @output_file_path = output_file_path
   end
 
   def write
-    headers = %w[Reference]
-    values = [@submission_reference]
+    headers = ["Reference", "Submitted at"]
+    values = [@submission_reference, @timestamp.iso8601]
     @current_context.completed_steps.map do |page|
       headers << page.question_text
       values << page.show_answer

--- a/spec/services/submission_csv_service_spec.rb
+++ b/spec/services/submission_csv_service_spec.rb
@@ -1,13 +1,16 @@
 require "rails_helper"
 
 RSpec.describe SubmissionCsvService do
-  subject(:service) { described_class.new(current_context:, submission_reference:, output_file_path: test_file.path) }
+  subject(:service) { described_class.new(current_context:, submission_reference:, timestamp:, output_file_path: test_file.path) }
 
   let(:form) { build(:form, id: 1) }
   let(:first_step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer: "42" }) }
   let(:second_step) { OpenStruct.new({ question_text: "What is your email address?", show_answer: "someone@example.com" }) }
   let(:current_context) { OpenStruct.new(form:, completed_steps: [first_step, second_step], support_details: OpenStruct.new(call_back_url: "http://gov.uk")) }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+  let(:timestamp) do
+    Time.use_zone("London") { Time.zone.local(2022, 9, 14, 8, 0o0, 0o0) }
+  end
 
   let(:test_file) { Tempfile.new("csv") }
 
@@ -20,8 +23,8 @@ RSpec.describe SubmissionCsvService do
       service.write
       expect(CSV.open(test_file.path).readlines).to eq(
         [
-          ["Reference", "What is the meaning of life?", "What is your email address?"],
-          [submission_reference, "42", "someone@example.com"],
+          ["Reference", "Submitted at", "What is the meaning of life?", "What is your email address?"],
+          [submission_reference, "2022-09-14T08:00:00+01:00", "42", "someone@example.com"],
         ],
       )
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/BjjG6uTU/1666-generate-csv-data-for-a-submission

Include column with header "Submitted at", which contains the timestamp the form was submitted at as an ISO 8601 string. The time will match the timezone of the date/time in the submission email,  which is set to UK Local time in the app configuration.

Example CSV output:

```
Reference,Submitted at,What’s your name?,What’s your phone number?
NP44K96S,2024-08-06T13:09:25+01:00,Mike Forms,01134960000
```

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
