### PR TITLE
Change all url helpers to use keyword arguments

### DIFF
--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Forms::BaseController, type: :request do
     end
 
     it "renders the page with a link back to the form start page" do
-      expect(response.body).to include(form_page_path("form", 2, form_response_data.form_slug, 1))
+      expect(response.body).to include(form_page_path(mode: "form", form_id: 2, form_slug: form_response_data.form_slug, page_slug: 1))
     end
   end
 
@@ -148,7 +148,7 @@ RSpec.describe Forms::BaseController, type: :request do
 
           context "when the form has a start page" do
             it "Redirects to the first page" do
-              expect(response).to redirect_to(form_page_path("preview-draft", 2, form_response_data.form_slug, 1))
+              expect(response).to redirect_to(form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_response_data.form_slug, page_slug: 1))
             end
 
             it "does not log the form_visit event" do
@@ -225,7 +225,7 @@ RSpec.describe Forms::BaseController, type: :request do
 
           context "when the form has a start page" do
             it "Redirects to the first page" do
-              expect(response).to redirect_to(form_page_path("preview-live", 2, form_response_data.form_slug, 1))
+              expect(response).to redirect_to(form_page_path(mode: "preview-live", form_id: 2, form_slug: form_response_data.form_slug, page_slug: 1))
             end
 
             it "does not log the form_visit event" do
@@ -302,7 +302,7 @@ RSpec.describe Forms::BaseController, type: :request do
 
           context "when the form has a start page" do
             it "Redirects to the first page" do
-              expect(response).to redirect_to(form_page_path("form", 2, form_response_data.form_slug, 1))
+              expect(response).to redirect_to(form_page_path(mode: "form", form_id: 2, form_slug: form_response_data.form_slug, page_slug: 1))
             end
 
             it "Logs the form_visit event" do

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         it "redirects to first incomplete page of form" do
           get check_your_answers_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug)
           expect(response).to have_http_status(:found)
