### PR TITLE
Send a CSV file with submission

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,8 +178,8 @@ GEM
       activemodel (>= 6.1)
       activesupport (>= 6.1)
       html-attributes-utils (~> 1)
-    govuk_notify_rails (2.2.0)
-      notifications-ruby-client (~> 5.1)
+    govuk_notify_rails (3.0.0)
+      notifications-ruby-client (~> 6.2)
       rails (>= 4.1.0)
     highline (3.0.1)
     html-attributes-utils (1.0.2)
@@ -203,7 +203,8 @@ GEM
       reline (>= 0.4.2)
     jmespath (1.6.2)
     json (2.7.2)
-    jwt (2.5.0)
+    jwt (2.8.2)
+      base64
     language_server-protocol (3.17.0.3)
     logger (1.6.0)
     lograge (0.14.0)
@@ -226,7 +227,7 @@ GEM
     minitest (5.24.1)
     msgpack (1.7.2)
     mutex_m (0.2.0)
-    net-imap (0.4.12)
+    net-imap (0.4.14)
       date
       net-protocol
     net-pop (0.1.2)
@@ -236,15 +237,15 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.16.6-aarch64-linux)
+    nokogiri (1.16.7-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.16.6-arm64-darwin)
+    nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.6-x86_64-darwin)
+    nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.6-x86_64-linux)
+    nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
-    notifications-ruby-client (5.4.0)
+    notifications-ruby-client (6.2.0)
       jwt (>= 1.5, < 3)
     pagy (8.6.3)
     parallel (1.25.1)
@@ -256,7 +257,7 @@ GEM
     public_suffix (5.0.4)
     puma (6.4.2)
       nio4r (~> 2.0)
-    racc (1.8.0)
+    racc (1.8.1)
     rack (3.1.7)
     rack-proxy (0.7.7)
       rack
@@ -422,7 +423,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.16)
+    zeitwerk (2.6.17)
 
 PLATFORMS
   aarch64-linux

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -40,8 +40,10 @@ private
       raise StandardError, "Form id(#{@form.id}) is missing a submission email address"
     end
 
+    csv_attached = false
     unless @form.submission_email.blank? && @preview_mode
       mail = if FeatureService.enabled?("attach_csv_to_submission_email", @form)
+               csv_attached = true
                deliver_submission_email_with_csv_attachment
              else
                deliver_submission_email
@@ -50,7 +52,7 @@ private
       CurrentLoggingAttributes.submission_email_id = mail.govuk_notify_response.id
     end
 
-    LogEventService.log_submit(@current_context, requested_email_confirmation: @requested_email_confirmation, preview: @preview_mode)
+    LogEventService.log_submit(@current_context, requested_email_confirmation: @requested_email_confirmation, preview: @preview_mode, csv_attached:)
   end
 
   def submit_confirmation_email_to_user

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -41,16 +41,11 @@ private
     end
 
     unless @form.submission_email.blank? && @preview_mode
-
-      if FeatureService.enabled?("attach_csv_to_submission_email", @form)
-        write_csv_file
-      end
-
-      mail = FormSubmissionMailer
-               .email_confirmation_input(text_input: email_body,
-                                         notify_response_id: @email_confirmation_input.submission_email_reference,
-                                         submission_email: @form.submission_email,
-                                         mailer_options: @mailer_options).deliver_now
+      mail = if FeatureService.enabled?("attach_csv_to_submission_email", @form)
+               deliver_submission_email_with_csv_attachment
+             else
+               deliver_submission_email
+             end
 
       CurrentLoggingAttributes.submission_email_id = mail.govuk_notify_response.id
     end
@@ -73,23 +68,24 @@ private
     CurrentLoggingAttributes.confirmation_email_id = mail.govuk_notify_response.id
   end
 
