### PR TITLE
Accept an array of form IDs for per form feature flagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,17 +151,22 @@ features:
 
 And check with `FeatureService.enabled?("some.nested_feature")`.
 
-You can also set a feature for a specific form:
+#### Enabling feature flags for specific forms
+
+You can also enable a feature flag just for specific form(s) by providing a list of form IDs.
 
 ```yaml
 features:
   some_feature:
     enabled: false
-    forms:
-      "123": true
+    enabled_for_form_ids: "123,456"
 ```
 
-The `features.some_features.enabled` key sets the default for the flag, and then you can override for a form by adding a key for the form id. And then check the flag for a form with `FeatureService.enabled?(:some_feature, form)`.
+The `features.some_features.enabled` key sets the default for the flag for all forms.
+
+You can enable the feature just for specific forms by adding the form ID to the `enabled_for_form_ids` comma separated string. Then check whether the flag is enabled for a form with `FeatureService.enabled?(:some_feature, form)` in the code.
+
+The list of form IDs should only be populated by setting the environment variable `SETTINGS__FEATURES__SOME_FEATURE__ENABLED_FOR_FORM_IDS` via Terraform in forms-deploy, to avoid mistakenly enabling CSV submissions for unrelated forms in different environments.
 
 ### Testing with features
 

--- a/app/services/feature_service.rb
+++ b/app/services/feature_service.rb
@@ -9,11 +9,16 @@ module FeatureService
 
     return feature unless feature.is_a? Config::Options
 
-    if feature.forms.present?
+    return true if feature.enabled
+
+    if feature.enabled_for_form_ids.present?
       raise FormRequiredError, "Feature #{feature_name} requires form to be provided" if form.blank?
 
-      form_key = form.id.to_s.underscore.to_sym
-      return feature.forms[form_key] if feature.forms.key?(form_key)
+      return feature.enabled_for_form_ids == form.id if feature.enabled_for_form_ids.is_a?(Integer)
+
+      form_ids = feature.enabled_for_form_ids.split(",").collect(&:strip)
+
+      return form_ids.include?(form.id.to_s)
     end
 
     feature.enabled

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -42,7 +42,7 @@ private
 
     csv_attached = false
     unless @form.submission_email.blank? && @preview_mode
-      mail = if FeatureService.enabled?("attach_csv_to_submission_email", @form)
+      mail = if FeatureService.enabled?("csv_submission", @form)
                csv_attached = true
                deliver_submission_email_with_csv_attachment
              else

--- a/app/services/log_event_service.rb
+++ b/app/services/log_event_service.rb
@@ -13,7 +13,7 @@ class LogEventService
 
   def self.log_submit(context, requested_email_confirmation: false, preview: false, csv_attached: false)
     if preview
-      EventLogger.log_form_event("preview_submission")
+      EventLogger.log_form_event("preview_submission", { csv_attached: })
     else
       # Logging to Splunk
       EventLogger.log_form_event("submission", { csv_attached: })

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,9 @@
 features:
-  attach_csv_to_submission_email: false
+  csv_submission:
+    enabled: false
+    # this list of form IDs should only be populated via Terraform in forms-deploy, to avoid mistakenly
+    # enabling CSV submissions for unrelated forms in different environments
+    enabled_for_form_ids: ""
 
 forms_admin:
   # URL to form-admin

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -21,7 +21,14 @@ describe "Settings" do
   describe ".features" do
     features = settings[:features]
 
-    include_examples expected_value_test, :attach_csv_to_submission_email, features, false
+    it "csv_submission has a default value" do
+      expect(features["csv_submission"]).to eq(
+        {
+          "enabled" => false,
+          "enabled_for_form_ids" => "",
+        },
+      )
+    end
   end
 
   describe ".forms_api" do

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe FormSubmissionService do
     end
 
     describe "sending the submission email" do
-      context "when send CSV feature is disabled", feature_attach_csv_to_submission_email: false do
+      context "when send CSV feature is disabled", feature_csv_submission: false do
         it "calls FormSubmissionMailer" do
           freeze_time do
             allow(FormSubmissionMailer).to receive(:email_confirmation_input).and_call_original
@@ -101,7 +101,7 @@ RSpec.describe FormSubmissionService do
         end
       end
 
-      context "when send CSV feature is enabled", :feature_attach_csv_to_submission_email do
+      context "when send CSV feature is enabled", :feature_csv_submission do
         it "writes a CSV file" do
           service.submit
           expect(submission_csv_service_spy).to have_received(:write)

--- a/spec/services/log_event_service_spec.rb
+++ b/spec/services/log_event_service_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe LogEventService do
       it "calls the event logger with .log_form_event" do
         described_class.log_submit(current_context, preview: true)
 
-        expect(EventLogger).to have_received(:log_form_event).with("preview_submission")
+        expect(EventLogger).to have_received(:log_form_event).with("preview_submission", { csv_attached: false })
       end
 
       it "does not call the cloud watch service" do


### PR DESCRIPTION
### What problem does this pull request solve?

This commit changes per form feature flagging to accept a comma separated list of form IDs for which a feature is enabled. This only applies if the feature flag itself is disabled.
    
This is to facilitate feature flagging per form separately in different environments.

All environment variables are strings, and because we want to be able to test the CSV submissions with users imminently we will just do the string parsing in the feature service for now.

It might be possible to persuade Terraform to provide an array to the application such that it is parsed as an array. We'll look at this next.

Trello card: https://trello.com/c/9XvRKwdK

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