-          expect(response.location).to eq(form_page_url(2, form_data.form_slug, 1))
+          expect(response.location).to eq(form_page_url(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
         end
       end
 
@@ -148,7 +148,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         end
 
         it "Displays a back link to the last page of the form" do
-          expect(response.body).to include(form_page_path("preview-draft", 2, form_data.form_slug, 2))
+          expect(response.body).to include(form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
         end
 
         it "Returns the correct X-Robots-Tag header" do
@@ -190,14 +190,14 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         it "redirects to first incomplete page of form" do
           get check_your_answers_path(mode: "form", form_id: 2, form_slug: form_data.form_slug)
           expect(response).to have_http_status(:found)
-          expect(response.location).to eq(form_page_url(2, form_data.form_slug, 1))
+          expect(response.location).to eq(form_page_url(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
         end
       end
 
       context "with all questions answered and valid" do
         before do
-          post save_form_page_path("form", 2, "form-1", 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-          post save_form_page_path("form", 2, "form-1", 2), params: { question: { text: "answer text" }, changing_existing_answer: false }
+          post save_form_page_path(mode: "form", form_id: 2, form_slug: "form-1", page_slug: 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+          post save_form_page_path(mode: "form", form_id: 2, form_slug: "form-1", page_slug: 2), params: { question: { text: "answer text" }, changing_existing_answer: false }
 
           allow(EventLogger).to receive(:log_form_event).at_least(:once)
 
@@ -209,7 +209,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         end
 
         it "Displays a back link to the last page of the form" do
-          expect(response.body).to include(form_page_path("form", 2, form_data.form_slug, 2))
+          expect(response.body).to include(form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
         end
 
         it "Returns the correct X-Robots-Tag header" do

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -100,32 +100,32 @@ RSpec.describe Forms::PageController, type: :request do
       let(:api_url_suffix) { "/draft" }
 
       it "Returns a 200" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response).to have_http_status(:ok)
       end
 
       it "redirects to first page if second request before first complete" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 2)
-        expect(response).to redirect_to(form_page_path(2, form_data.form_slug, 1))
+        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
+        expect(response).to redirect_to(form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
       end
 
       it "Displays the question text on the page" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include(form_data.pages.first.question_text)
       end
 
       it "Displays the privacy policy link on the page" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include("Privacy")
       end
 
       it "Displays the accessibility statement link on the page" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include("Accessibility statement")
       end
 
       it "Displays the Cookies link on the page" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include("Cookies")
       end
 
@@ -134,8 +134,8 @@ RSpec.describe Forms::PageController, type: :request do
           allow_any_instance_of(Flow::Context).to receive(:can_visit?)
                                               .and_return(true)
           allow_any_instance_of(Flow::Context).to receive(:previous_step).and_return(1)
-          get form_page_path("preview-draft", 2, form_data.form_slug, 2)
-          expect(response.body).to include(form_page_path(2, form_data.form_slug, 1))
+          get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
+          expect(response.body).to include(form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
         end
       end
 
@@ -147,12 +147,12 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "Passes the changing answers parameter in its submit request" do
           get form_change_answer_path("preview-draft", 2, form_data.form_slug, 1)
-          expect(response.body).to include(save_form_page_path("preview-draft", 2, form_data.form_slug, 1, changing_existing_answer: true))
+          expect(response.body).to include(save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true))
         end
       end
 
       it "Returns the correct X-Robots-Tag header" do
-        get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
       end
 
@@ -160,7 +160,7 @@ RSpec.describe Forms::PageController, type: :request do
         it "redirects if a later page is requested" do
           get check_your_answers_path("preview-draft", 2, form_data.form_slug)
           expect(response).to have_http_status(:found)
-          expect(response.location).to eq(form_page_url("preview-draft", 2, form_data.form_slug, 1))
+          expect(response.location).to eq(form_page_url(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
         end
       end
     end
@@ -198,32 +198,32 @@ RSpec.describe Forms::PageController, type: :request do
       end
 
       it "Returns a 200" do
-        get form_page_path("form", 2, form_data.form_slug, 1)
+        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response).to have_http_status(:ok)
       end
 
       it "redirects to first page if second request before first complete" do
-        get form_page_path("form", 2, form_data.form_slug, 2)
-        expect(response).to redirect_to(form_page_path(2, form_data.form_slug, 1))
+        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
+        expect(response).to redirect_to(form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
       end
 
       it "Displays the question text on the page" do
-        get form_page_path("form", 2, form_data.form_slug, 1)
+        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include(form_data.pages.first.question_text)
       end
 
       it "Displays the privacy policy link on the page" do
-        get form_page_path("form", 2, form_data.form_slug, 1)
+        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include("Privacy")
       end
 
       it "Displays the accessibility statement link on the page" do
-        get form_page_path("form", 2, form_data.form_slug, 1)
+        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include("Accessibility statement")
       end
 
       it "Displays the Cookies link on the page" do
-        get form_page_path("form", 2, form_data.form_slug, 1)
+        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include("Cookies")
       end
 
@@ -232,8 +232,8 @@ RSpec.describe Forms::PageController, type: :request do
           allow_any_instance_of(Flow::Context).to receive(:can_visit?)
                                               .and_return(true)
           allow_any_instance_of(Flow::Context).to receive(:previous_step).and_return(1)
-          get form_page_path("form", 2, form_data.form_slug, 2)
-          expect(response.body).to include(form_page_path(2, form_data.form_slug, 1))
+          get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
+          expect(response.body).to include(form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
         end
       end
 
@@ -245,12 +245,12 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "Passes the changing answers parameter in its submit request" do
           get form_change_answer_path("form", 2, form_data.form_slug, 1)
-          expect(response.body).to include(save_form_page_path("form", 2, form_data.form_slug, 1, changing_existing_answer: true))
+          expect(response.body).to include(save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true))
         end
       end
 
       it "Returns the correct X-Robots-Tag header" do
-        get form_page_path("form", 2, form_data.form_slug, 1)
+        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
       end
 
@@ -258,7 +258,7 @@ RSpec.describe Forms::PageController, type: :request do
         it "redirects if a later page is requested" do
           get check_your_answers_path("form", 2, form_data.form_slug)
           expect(response).to have_http_status(:found)
-          expect(response.location).to eq(form_page_url("form", 2, form_data.form_slug, 1))
+          expect(response.location).to eq(form_page_url(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
         end
       end
 
@@ -267,7 +267,7 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "returns 404" do
           travel_to timestamp_of_request do
-            get form_page_path("form", 2, form_data.form_slug, 1)
+            get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
           end
 
           expect(response).to have_http_status(:not_found)
@@ -286,7 +286,7 @@ RSpec.describe Forms::PageController, type: :request do
       end
 
       it "Returns a 200" do
-        get form_page_path("preview-live", 2, form_data.form_slug, 1)
+        get form_page_path(mode: "preview-live", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response).to have_http_status(:ok)
       end
     end
@@ -320,12 +320,12 @@ RSpec.describe Forms::PageController, type: :request do
         let(:validation_errors) { [{ name: "cannot_have_goto_page_before_routing_page" }] }
 
         it "returns a 422 response" do
-          get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+          get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
           expect(response).to have_http_status(:unprocessable_entity)
         end
 
         it "shows the error page" do
-          get form_page_path("preview-draft", 2, form_data.form_slug, 1)
+          get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
           link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/conditions/1"
           question_number = first_page_in_form.position
           expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))
@@ -343,49 +343,49 @@ RSpec.describe Forms::PageController, type: :request do
       let(:api_url_suffix) { "/draft" }
 
       it "Redirects to the next page" do
-        post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path("preview-draft", 2, form_data.form_slug, 2))
+        post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
       end
 
       context "when changing an existing answer" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
           expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, form_data.form_slug))
         end
 
         it "does not log the change_answer_page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
         end
       end
 
       context "with the first page" do
         it "Logs the first_page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" } }
         end
 
         it "clears the submission reference from the session" do
           expect_any_instance_of(Flow::Context).to receive(:clear_submission_details).once
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" } }
         end
       end
 
       context "with a subsequent page" do
         it "Logs the page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
         end
 
         it "does not clear the submission reference from the session" do
           expect_any_instance_of(Flow::Context).not_to receive(:clear_submission_details)
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
         end
       end
 
       context "with the final page" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
           expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, form_data.form_slug))
         end
       end
@@ -395,7 +395,7 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "does not return 404" do
           travel_to timestamp_of_request do
-            post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+            post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
           end
           expect(response).not_to have_http_status(:not_found)
         end
@@ -403,7 +403,7 @@ RSpec.describe Forms::PageController, type: :request do
 
       context "when the form is invalid" do
         before do
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { text: "" }, changing_existing_answer: false }
+          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "" }, changing_existing_answer: false }
         end
 
         it "renders the show page template" do