-  def write_csv_file
-    # For now, we're just writing to a Tempfile. We will send this file using Notify.
-    file = Tempfile.new(%W[submission_#{@submission_reference}_ .csv])
-    begin
+  def deliver_submission_email(csv_file = nil)
+    FormSubmissionMailer
+      .email_confirmation_input(text_input: email_body,
+                                notify_response_id: @email_confirmation_input.submission_email_reference,
+                                submission_email: @form.submission_email,
+                                mailer_options: @mailer_options,
+                                csv_file:).deliver_now
+  end
+
+  def deliver_submission_email_with_csv_attachment
+    Tempfile.create do |file|
       SubmissionCsvService.new(
         current_context: @current_context,
         submission_reference: @submission_reference,
         timestamp: @timestamp,
         output_file_path: file.path,
       ).write
-      Rails.logger.info("Wrote submission CSV", { path: file.path })
-    ensure
-      file.close
-      # To inspect the temporary file after it's written to, comment out file.unlink locally
-      # If we don't unlink the file, it is available until the Tempfile object is garbage collected or the Ruby
-      # interpreter exits.
-      file.unlink
+      deliver_submission_email(file)
     end
   end
 

--- a/app/services/log_event_service.rb
+++ b/app/services/log_event_service.rb
@@ -11,12 +11,12 @@ class LogEventService
     EventLogger.log_form_event("visit")
   end
 
-  def self.log_submit(context, requested_email_confirmation: false, preview: false)
+  def self.log_submit(context, requested_email_confirmation: false, preview: false, csv_attached: false)
     if preview
       EventLogger.log_form_event("preview_submission")
     else
       # Logging to Splunk
-      EventLogger.log_form_event("submission")
+      EventLogger.log_form_event("submission", { csv_attached: })
 
       EventLogger.log_form_event("requested_email_confirmation") if requested_email_confirmation
 

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -291,6 +291,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           not_test: "no",
           submission_reference: reference,
           include_payment_link: "no",
+          csv_attached: "no",
+          link_to_file: "",
         }
 
         expect(mail.body.raw_source).to match(expected_personalisation.to_s)
@@ -335,6 +337,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           not_test: "yes",
           submission_reference: reference,
           include_payment_link: "no",
+          csv_attached: "no",
+          link_to_file: "",
         }
 
         expect(mail.body.raw_source).to match(expected_personalisation.to_s)

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe FormSubmissionService do
             current_context,
             requested_email_confirmation: true,
             preview: false,
+            csv_attached: false,
           )
         end
       end
@@ -122,7 +123,7 @@ RSpec.describe FormSubmissionService do
           end
         end
 
-        it "logs submission" do
+        it "logs submission with csv_attached=true" do
           allow(LogEventService).to receive(:log_submit).once
 
           service.submit
@@ -131,6 +132,7 @@ RSpec.describe FormSubmissionService do
             current_context,
             requested_email_confirmation: true,
             preview: false,
+            csv_attached: true,
           )
         end
       end
@@ -182,6 +184,7 @@ RSpec.describe FormSubmissionService do
             current_context,
             requested_email_confirmation: true,
             preview: true,
+            csv_attached: false,
           )
         end
 

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -64,46 +64,75 @@ RSpec.describe FormSubmissionService do
       expect(log_lines[0]["submission_reference"]).to eq(reference)
     end
 
-    context "when send CSV feature is enabled", :feature_attach_csv_to_submission_email do
-      it "writes CSV file" do
-        service.submit
-        expect(submission_csv_service_spy).to have_received(:write)
-      end
-    end
-
-    context "when send CSV feature is disabled", feature_attach_csv_to_submission_email: false do
-      it "does not write CSV file" do
-        service.submit
-        expect(submission_csv_service_spy).not_to have_received(:write)
-      end
-    end
-
     describe "sending the submission email" do
-      it "calls FormSubmissionMailer" do
-        freeze_time do
-          allow(FormSubmissionMailer).to receive(:email_confirmation_input).and_call_original
+      context "when send CSV feature is disabled", feature_attach_csv_to_submission_email: false do
+        it "calls FormSubmissionMailer" do
+          freeze_time do
+            allow(FormSubmissionMailer).to receive(:email_confirmation_input).and_call_original
+
+            service.submit
+
+            expect(FormSubmissionMailer).to have_received(:email_confirmation_input).with(
+              { text_input: "# What is the meaning of life?\n42\n",
+                notify_response_id: email_confirmation_input.submission_email_reference,
+                submission_email: "testing@gov.uk",
+                mailer_options: instance_of(FormSubmissionService::MailerOptions),
+                csv_file: nil },
+            ).once
+          end
+        end
+
+        it "does not write a CSV file" do
+          service.submit
+          expect(submission_csv_service_spy).not_to have_received(:write)
+        end
+
+        it "logs submission" do
+          allow(LogEventService).to receive(:log_submit).once
 
           service.submit
 
-          expect(FormSubmissionMailer).to have_received(:email_confirmation_input).with(
-            { text_input: "# What is the meaning of life?\n42\n",
-              notify_response_id: email_confirmation_input.submission_email_reference,
-              submission_email: "testing@gov.uk",
-              mailer_options: instance_of(FormSubmissionService::MailerOptions) },
-          ).once
+          expect(LogEventService).to have_received(:log_submit).with(
+            current_context,
+            requested_email_confirmation: true,
+            preview: false,
+          )
         end
       end
 
