### PR TITLE
Add "repeatable?" to Page

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -19,4 +19,8 @@ class Page < ActiveResource::Base
   def answer_settings
     @attributes["answer_settings"] || {}
   end
+
+  def repeatable?
+    @attributes["is_repeatable"] || false
+  end
 end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -16,7 +16,6 @@ FactoryBot.define do
     question_text { Faker::Lorem.question }
     answer_type { "number" }
     is_optional { nil }
-    answer_settings { nil }
     page_heading { nil }
     guidance_markdown { nil }
     hint_text { nil }

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -10,6 +10,8 @@ end
 
 FactoryBot.define do
   factory :page, class: "Page" do
+    initialize_with { new(**attributes) }
+
     id { Faker::Number.number(digits: 2) }
     question_text { Faker::Lorem.question }
     answer_type { Page::ANSWER_TYPES.reject { |item| Page::ANSWER_TYPES_WITH_SETTINGS.include? item }.sample }

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
 
     id { Faker::Number.number(digits: 2) }
     question_text { Faker::Lorem.question }
-    answer_type { Page::ANSWER_TYPES.reject { |item| Page::ANSWER_TYPES_WITH_SETTINGS.include? item }.sample }
+    answer_type { "number" }
     is_optional { nil }
     answer_settings { nil }
     page_heading { nil }

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -6,6 +6,18 @@ RSpec.describe Page, type: :model do
     expect(page).to be_valid
   end
 
+  describe "#answer_settings" do
+    it "returns an empty object for answer_settings when it's not present" do
+      page = build :page
+      expect(page).to have_attributes(answer_settings: {})
+    end
+
+    it "returns an answer settings object for answer_settings when present" do
+      page = build :page, answer_settings: { only_one_option: "true" }
+      expect(page.answer_settings.attributes).to eq({ "only_one_option" => "true" })
+    end
+  end
+
   describe "API call" do
     let(:response_data) do
       {
@@ -30,27 +42,6 @@ RSpec.describe Page, type: :model do
 
     it "returns the page for a form" do
       expect(described_class.find(1, params: { form_id: 2 })).to have_attributes(id: 1, question_text: "Question text", answer_type: "date")
-    end
-
-    context "when answer_settings is not present" do
-      it "returns an empty object for answer_settings" do
-        expect(described_class.find(1, params: { form_id: 2 })).to have_attributes(answer_settings: {})
-      end
-    end
-
-    context "when answer_settings is present" do
-      let(:response_data) do
-        {
-          id: 1,
-          question_text: "Question text",
-          answer_type: "selection",
-          answer_settings: { only_one_option: "true" },
-        }.to_json
-      end
-
-      it "returns an answer settings object for answer_settings" do
-        expect(described_class.find(1, params: { form_id: 2 }).answer_settings.attributes).to eq({ "only_one_option" => "true" })
-      end
     end
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -18,6 +18,23 @@ RSpec.describe Page, type: :model do
     end
   end
 
+  describe "repeatable?" do
+    it "when attribute does not exist" do
+      page = build :page
+      expect(page.repeatable?).to be false
+    end
+
+    it "when attribute is false" do
+      page = build :page, is_repeatable: false
+      expect(page.repeatable?).to be false
+    end
+
+    it "when attribute is true" do
+      page = build :page, is_repeatable: true
+      expect(page.repeatable?).to be true
+    end
+  end
+
   describe "API call" do
     let(:response_data) do
       {

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,49 +1,51 @@
 require "rails_helper"
 
 RSpec.describe Page, type: :model do
-  let(:response_data) do
-    {
-      id: 1,
-      question_text: "Question text",
-      answer_type: "date",
-    }.to_json
-  end
-
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
-
-  before do
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2/pages/1", req_headers, response_data, 200
-    end
-  end
-
-  it "returns the page for a form" do
-    expect(described_class.find(1, params: { form_id: 2 })).to have_attributes(id: 1, question_text: "Question text", answer_type: "date")
-  end
-
-  context "when answer_settings is not present" do
-    it "returns an empty object for answer_settings" do
-      expect(described_class.find(1, params: { form_id: 2 })).to have_attributes(answer_settings: {})
-    end
-  end
-
-  context "when answer_settings is present" do
+  describe "API call" do
     let(:response_data) do
       {
         id: 1,
         question_text: "Question text",
-        answer_type: "selection",
-        answer_settings: { only_one_option: "true" },
+        answer_type: "date",
       }.to_json
     end
 
-    it "returns an answer settings object for answer_settings" do
-      expect(described_class.find(1, params: { form_id: 2 }).answer_settings.attributes).to eq({ "only_one_option" => "true" })
+    let(:req_headers) do
+      {
+        "X-API-Token" => Settings.forms_api.auth_key,
+        "Accept" => "application/json",
+      }
+    end
+
+    before do
+      ActiveResource::HttpMock.respond_to do |mock|
+        mock.get "/api/v1/forms/2/pages/1", req_headers, response_data, 200
+      end
+    end
+
+    it "returns the page for a form" do
+      expect(described_class.find(1, params: { form_id: 2 })).to have_attributes(id: 1, question_text: "Question text", answer_type: "date")
+    end
+
+    context "when answer_settings is not present" do
+      it "returns an empty object for answer_settings" do
+        expect(described_class.find(1, params: { form_id: 2 })).to have_attributes(answer_settings: {})
+      end
+    end
+
+    context "when answer_settings is present" do
+      let(:response_data) do
+        {
+          id: 1,
+          question_text: "Question text",
+          answer_type: "selection",
+          answer_settings: { only_one_option: "true" },
+        }.to_json
+      end
+
+      it "returns an answer settings object for answer_settings" do
+        expect(described_class.find(1, params: { form_id: 2 }).answer_settings.attributes).to eq({ "only_one_option" => "true" })
+      end
     end
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Page, type: :model do
+  it "has a valid factory" do
+    page = build :page
+    expect(page).to be_valid
+  end
+
   describe "API call" do
     let(:response_data) do
       {


### PR DESCRIPTION
- **Make Page factory work with ActiveResource**
- **Move Page specs into another describe**
- **Ensure Page factory is valid**
- **Change answer_settings tests to use factory**
- **Add Page#repeatable?**

### Refactor Page specs and add Page#repeatable?

Trello card: https://trello.com/c/3nMdZ3Pa/1676-13-implement-add-another-answer-in-forms-runner-for-single-question-only-13

This PR makes changes to the Pages factory and adds a new test for an attribute added by an API change:

See: https://github.com/alphagov/forms-api/pull/542

The commit messages describe the changes to the Page factory and tests.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