@@ -418,39 +418,39 @@ RSpec.describe Forms::PageController, type: :request do
 
     context "with preview mode off" do
       it "Redirects to the next page" do
-        post save_form_page_path("form", 2, form_data.form_slug, 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path("form", 2, form_data.form_slug, 2))
+        post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
       end
 
       context "when changing an existing answer" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("form", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
           expect(response).to redirect_to(check_your_answers_path("form", 2, form_data.form_slug))
         end
 
         it "Logs the change_answer_page_save event" do
           expect(EventLogger).to receive(:log_page_event).with("change_answer_page_save", first_page_in_form.question_text, nil)
-          post save_form_page_path("form", 2, form_data.form_slug, 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
         end
       end
 
       context "with the first page" do
         it "Logs the first_page_save event" do
           expect(EventLogger).to receive(:log_page_event).with("first_page_save", first_page_in_form.question_text, nil)
-          post save_form_page_path("form", 2, form_data.form_slug, 1), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" } }
         end
       end
 
       context "with a subsequent page" do
         it "Logs the page_save event" do
           expect(EventLogger).to receive(:log_page_event).with("page_save", second_page_in_form.question_text, nil)
-          post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
         end
       end
 
       context "with the final page" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
           expect(response).to redirect_to(check_your_answers_path("form", 2, form_data.form_slug))
         end
       end
@@ -461,21 +461,21 @@ RSpec.describe Forms::PageController, type: :request do
         context "when an optional question is completed" do
           it "Logs the optional_save event with skipped_question as true" do
             expect(EventLogger).to receive(:log_page_event).with("optional_save", second_page_in_form.question_text, true)
-            post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "" } }
+            post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "" } }
           end
         end
 
         context "when an optional question is skipped" do
           it "Logs the optional_save event with skipped_question as false" do
             expect(EventLogger).to receive(:log_page_event).with("optional_save", second_page_in_form.question_text, false)
-            post save_form_page_path("form", 2, form_data.form_slug, 2), params: { question: { text: "answer text" } }
+            post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
           end
         end
       end
 
       context "when the form is invalid" do
         before do
-          post save_form_page_path("form", 2, form_data.form_slug, 1), params: { question: { text: "" }, changing_existing_answer: false }
+          post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "" }, changing_existing_answer: false }
         end
 
         it "renders the show page template" do
@@ -513,14 +513,14 @@ RSpec.describe Forms::PageController, type: :request do
       let(:api_url_suffix) { "/draft" }
 
       it "redirects to the goto page if answer value matches condition" do
-        post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { selection: "Option 1" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path("preview-draft", 2, form_data.form_slug, 3))
+        post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 1" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 3))
       end
 
       context "when the answer_value does not match the condition" do
         it "redirects to the next page in the journey" do
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
-          expect(response).to redirect_to(form_page_path("preview-draft", 2, form_data.form_slug, 2))
+          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
+          expect(response).to redirect_to(form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
         end
       end
 
@@ -529,12 +529,12 @@ RSpec.describe Forms::PageController, type: :request do
         let(:validation_errors) { [{ name: "cannot_have_goto_page_before_routing_page" }] }
 
         it "returns a 422 response" do
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
+          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
           expect(response).to have_http_status(:unprocessable_entity)
         end
 
         it "shows the error page" do
-          post save_form_page_path("preview-draft", 2, form_data.form_slug, 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
+          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
           link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/conditions/1"
           question_number = first_page_in_form.position
           expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))


### PR DESCRIPTION
Currently the feature tests call URL helpers, like form_page_path, with a mix of positional and keyword arguments .

An example of a positional argument call:
form_page_path("preview-draft", 2, form_response_data.form_slug, 1)

An example of a keyword call:
form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_response_data.form_slug, page_slug: 1)

This is fine, but inconsistent.

This PR changes all calls to use the keyword form. This makes it clearer
which arguments are for which routing segment. The keyword argument is
clearer because there are 4 arguments which makes it hard to get right.

It also allows adding new optional parameters to the calls, which will
be useful in the future.

There maybe a better way to do this in general, rather than using the helpers with all params like this.

The application code doesn't need to be changed.
Somehow the helpers in tests don't work the same way as they do in app code. I
think this is partly because of settings like `default_url_options`, which isn't
used in the tests.

This doesn't currently matter though because our routes don't have lots of
optional params, which makes using positional arguments difficult.

This commit does the simplest thing to make it consistent.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