-      it "logs submission" do
-        allow(LogEventService).to receive(:log_submit).once
+      context "when send CSV feature is enabled", :feature_attach_csv_to_submission_email do
+        it "writes a CSV file" do
+          service.submit
+          expect(submission_csv_service_spy).to have_received(:write)
+        end
 
-        service.submit
+        it "calls FormSubmissionMailer passing in a CSV file" do
+          freeze_time do
+            allow(FormSubmissionMailer).to receive(:email_confirmation_input).and_call_original
 
-        expect(LogEventService).to have_received(:log_submit).with(
-          current_context,
-          requested_email_confirmation: true,
-          preview: false,
-        )
+            service.submit
+
+            expect(FormSubmissionMailer).to have_received(:email_confirmation_input).with(
+              { text_input: "# What is the meaning of life?\n42\n",
+                notify_response_id: email_confirmation_input.submission_email_reference,
+                submission_email: "testing@gov.uk",
+                mailer_options: instance_of(FormSubmissionService::MailerOptions),
+                csv_file: instance_of(File) },
+            ).once
+          end
+        end
+
+        it "logs submission" do
+          allow(LogEventService).to receive(:log_submit).once
+
+          service.submit
+
+          expect(LogEventService).to have_received(:log_submit).with(
+            current_context,
+            requested_email_confirmation: true,
+            preview: false,
+          )
+        end
       end
 
       describe "validations" do
@@ -138,7 +167,8 @@ RSpec.describe FormSubmissionService do
               { text_input: "# What is the meaning of life?\n42\n",
                 notify_response_id: email_confirmation_input.submission_email_reference,
                 submission_email: "testing@gov.uk",
-                mailer_options: instance_of(FormSubmissionService::MailerOptions) },
+                mailer_options: instance_of(FormSubmissionService::MailerOptions),
+                csv_file: nil },
             ).once
           end
         end

--- a/spec/services/log_event_service_spec.rb
+++ b/spec/services/log_event_service_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe LogEventService do
       it "calls the event logger with .log_form_event" do
         described_class.log_submit(current_context)
 
-        expect(EventLogger).to have_received(:log_form_event).with("submission")
+        expect(EventLogger).to have_received(:log_form_event).with("submission", { csv_attached: false })
       end
 
       it "does not call the event logger for confirmation request" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/hjGOVjVL/1669-send-a-csv-with-submission

This PR attaches a CSV file to the submission email we send using Notify if the `attach_csv_to_submission_email` feature flag is enabled.

Have setup a test template in Notify that I tested this with - https://www.notifications.service.gov.uk/services/edf2d8fd-35d4-49fd-98b7-eb2738dafc98/templates/9948c208-dade-4600-b75f-b052be659204

The template looks like this:

<img width="752" alt="Screenshot 2024-08-07 at 13 23 08" src="https://github.com/user-attachments/assets/9e3a54ac-1e4a-4324-b8f4-901d1042cdb8">

All the content for the "Data processing" section is optional, so it will appear as it does now for submissions without a CSV file attached. The email sent looks like this:

<img width="972" alt="Screenshot 2024-08-07 at 13 21 08" src="https://github.com/user-attachments/assets/0d2390c5-e6be-4ac5-a824-4b6f375d1364">

The link in the email asks the user to enter the email address the file was sent to. It shows that the retention period is 7 days:

<img width="1060" alt="Screenshot 2024-08-07 at 13 21 28" src="https://github.com/user-attachments/assets/388412b1-2097-4e84-9949-5e9ad79469f9">

The CSV file generated looks like this:

<img width="904" alt="Screenshot 2024-08-07 at 13 21 48" src="https://github.com/user-attachments/assets/3fe6b7e2-17f3-4d4f-868b-c69f73dffc94">

The file name includes the form name and the submission reference.

### Things to consider when reviewing

To test locally, set:
- the template ID to be the test template ID
- the `attach_csv_to_submission_email` to be true
- set the Notify API key to be your test API key

```
SETTINGS__GOVUK_NOTIFY__FORM_SUBMISSION_EMAIL_TEMPLATE_ID=9948c208-dade-4600-b75f-b052be659204 SETTINGS__FEATURES__ATTACH_CSV_TO_SUBMISSION_EMAIL=true SETTINGS__GOVUK_NOTIFY__API_KEY=<your api key> bundle exec rails s
```

Fill out a live form. You should receive the submission email with a CSV attached.

I have also tested without the feature flag enabled to ensure the email appears without the optional content when a CSV isn't attached.

Have also tested with the live submission email Notify template to ensure it will work with the new personalisation before we update the live template.

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
