### PR TITLE
Prepare FeatureService for form external IDs

### DIFF
--- a/app/services/feature_service.rb
+++ b/app/services/feature_service.rb
@@ -14,7 +14,9 @@ module FeatureService
     if feature.enabled_for_form_ids.present?
       raise FormRequiredError, "Feature #{feature_name} requires form to be provided" if form.blank?
 
-      return feature.enabled_for_form_ids == form.id if feature.enabled_for_form_ids.is_a?(Integer)
+      # Do a string comparison to get ready for form.id being the external form ID rather than the database ID
+      # The form.id.to_s cast can be removed once the `form.id` is always a string.
+      return feature.enabled_for_form_ids.to_s == form.id.to_s if feature.enabled_for_form_ids.is_a?(Integer)
 
       form_ids = feature.enabled_for_form_ids.split(",").collect(&:strip)
 

--- a/spec/services/feature_service_spec.rb
+++ b/spec/services/feature_service_spec.rb
@@ -156,6 +156,19 @@ describe FeatureService do
           expect(feature_service).not_to be_enabled(:some_feature, form)
         end
       end
+
+      # This test is to account for the form ID being a string when we are using form external IDs instead. It can
+      # be removed once the migration to using external IDs is completed.
+      context "when the form id is a string" do
+        before do
+          form.id = "123"
+          Settings.features[:some_feature] = Config::Options.new(enabled: false, enabled_for_form_ids: "123")
+        end
+
+        it "returns the value of the enabled flag" do
+          expect(feature_service).to be_enabled(:some_feature, form)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION


### What problem does this pull request solve?

Trello card: <!-- link -->

We are introducing external IDs for forms, and replacing exposing the form database ID outside of forms-api with using this exernal ID.

This means that the `form.id` in runner will become the external ID, which is a String rather than an integer.

Existing forms will have an external ID equal to the internal ID cast to a String. This means that if we have enabled a feature flag for individual forms using the `enabled_for_form_ids` configuration, this will continue to work without having to update the value of the environment variable in forms deploy. We do, however need to make sure we are treating the value as a string.

We can get ready for the form.id becoming a String by converting both the value of `enabled_for_form_ids` if it is just a single number to a string and also converting the form.id to a string for comparison.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
