### PR TITLE
Make methods in form_submission_service private

### DIFF
--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -31,6 +31,8 @@ class FormSubmissionService
     @submission_reference
   end
 
+private
+
   def submit_form_to_processing_team
     raise StandardError, "Form id(#{@form.id}) has no completed steps i.e questions/answers to include in submission email" if @current_context.completed_steps.blank?
 
@@ -70,8 +72,6 @@ class FormSubmissionService
 
     CurrentLoggingAttributes.confirmation_email_id = mail.govuk_notify_response.id
   end
-
-private
 
   def write_csv_file
     # For now, we're just writing to a Tempfile. We will send this file using Notify.


### PR DESCRIPTION
### What problem does this pull request solve?

There was no need for these methods to be public, but they were called directly in tests.

Modify the tests to just call the `submit` method whilst maintaining the same tests for sending the submission/confirmation email.

**NOTE**: Hiding whitespace changes will make this PR a lot easier to review because contexts were moved around in the tests so indentation changed.
