### PR TITLE
Add a single repeatable step

### DIFF
--- a/app/controllers/forms/add_another_answer_controller.rb
+++ b/app/controllers/forms/add_another_answer_controller.rb
@@ -1,5 +1,7 @@
 module Forms
   class AddAnotherAnswerController < PageController
+    before_action :redirect_if_not_repeating
+
     def show
       @rows = rows
       back_link(@step.page_slug)
@@ -48,6 +50,16 @@ module Forms
 
     def add_another_input_params
       params.require(:add_another_answer_input).permit(:add_another_answer)
+    end
+
+    def redirect_if_not_repeating
+      unless @step.is_a?(RepeatableStep)
+        if changing_existing_answer
+          redirect_to form_change_answer_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
+        else
+          redirect_to form_page_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
+        end
+      end
     end
   end
 end

--- a/app/controllers/forms/add_another_answer_controller.rb
+++ b/app/controllers/forms/add_another_answer_controller.rb
@@ -28,18 +28,18 @@ module Forms
 
     def add_another_path
       if changing_existing_answer
-        form_change_answer_path(@step.form_id, @step.form_slug, @step.page_slug, answer_id: @step.next_answer_id)
+        form_change_answer_path(@step.form_id, @step.form_slug, @step.page_slug, answer_index: @step.next_answer_index)
       else
-        form_page_path(@step.form_id, @step.form_slug, @step.page_slug, answer_id: @step.next_answer_id)
+        form_page_path(@step.form_id, @step.form_slug, @step.page_slug, answer_index: @step.next_answer_index)
       end
     end
 
     def rows
-      @step.questions.map.with_index(1) do |question, answer_id|
+      @step.questions.map.with_index(1) do |question, answer_index|
         {
-          key: { text: answer_id },
+          key: { text: answer_index },
           value: { text: question.show_answer },
-          actions: [{ text: t("forms.add_another_answer.rows.change"), href: form_change_answer_path(@step.form_id, @step.form_slug, @step.page_slug, answer_id:), visually_hidden_text: "" }],
+          actions: [{ text: t("forms.add_another_answer.rows.change"), href: form_change_answer_path(@step.form_id, @step.form_slug, @step.page_slug, answer_index:), visually_hidden_text: "" }],
         }
       end
     end

--- a/app/controllers/forms/add_another_answer_controller.rb
+++ b/app/controllers/forms/add_another_answer_controller.rb
@@ -1,0 +1,53 @@
+module Forms
+  class AddAnotherAnswerController < PageController
+    def show
+      @rows = rows
+      back_link(@step.page_slug)
+      @add_another_answer_input = AddAnotherAnswerInput.new
+    end
+
+    def save
+      @add_another_answer_input = AddAnotherAnswerInput.new(add_another_input_params)
+
+      if @add_another_answer_input.invalid?
+        @rows = rows
+        back_link(@step.page_slug)
+        return render :show
+      end
+
+      if @add_another_answer_input.add_another_answer?
+        redirect_to add_another_path
+      else
+        redirect_to next_page
+      end
+    end
+
+  private
+
+    def add_another_path
+      if changing_existing_answer
+        form_change_answer_path(@step.form_id, @step.form_slug, @step.page_slug, answer_id: @step.next_answer_id)
+      else
+        form_page_path(@step.form_id, @step.form_slug, @step.page_slug, answer_id: @step.next_answer_id)
+      end
+    end
+
+    def rows
+      @step.questions.map.with_index(1) do |question, answer_id|
+        {
+          key: { text: answer_id },
+          value: { text: question.show_answer },
+          actions: [{ text: t("forms.add_another_answer.rows.change"), href: form_change_answer_path(@step.form_id, @step.form_slug, @step.page_slug, answer_id:), visually_hidden_text: "" }],
+        }
+      end
+    end
+
+    def repeating?
+      false
+    end
+
+    def add_another_input_params
+      params.require(:add_another_answer_input).permit(:add_another_answer)
+    end
+  end
+end

--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -7,7 +7,7 @@ module Forms
       LogEventService.log_form_start unless mode.preview?
     end
 
-    rescue_from ActiveResource::ResourceNotFound, Flow::StepFactory::PageNotFoundError do
+    rescue_from ActiveResource::ResourceNotFound, Flow::StepFactory::PageNotFoundError, RepeatableStep::AnswerIndexError do
       render template: "errors/not_found", status: :not_found
     end
 

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -50,11 +50,17 @@ module Forms
   private
 
     def page_to_row(page)
+      change_link = if page.repeatable?
+                      change_add_another_answer_path(page.form_id, page.form_slug, page.page_id)
+                    else
+                      form_change_answer_path(page.form_id, page.form_slug, page.page_id)
+                    end
+
       question_name = helpers.question_text_with_optional_suffix_inc_mode(page, @mode)
       {
         key: { text: question_name },
         value: { text: page.show_answer },
-        actions: [{ href: form_change_answer_path(page.form_id, page.form_slug, page.page_id), visually_hidden_text: question_name }],
+        actions: [{ href: change_link, visually_hidden_text: question_name }],
       }
     end
 

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -9,7 +9,7 @@ module Forms
     end
 
     def show
-      return redirect_to form_page_path(current_context.form.id, current_context.form.form_slug, current_context.next_page_slug) unless current_context.can_visit?(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)
+      return redirect_to form_page_path(current_context.form.id, current_context.form.form_slug, current_context.next_page_slug, nil) unless current_context.can_visit?(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)
 
       setup_check_your_answers
       email_confirmation_input = EmailConfirmationInput.new

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -77,8 +77,7 @@ module Forms
     end
 
     def setup_check_your_answers
-      previous_step = current_context.previous_step("check_your_answers")
-      @back_link = form_page_path(current_context.form.id, current_context.form.form_slug, previous_step)
+      @back_link = back_link
       @rows = check_your_answers_rows
       @form_submit_path = form_submit_answers_path
 
@@ -87,6 +86,14 @@ module Forms
       end
 
       answers_need_full_width
+    end
+
+    def back_link
+      previous_step = current_context.previous_step(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)
+
+      if previous_step.present?
+        previous_step.repeatable? ? add_another_answer_path(form_id: current_context.form.id, form_slug: current_context.form.form_slug, page_slug: previous_step.page_slug) : form_page_path(current_context.form.id, current_context.form.form_slug, previous_step.page_id)
+      end
     end
   end
 end

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -37,6 +37,10 @@ module Forms
       page_slug = params.require(:page_slug)
       @step = current_context.find_or_create(page_slug)
 
+      if @step.respond_to?(:answer_id)
+        @step.answer_id = answer_id
+      end
+
       @support_details = current_context.support_details
     end
 

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -51,6 +51,7 @@ module Forms
     def setup_instance_vars_for_view
       @is_question = true
       @question_edit_link = "#{Settings.forms_admin.base_url}/forms/#{@step.form_id}/pages/#{@step.page_slug}/edit/question"
+      @save_url = save_url
     end
 
     def changing_existing_answer
@@ -93,6 +94,10 @@ module Forms
 
     def is_first_page?
       current_context.form.start_page == @step.id
+    end
+
+    def save_url
+      save_form_page_path(@step.form_id, @step.form_slug, @step.id, changing_existing_answer: @changing_existing_answer, answer_id:)
     end
   end
 end

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -70,10 +70,16 @@ module Forms
     end
 
     def next_page
-      if @changing_existing_answer
-        check_your_answers_path(form_id: current_context.form.id, form_slug: current_context.form.form_slug)
+      if changing_existing_answer
+        if @step.repeatable? && repeating?
+          change_add_another_answer_path(@step.form_id, @step.form_slug, @step.page_id)
+        else
+          check_your_answers_path(form_id: current_context.form.id, form_slug: current_context.form.form_slug)
+        end
       elsif @step.routing_conditions.any?
         calculate_page_routing
+      elsif @step.repeatable? && repeating?
+        add_another_answer_path(form_id: current_context.form.id, form_slug: current_context.form.form_slug, page_slug: @step.page_slug)
       else
         form_page_path(@step.form_id, @step.form_slug, @step.next_page_slug)
       end
@@ -96,6 +102,10 @@ module Forms
 
     def is_first_page?
       current_context.form.start_page == @step.id
+    end
+
+    def repeating?
+      true
     end
 
     def save_url

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -37,15 +37,15 @@ module Forms
       page_slug = params.require(:page_slug)
       @step = current_context.find_or_create(page_slug)
 
-      if @step.respond_to?(:answer_id)
-        @step.answer_id = answer_id
+      if @step.respond_to?(:answer_index)
+        @step.answer_index = answer_index
       end
 
       @support_details = current_context.support_details
     end
 
-    def answer_id
-      params.fetch(:answer_id, 1).to_i
+    def answer_index
+      params.fetch(:answer_index, 1).to_i
     end
 
     def setup_instance_vars_for_view
@@ -109,7 +109,7 @@ module Forms
     end
 
     def save_url
-      save_form_page_path(@step.form_id, @step.form_slug, @step.id, changing_existing_answer: @changing_existing_answer, answer_id:)
+      save_form_page_path(@step.form_id, @step.form_slug, @step.id, changing_existing_answer: @changing_existing_answer, answer_index:)
     end
   end
 end

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -40,6 +40,10 @@ module Forms
       @support_details = current_context.support_details
     end
 
+    def answer_id
+      params.fetch(:answer_id, 1).to_i
+    end
+
     def setup_instance_vars_for_view
       @is_question = true
       @question_edit_link = "#{Settings.forms_admin.base_url}/forms/#{@step.form_id}/pages/#{@step.page_slug}/edit/question"

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -60,10 +60,12 @@ module Forms
 
     def back_link(page_slug)
       previous_step = current_context.previous_step(page_slug)
+
       if @changing_existing_answer
         @back_link = check_your_answers_path(form_id: current_context.form.id)
       elsif previous_step
-        @back_link = form_page_path(@step.form_id, @step.form_slug, previous_step)
+
+        @back_link = previous_step.repeatable? ? add_another_answer_path(form_id: current_context.form.id, form_slug: current_context.form.form_slug, page_slug: previous_step.page_slug) : form_page_path(@step.form_id, @step.form_slug, previous_step.page_id)
       end
     end
 

--- a/app/input_objects/add_another_answer_input.rb
+++ b/app/input_objects/add_another_answer_input.rb
@@ -1,0 +1,18 @@
+class AddAnotherAnswerInput
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :add_another_answer
+
+  RADIO_OPTIONS = { yes: "yes", no: "no" }.freeze
+
+  validates :add_another_answer, presence: true, inclusion: { in: RADIO_OPTIONS.values }
+
+  def add_another_answer?
+    add_another_answer == RADIO_OPTIONS[:yes]
+  end
+
+  def values
+    RADIO_OPTIONS.keys
+  end
+end

--- a/app/lib/flow/context.rb
+++ b/app/lib/flow/context.rb
@@ -32,9 +32,9 @@ module Flow
       index = completed_steps.find_index { |step| step.page_slug == page_slug }
       return nil if completed_steps.empty? || index&.zero?
 
-      return completed_steps.last.page_id if index.nil?
+      return completed_steps.last if index.nil?
 
-      completed_steps[index - 1].page_id
+      completed_steps[index - 1]
     end
 
     def next_page_slug

--- a/app/lib/flow/journey.rb
+++ b/app/lib/flow/journey.rb
@@ -15,7 +15,7 @@ module Flow
     def find_existing_step(page_slug)
       step = @step_factory.create_step(page_slug)
       step.load_from_context(@form_context) unless @form_context.get_stored_answer(step).nil?
-    rescue ActiveModel::UnknownAttributeError
+    rescue ActiveModel::UnknownAttributeError, ArgumentError
       @form_context.clear_stored_answer(step)
       nil
     end

--- a/app/lib/flow/step_factory.rb
+++ b/app/lib/flow/step_factory.rb
@@ -27,11 +27,17 @@ module Flow
       next_page_slug = page.has_next_page? ? page.next_page.to_s : CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG
       question = QuestionRegister.from_page(page)
 
-      Step.new(question:, page:, form_id: @form.id, form_slug: @form.form_slug, next_page_slug:, page_slug:)
+      step_class(page).new(question:, page:, form_id: @form.id, form_slug: @form.form_slug, next_page_slug:, page_slug:)
     end
 
     def start_step
       create_step(START_PAGE)
+    end
+
+  private
+
+    def step_class(page)
+      page.repeatable? ? RepeatableStep : Step
     end
   end
 end

--- a/app/models/repeatable_step.rb
+++ b/app/models/repeatable_step.rb
@@ -25,6 +25,7 @@ class RepeatableStep < Step
 
   def load_from_context(form_context)
     question_attrs = form_context.get_stored_answer(self)
+
     unless question_attrs.is_a?(Array)
       raise ArgumentError
     end
@@ -54,11 +55,6 @@ class RepeatableStep < Step
     questions.first
   end
 
-  def add_blank_answer
-    questions << parent_question.dup
-    questions[answer_id - 1]
-  end
-
   def next_answer_id
     questions.length + 1
   end
@@ -66,10 +62,17 @@ class RepeatableStep < Step
   def show_answer
     if questions.present?
       safe_join(
-        questions.map.with_index do |question, index|
-          content_tag(:p, sanitize("#{index + 1}. #{question.show_answer}"))
+        questions.map.with_index(1) do |question, index|
+          content_tag(:p, sanitize("#{index}. #{question.show_answer}"))
         end,
       )
     end
+  end
+
+private
+
+  def add_blank_answer
+    questions << parent_question.dup
+    questions[answer_id - 1]
   end
 end

--- a/app/models/repeatable_step.rb
+++ b/app/models/repeatable_step.rb
@@ -65,6 +65,14 @@ class RepeatableStep < Step
     end
   end
 
+  def show_answer_in_email
+    if questions.present?
+      questions.map.with_index(1) { |question, index|
+        "#{index}. #{question.show_answer_in_email}"
+      }.join("\n\n")
+    end
+  end
+
 private
 
   def add_blank_answer

--- a/app/models/repeatable_step.rb
+++ b/app/models/repeatable_step.rb
@@ -1,0 +1,2 @@
+class RepeatableStep < Step
+end

--- a/app/models/repeatable_step.rb
+++ b/app/models/repeatable_step.rb
@@ -61,11 +61,13 @@ class RepeatableStep < Step
 
   def show_answer
     if questions.present?
-      safe_join(
-        questions.map.with_index(1) do |question, index|
-          content_tag(:p, sanitize("#{index}. #{question.show_answer}"))
-        end,
-      )
+      content_tag(:ol, class: "govuk-list govuk-list--number") do
+        safe_join(
+          questions.map do |question|
+            content_tag(:li, sanitize(question.show_answer))
+          end,
+        )
+      end
     end
   end
 

--- a/app/models/repeatable_step.rb
+++ b/app/models/repeatable_step.rb
@@ -1,2 +1,71 @@
 class RepeatableStep < Step
+  include ActionView::Helpers::SanitizeHelper
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::OutputSafetyHelper
+
+  attr_accessor :answer_id, :questions
+
+  def initialize(...)
+    super
+    @questions = []
+  end
+
+  def repeatable?
+    true
+  end
+
+  def parent_question
+    Step.instance_method(:question).bind(self).call
+  end
+
+  def save_to_context(form_context)
+    form_context.save_step(self, @questions.map(&:serializable_hash))
+    self
+  end
+
+  def load_from_context(form_context)
+    question_attrs = form_context.get_stored_answer(self)
+    @questions = question_attrs.map do |attrs|
+      q = parent_question.dup
+      q.assign_attributes(attrs || {})
+      q
+    end
+
+    self
+  end
+
+  def question
+    if questions.blank?
+      add_blank_answer
+    end
+
+    if next_answer_id == answer_id
+      return add_blank_answer
+    end
+
+    if answer_id && answer_id <= @questions.count
+      return questions[answer_id - 1]
+    end
+
+    questions.first
+  end
+
+  def add_blank_answer
+    questions << parent_question.dup
+    questions[answer_id - 1]
+  end
+
+  def next_answer_id
+    questions.length + 1
+  end
+
+  def show_answer
+    if questions.present?
+      safe_join(
+        questions.map.with_index do |question, index|
+          content_tag(:p, sanitize("#{index + 1}. #{question.show_answer}"))
+        end,
+      )
+    end
+  end
 end

--- a/app/models/repeatable_step.rb
+++ b/app/models/repeatable_step.rb
@@ -25,6 +25,10 @@ class RepeatableStep < Step
 
   def load_from_context(form_context)
     question_attrs = form_context.get_stored_answer(self)
+    unless question_attrs.is_a?(Array)
+      raise ArgumentError
+    end
+
     @questions = question_attrs.map do |attrs|
       q = parent_question.dup
       q.assign_attributes(attrs || {})

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -77,4 +77,8 @@ class Step
     condition = routing_conditions.first
     condition.goto_page_id.nil? && condition.skip_to_end ? CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG : condition.goto_page_id.to_s
   end
+
+  def repeatable?
+    false
+  end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -49,15 +49,7 @@ class Step
     question.errors.clear
   end
 
-  delegate :show_answer, to: :question
-
-  delegate :show_answer_in_email, to: :question
-
-  delegate :question_text, to: :question
-
-  delegate :hint_text, to: :question
-
-  delegate :answer_settings, to: :question
+  delegate :show_answer, :show_answer_in_email, :question_text, :hint_text, :answer_settings, to: :question
 
   def end_page?
     next_page_slug.nil?

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -43,33 +43,21 @@ class Step
     @question.attribute_names.concat([selection: []])
   end
 
-  def valid?
-    @question.valid?
-  end
+  delegate :valid?, to: :question
 
   def clear_errors
     @question.errors.clear
   end
 
-  def show_answer
-    @question.show_answer
-  end
+  delegate :show_answer, to: :question
 
-  def show_answer_in_email
-    @question.show_answer_in_email
-  end
+  delegate :show_answer_in_email, to: :question
 
-  def question_text
-    @question.question_text
-  end
+  delegate :question_text, to: :question
 
-  def hint_text
-    @question.hint_text
-  end
+  delegate :hint_text, to: :question
 
-  def answer_settings
-    @question.answer_settings
-  end
+  delegate :answer_settings, to: :question
 
   def end_page?
     next_page_slug.nil?

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -24,29 +24,29 @@ class Step
   end
 
   def save_to_context(form_context)
-    form_context.save_step(self, @question.serializable_hash)
+    form_context.save_step(self, question.serializable_hash)
     self
   end
 
   def load_from_context(form_context)
     attrs = form_context.get_stored_answer(self)
-    @question.assign_attributes(attrs || {})
+    question.assign_attributes(attrs || {})
     self
   end
 
   def update!(params)
-    @question.assign_attributes(params)
-    @question.valid?
+    question.assign_attributes(params)
+    question.valid?
   end
 
   def params
-    @question.attribute_names.concat([selection: []])
+    question.attribute_names.concat([selection: []])
   end
 
   delegate :valid?, to: :question
 
   def clear_errors
-    @question.errors.clear
+    question.errors.clear
   end
 
   delegate :show_answer, to: :question
@@ -64,7 +64,7 @@ class Step
   end
 
   def next_page_slug_after_routing
-    if routing_conditions.any? && routing_conditions.first.answer_value == @question.selection
+    if routing_conditions.any? && routing_conditions.first.answer_value == question.selection
       goto_page_slug
     else
       next_page_slug

--- a/app/views/forms/add_another_answer/show.html.erb
+++ b/app/views/forms/add_another_answer/show.html.erb
@@ -1,0 +1,28 @@
+<% set_page_title(form_title(form_name: @current_context.form.name, page_name: (@step.question.page_heading.present? ? @step.question.page_heading : @step.question.question_text), mode: @mode, error: @step.question&.errors&.any?)) %>
+
+<% content_for :back_link do %>
+  <% if @back_link.present? %>
+    <%= link_to t("forms.back"), @back_link, class: "govuk-back-link" %>
+  <% end %>
+<% end %>
+
+<%= form_with(model: @add_another_answer_input , method: :post, url: add_another_answer_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer: @changing_existing_answer)) do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <% if @add_another_answer_input&.errors.any? %>
+        <%= f.govuk_error_summary %>
+      <% end %>
+
+      <h1 class="govuk-heading-l"><%= t('.heading', count: @rows.count) %></h1>
+
+      <%= govuk_summary_list(classes: "add-another-answer", rows: @rows) %>
+
+      <%= f.govuk_collection_radio_buttons :add_another_answer,
+        @add_another_answer_input.values, ->(option) { option }, ->(option) { t('helpers.label.add_another_answer_input.options.' + "#{option}") },
+        legend: { text: t('.radios_legend'), size: 'm' },
+        inline: true %>
+
+      <%= f.govuk_submit %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/forms/page/show.html.erb
+++ b/app/views/forms/page/show.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @step.question, url: save_form_page_path(@step.form_id, @step.form_slug, @step.id, :changing_existing_answer => @changing_existing_answer), scope: :question, method: :post do |form| %>
+    <%= form_with model: @step.question, url: @save_url, scope: :question, method: :post do |form| %>
       <% if @step.question&.errors&.any? %>
         <%= form.govuk_error_summary %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,10 @@ en:
   activemodel:
     errors:
       models:
+        add_another_answer_input:
+          attributes:
+            add_another_answer:
+              blank: You must select an option
         email_confirmation_input:
           attributes:
             confirmation_email_address:
@@ -110,11 +114,26 @@ en:
       title: Your form has been submitted
       what_happens_next: What happens next
       your_reference: 'Your form reference number is:'
+  forms:
+    add_another_answer:
+      rows:
+        change: Change
+      show:
+        heading:
+          one: You have added one answer
+          other: You have added %{count} answers
+          zero: You have added no answers
+        radios_legend: Do you need to add another answer?
+    back: Back
   helpers:
     hint:
       email_confirmation_input:
         send_confirmation: We’ll only use the email address you provide here to send a confirmation that your form’s been successfully submitted. It will not contain a copy of your answers.
     label:
+      add_another_answer_input:
+        options:
+          'no': 'No'
+          'yes': 'Yes'
       email_confirmation_input:
         confirmation_email_address: What email address do you want us to send your confirmation to?
         send_confirmation_options:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,19 +22,34 @@ Rails.application.routes.draw do
       post "/#{CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG}" => "forms/check_your_answers#submit_answers", as: :form_submit_answers
       get "/submitted" => "forms/submitted#submitted", as: :form_submitted
       get "/privacy" => "forms/privacy_page#show", as: :form_privacy
-      get "/:page_slug/change(/:answer_id)" => "forms/page#show", as: :form_change_answer, defaults: { changing_existing_answer: true, answer_id: 1 }
 
-      get "/:page_slug/add-another-answer" => "forms/add_another_answer#show", constraints: { page_slug: Flow::StepFactory::PAGE_SLUG_REGEX }, as: :add_another_answer
-      post "/:page_slug/add-another-answer" => "forms/add_another_answer#save", constraints: { page_slug: Flow::StepFactory::PAGE_SLUG_REGEX }, as: :save_add_another_answer
-      get "/:page_slug/change-add-another-answer" => "forms/add_another_answer#show", constraints: { page_slug: Flow::StepFactory::PAGE_SLUG_REGEX }, as: :change_add_another_answer, defaults: { changing_existing_answer: true }
-      post "/:page_slug(/:answer_id)" => "forms/page#save", as: :save_form_page, defaults: { answer_id: 1 }
+      page_constraints = { page_slug: Flow::StepFactory::PAGE_SLUG_REGEX }
+      answer_constraints = { answer_id: /\d+/ }
+      page_answer_defaults = { answer_id: 1 }
+
+      get "/:page_slug/add-another-answer/change" => "forms/add_another_answer#show",
+          as: :change_add_another_answer,
+          constraints: page_constraints,
+          defaults: { changing_existing_answer: true }
+      get "/:page_slug/add-another-answer" => "forms/add_another_answer#show",
+          as: :add_another_answer,
+          constraints: page_constraints
+      post "/:page_slug/add-another-answer" => "forms/add_another_answer#save",
+           as: :save_add_another_answer,
+           constraints: page_constraints
+
+      get "/:page_slug/(/:answer_id)/change" => "forms/page#show",
+          as: :form_change_answer,
+          defaults: page_answer_defaults.merge(changing_existing_answer: true),
+          constraints: page_constraints.merge(answer_constraints)
       get "/:page_slug(/:answer_id)" => "forms/page#show",
-          constraints: {
-            page_slug: Flow::StepFactory::PAGE_SLUG_REGEX,
-            answer_id: /\d+/,
-          },
-          defaults: { answer_id: 1 },
-          as: :form_page
+          as: :form_page,
+          constraints: page_constraints.merge(answer_constraints),
+          defaults: page_answer_defaults
+      post "/:page_slug(/:answer_id)" => "forms/page#save",
+           as: :save_form_page,
+           constraints: page_constraints,
+           defaults: page_answer_defaults
 
       get "/repeat-submission" => "forms/base#error_repeat_submission", as: :error_repeat_submission, via: :all
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,8 +24,8 @@ Rails.application.routes.draw do
       get "/privacy" => "forms/privacy_page#show", as: :form_privacy
 
       page_constraints = { page_slug: Flow::StepFactory::PAGE_SLUG_REGEX }
-      answer_constraints = { answer_id: /\d+/ }
-      page_answer_defaults = { answer_id: 1 }
+      answer_constraints = { answer_index: /\d+/ }
+      page_answer_defaults = { answer_index: 1 }
 
       get "/:page_slug/add-another-answer/change" => "forms/add_another_answer#show",
           as: :change_add_another_answer,
@@ -38,15 +38,15 @@ Rails.application.routes.draw do
            as: :save_add_another_answer,
            constraints: page_constraints
 
-      get "/:page_slug/(/:answer_id)/change" => "forms/page#show",
+      get "/:page_slug/(/:answer_index)/change" => "forms/page#show",
           as: :form_change_answer,
           defaults: page_answer_defaults.merge(changing_existing_answer: true),
           constraints: page_constraints.merge(answer_constraints)
-      get "/:page_slug(/:answer_id)" => "forms/page#show",
+      get "/:page_slug(/:answer_index)" => "forms/page#show",
           as: :form_page,
           constraints: page_constraints.merge(answer_constraints),
           defaults: page_answer_defaults
-      post "/:page_slug(/:answer_id)" => "forms/page#save",
+      post "/:page_slug(/:answer_index)" => "forms/page#save",
            as: :save_form_page,
            constraints: page_constraints,
            defaults: page_answer_defaults

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,9 +22,15 @@ Rails.application.routes.draw do
       post "/#{CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG}" => "forms/check_your_answers#submit_answers", as: :form_submit_answers
       get "/submitted" => "forms/submitted#submitted", as: :form_submitted
       get "/privacy" => "forms/privacy_page#show", as: :form_privacy
-      get "/:page_slug/change" => "forms/page#show", as: :form_change_answer, defaults: { changing_existing_answer: true }
-      get "/:page_slug" => "forms/page#show", constraints: { page_slug: Flow::StepFactory::PAGE_SLUG_REGEX }, as: :form_page
-      post "/:page_slug" => "forms/page#save", as: :save_form_page
+      get "/:page_slug/change(/:answer_id)" => "forms/page#show", as: :form_change_answer, defaults: { changing_existing_answer: true, answer_id: 1 }
+      post "/:page_slug(/:answer_id)" => "forms/page#save", as: :save_form_page, defaults: { answer_id: 1 }
+      get "/:page_slug(/:answer_id)" => "forms/page#show",
+          constraints: {
+            page_slug: Flow::StepFactory::PAGE_SLUG_REGEX,
+            answer_id: /\d+/,
+          },
+          defaults: { answer_id: 1 },
+          as: :form_page
 
       get "/repeat-submission" => "forms/base#error_repeat_submission", as: :error_repeat_submission, via: :all
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,10 @@ Rails.application.routes.draw do
       get "/submitted" => "forms/submitted#submitted", as: :form_submitted
       get "/privacy" => "forms/privacy_page#show", as: :form_privacy
       get "/:page_slug/change(/:answer_id)" => "forms/page#show", as: :form_change_answer, defaults: { changing_existing_answer: true, answer_id: 1 }
+
+      get "/:page_slug/add-another-answer" => "forms/add_another_answer#show", constraints: { page_slug: Flow::StepFactory::PAGE_SLUG_REGEX }, as: :add_another_answer
+      post "/:page_slug/add-another-answer" => "forms/add_another_answer#save", constraints: { page_slug: Flow::StepFactory::PAGE_SLUG_REGEX }, as: :save_add_another_answer
+
       post "/:page_slug(/:answer_id)" => "forms/page#save", as: :save_form_page, defaults: { answer_id: 1 }
       get "/:page_slug(/:answer_id)" => "forms/page#show",
           constraints: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
 
       get "/:page_slug/add-another-answer" => "forms/add_another_answer#show", constraints: { page_slug: Flow::StepFactory::PAGE_SLUG_REGEX }, as: :add_another_answer
       post "/:page_slug/add-another-answer" => "forms/add_another_answer#save", constraints: { page_slug: Flow::StepFactory::PAGE_SLUG_REGEX }, as: :save_add_another_answer
-
+      get "/:page_slug/change-add-another-answer" => "forms/add_another_answer#show", constraints: { page_slug: Flow::StepFactory::PAGE_SLUG_REGEX }, as: :change_add_another_answer, defaults: { changing_existing_answer: true }
       post "/:page_slug(/:answer_id)" => "forms/page#save", as: :save_form_page, defaults: { answer_id: 1 }
       get "/:page_slug(/:answer_id)" => "forms/page#show",
           constraints: {

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -83,4 +83,8 @@ FactoryBot.define do
       answer_settings { DataStruct.new(input_type:, title_needed:) }
     end
   end
+
+  trait :with_repeatable do
+    is_repeatable { true }
+  end
 end

--- a/spec/features/fill_in_single_repeatable_form_spec.rb
+++ b/spec/features/fill_in_single_repeatable_form_spec.rb
@@ -1,0 +1,128 @@
+require "rails_helper"
+
+feature "Fill in and submit a form with a single repeatable question", type: :feature do
+  let(:pages) { [(build :page, :with_repeatable, answer_type: "number")] }
+  let(:form) { build :form, :live?, id: 42, name: "Form with repeating question", pages:, start_page: pages.first.id }
+
+  let(:question_text) { pages[0].question_text }
+  let(:first_answer_text) { "99" }
+  let(:second_answer_text) { "7" }
+  let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Content-Type" => "application/json",
+    }
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms/42", req_headers, form.to_json, 200
+      mock.get "/api/v1/forms/42/live", req_headers, form.to_json(include: [:pages]), 200
+    end
+
+    allow(ReferenceNumberService).to receive(:generate).and_return(reference)
+  end
+
+  scenario "As a form filler" do
+    when_i_visit_the_form_start_page
+    then_i_should_see_the_first_question
+
+    when_i_fill_in_the_question
+    and_i_click_on_continue
+
+    then_i_should_see_the_add_another_page
+
+    when_i_choose_to_add_another
+    and_i_click_on_continue
+
+    then_i_should_see_the_first_question
+    when_i_fill_in_the_question_with_my_second_answer
+    and_i_click_on_continue
+
+    then_i_should_see_the_add_another_page_with_my_second_answer
+
+    when_i_choose_not_to_add_another
+    and_i_click_on_continue
+
+    then_i_should_see_the_check_your_answers_page
+    when_i_opt_out_of_email_confirmation
+    and_i_submit_my_form
+    then_my_form_should_be_submitted
+    and_i_should_receive_a_reference_number
+  end
+
+  def when_i_visit_the_form_start_page
+    visit form_path(mode: "form", form_id: 42, form_slug: "form-with-repeating-question")
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def then_i_should_see_the_first_question
+    expect(page.find("h1")).to have_text question_text
+  end
+
+  def when_i_fill_in_the_question
+    fill_in question_text, with: first_answer_text
+  end
+
+  def and_i_click_on_continue
+    click_button "Continue"
+  end
+
+  def then_i_should_see_the_add_another_page
+    expect(page.find("h1")).to have_text "You have added one answer"
+    expect(page).to have_text first_answer_text
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def when_i_choose_to_add_another
+    choose "Yes"
+  end
+
+  def when_i_fill_in_the_question_with_my_second_answer
+    fill_in question_text, with: second_answer_text
+  end
+
+  def then_i_should_see_the_add_another_page_with_my_second_answer
+    expect(page.find("h1")).to have_text "You have added 2 answers"
+    expect(page).to have_text first_answer_text
+    expect(page).to have_text second_answer_text
+  end
+
+  def when_i_choose_not_to_add_another
+    choose "No"
+  end
+
+  def then_i_should_see_the_check_your_answers_page
+    expect(page.find("h1")).to have_text "Check your answers before submitting your form"
+    expect(page).to have_text question_text
+    expect(page).to have_text first_answer_text
+    expect(page).to have_text second_answer_text
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def when_i_opt_out_of_email_confirmation
+    choose "No"
+  end
+
+  def and_i_submit_my_form
+    click_on "Submit"
+  end
+
+  def then_my_form_should_be_submitted
+    expect(page.find("h1")).to have_text "Your form has been submitted"
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def and_i_should_receive_a_reference_number
+    expect(page).to have_text reference
+  end
+end

--- a/spec/input_objects/add_another_answer_input_spec.rb
+++ b/spec/input_objects/add_another_answer_input_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe AddAnotherAnswerInput do
+  let(:valid_attributes) { { add_another_answer: "yes" } }
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      input = described_class.new(valid_attributes)
+      expect(input).to be_valid
+    end
+
+    it "is not valid without an add_another_answer" do
+      input = described_class.new(add_another_answer: nil)
+      expect(input).not_to be_valid
+      expect(input.errors[:add_another_answer]).to include(I18n.t("activemodel.errors.models.add_another_answer_input.attributes.add_another_answer.blank"))
+    end
+
+    it "is not valid with an invalid add_another_answer" do
+      input = described_class.new(add_another_answer: "invalid")
+      expect(input).not_to be_valid
+      expect(input.errors[:add_another_answer]).to include("is not included in the list")
+    end
+
+    it 'is valid with "yes" as add_another_answer' do
+      input = described_class.new(add_another_answer: "yes")
+      expect(input).to be_valid
+    end
+
+    it 'is valid with "no" as add_another_answer' do
+      input = described_class.new(add_another_answer: "no")
+      expect(input).to be_valid
+    end
+  end
+
+  describe "#add_another_answer?" do
+    it 'returns true when add_another_answer is "yes"' do
+      input = described_class.new(add_another_answer: "yes")
+      expect(input.add_another_answer?).to be true
+    end
+
+    it 'returns false when add_another_answer is "no"' do
+      input = described_class.new(add_another_answer: "no")
+      expect(input.add_another_answer?).to be false
+    end
+  end
+
+  describe "#values" do
+    it "returns an array of valid values" do
+      input = described_class.new
+      expect(input.values).to eq(%i[yes no])
+    end
+  end
+
+  describe "RADIO_OPTIONS" do
+    it "has the correct values" do
+      expect(described_class::RADIO_OPTIONS).to eq({ yes: "yes", no: "no" })
+    end
+
+    it "is frozen" do
+      expect(described_class::RADIO_OPTIONS).to be_frozen
+    end
+  end
+end

--- a/spec/lib/flow/context_spec.rb
+++ b/spec/lib/flow/context_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Flow::Context do
       end
 
       it "has the correct previous step" do
-        expect(@context.previous_step(@step.page_slug)).to eq(expected_output[:previous_step_id])
+        expect(@context.previous_step(@step.page_slug)&.page_id).to eq(expected_output[:previous_step_id])
       end
 
       it "has the correct next incomplete step" do

--- a/spec/lib/flow/step_factory_spec.rb
+++ b/spec/lib/flow/step_factory_spec.rb
@@ -42,6 +42,21 @@ RSpec.describe Flow::StepFactory do
       end
     end
 
+    context "when creating a repeating step" do
+      let(:page) { build :page, :with_repeatable, page_slug: "page-1" }
+      let(:question) { instance_double(Question) }
+
+      before do
+        allow(form.pages).to receive(:find).and_return(page)
+        allow(Flow::QuestionRegister).to receive(:from_page).with(page).and_return(question)
+      end
+
+      it "a RepeatingStep is created" do
+        step = factory.create_step(page.page_slug)
+        expect(step).to be_a(RepeatableStep)
+      end
+    end
+
     context "when page is not found" do
       it "raises a PageNotFoundError" do
         expect { factory.create_step("non-existent-page") }.to raise_error(Flow::StepFactory::PageNotFoundError)

--- a/spec/lib/flow/step_factory_spec.rb
+++ b/spec/lib/flow/step_factory_spec.rb
@@ -1,6 +1,76 @@
 require "rails_helper"
 
 RSpec.describe Flow::StepFactory do
+  let(:form) { build :form, id: "form-123", form_slug: "test-form", start_page: "page-1", pages: [] }
+  let(:factory) { described_class.new(form:) }
+
+  describe "#create_step" do
+    context "when creating a CheckYourAnswersStep" do
+      it "returns a CheckYourAnswersStep instance" do
+        step = factory.create_step(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)
+        expect(step).to be_a(CheckYourAnswersStep)
+        expect(step.form_id).to eq("form-123")
+      end
+    end
+
+    context "when creating a regular step" do
+      let(:page) { build_stubbed :page, id: "page-1", has_next_page?: true, next_page: "page-2" }
+      let(:question) { instance_double(Question) }
+
+      before do
+        allow(form.pages).to receive(:find).and_return(page)
+        allow(Flow::QuestionRegister).to receive(:from_page).with(page).and_return(question)
+      end
+
+      it "returns a Step instance" do
+        step = factory.create_step("page-1")
+        expect(step).to be_a(Step)
+        expect(step.question).to eq(question)
+        expect(step.form_id).to eq("form-123")
+        expect(step.form_slug).to eq("test-form")
+        expect(step.next_page_slug).to eq("page-2")
+        expect(step.page_slug).to eq("page-1")
+      end
+
+      context "when it is the last page" do
+        let(:page) { build :page, id: "page-1", has_next_page?: false }
+
+        it "sets next_page_slug to CHECK_YOUR_ANSWERS_PAGE_SLUG" do
+          step = factory.create_step("page-1")
+          expect(step.next_page_slug).to eq(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)
+        end
+      end
+    end
+
+    context "when page is not found" do
+      it "raises a PageNotFoundError" do
+        expect { factory.create_step("non-existent-page") }.to raise_error(Flow::StepFactory::PageNotFoundError)
+      end
+    end
+
+    context "when creating the start step" do
+      let(:start_page) { build :page, id: "page-1", has_next_page?: true, next_page: "page-2" }
+
+      before do
+        allow(form.pages).to receive(:find).and_return(start_page)
+        allow(Flow::QuestionRegister).to receive(:from_page).with(start_page).and_return(instance_double(Question))
+      end
+
+      it "creates a step for the start page" do
+        step = factory.create_step(Flow::StepFactory::START_PAGE)
+        expect(step).to be_a(Step)
+        expect(step.page_slug).to eq("page-1")
+      end
+    end
+  end
+
+  describe "#start_step" do
+    it "calls create_step with START_PAGE" do
+      expect(factory).to receive(:create_step).with(Flow::StepFactory::START_PAGE)
+      factory.start_step
+    end
+  end
+
   describe Flow::StepFactory::PAGE_SLUG_REGEX do
     it "matches valid page_id values" do
       %w[1 123 0123456789 check-your-answers].each do |string|

--- a/spec/models/repeatable_step_spec.rb
+++ b/spec/models/repeatable_step_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+RSpec.describe RepeatableStep, type: :model do
+  subject(:repeatable_step) { described_class.new(question:, page:, form_id: 1, form_slug: "form-slug", next_page_slug: 2, page_slug: page.id) }
+
+  let(:question) { build :name }
+  let(:page) { build :page }
+
+  describe "#repeatable?" do
+    it "returns true" do
+      expect(repeatable_step.repeatable?).to be true
+    end
+  end
+
+  describe "#save_to_context" do
+    let(:form_context) { instance_double(Flow::FormContext) }
+
+    it "calls save_step on the argument" do
+      allow(form_context).to receive(:save_step).with(repeatable_step, [question.serializable_hash])
+      expect(repeatable_step.save_to_context(form_context)).to be(repeatable_step)
+    end
+  end
+
+  describe "#load_from_context" do
+    let(:form_context) { instance_double(Flow::FormContext) }
+
+    context "when form context contains a non-array questions attribute" do
+      it "raises an argument error" do
+        allow(form_context).to receive(:get_stored_answer).with(repeatable_step).and_return("a string")
+        expect { repeatable_step.load_from_context(form_context) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when form context contains an array questions attribute" do
+      let(:question_attrs) { [first_attribute_hash, second_attribute_hash] }
+      let(:first_attribute_hash) { { answer: "first" } }
+      let(:second_attribute_hash) { { answer: "second" } }
+      let(:question) { instance_double(Question::QuestionBase) }
+      let(:question_dup) { instance_double(Question::QuestionBase) }
+
+      it "builds the @questions array" do
+        allow(form_context).to receive(:get_stored_answer).with(repeatable_step).and_return(question_attrs)
+        allow(question).to receive(:dup).and_return(question_dup)
+        expect(question_dup).to receive(:assign_attributes).with(first_attribute_hash)
+        expect(question_dup).to receive(:assign_attributes).with(second_attribute_hash)
+
+        expect(repeatable_step.load_from_context(form_context).questions).to eq([question_dup, question_dup])
+      end
+    end
+  end
+
+  describe "#question" do
+    let(:questions) { [1] }
+
+    before do
+      allow(question).to receive(:dup).and_return(1, 2, 3)
+      repeatable_step.answer_index = answer_index
+      repeatable_step.questions = questions
+    end
+
+    context "when the answer index is blank" do
+      let(:answer_index) { nil }
+
+      it "returns the first question" do
+        expect(repeatable_step.question).to eq(1)
+      end
+    end
+
+    context "when the answer index is exactly 1 greater than the questions length" do
+      let(:answer_index) { 2 }
+
+      it "duplicates question and adds it to the questions list" do
+        expect(repeatable_step.question).to eq(2)
+        expect(repeatable_step.questions).to eq([1, 2])
+      end
+    end
+
+    context "when the answer index is outside the range of the questions list" do
+      let(:answer_index) { 3 }
+
+      it "raises an AnswerIndexError" do
+        expect { repeatable_step.question }.to raise_error(RepeatableStep::AnswerIndexError)
+      end
+    end
+
+    context "when the answer index is within the range of the questions list" do
+      let(:answer_index) { 3 }
+      let(:questions) { [1, 2, 3] }
+
+      it "returns the question at that index" do
+        expect(repeatable_step.question).to eq(3)
+      end
+    end
+  end
+
+  describe "#next_answer_index" do
+    let(:questions) { [1, 2, 3] }
+
+    before { repeatable_step.questions = questions }
+
+    it "returns an index for the next question iteration" do
+      expect(repeatable_step.next_answer_index).to eq(4)
+    end
+  end
+
+  describe "#show_answer" do
+    let(:questions) { [first_question, second_question] }
+    let(:first_question) { OpenStruct.new({ show_answer: "first answer" }) }
+    let(:second_question) { OpenStruct.new({ show_answer: "second answer" }) }
+
+    before { repeatable_step.questions = questions }
+
+    it "returns an ordered list of answers" do
+      expect(repeatable_step.show_answer).to eq('<ol class="govuk-list govuk-list--number"><li>first answer</li><li>second answer</li></ol>')
+    end
+  end
+
+  describe "#show_answer_in_email" do
+    let(:questions) { [first_question, second_question] }
+    let(:first_question) { OpenStruct.new({ show_answer_in_email: "first answer" }) }
+    let(:second_question) { OpenStruct.new({ show_answer_in_email: "second answer" }) }
+
+    before { repeatable_step.questions = questions }
+
+    it "returns an ordered list of answers" do
+      expect(repeatable_step.show_answer_in_email).to eq("1. first answer\n\n2. second answer")
+    end
+  end
+end

--- a/spec/requests/forms/add_another_answer_controller_spec.rb
+++ b/spec/requests/forms/add_another_answer_controller_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+RSpec.describe Forms::AddAnotherAnswerController, type: :request do
+  let(:form) do
+    build(:form, :with_support, id: 2, start_page: 1, pages:)
+  end
+
+  let(:pages) { [first_page_in_form, second_page_in_form] }
+
+  let(:first_page_in_form) do
+    build :page,
+          :with_text_settings,
+          :with_repeatable,
+          id: 1,
+          next_page: 2,
+          is_optional: false
+  end
+
+  let(:second_page_in_form) do
+    build :page, :with_text_settings, id: 2
+  end
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:api_url_suffix) { "/draft" }
+
+  let(:stored_answers) do
+    [{ text: "answer 1" }, { text: "answer 2" }]
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v1/forms/#{form.id}#{api_url_suffix}", req_headers, form.to_json, 200
+    end
+
+    form_context = instance_double(Flow::FormContext)
+    allow(Flow::FormContext).to receive(:new).and_return(form_context)
+    allow(form_context).to receive(:clear_stored_answer)
+    allow(form_context).to receive(:get_stored_answer).and_return(stored_answers)
+  end
+
+  describe "GET #show" do
+    it "renders the show template" do
+      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer"
+      expect(response).to render_template(:show)
+    end
+
+    it "assigns @rows" do
+      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer"
+      expect(assigns(:rows).count).to eq 2
+    end
+
+    it "initializes @add_another_answer_input" do
+      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer"
+      expect(assigns(:add_another_answer_input)).to be_a(AddAnotherAnswerInput)
+    end
+  end
+
+  describe "POST #save" do
+    context "with valid params" do
+      context "when adding another answer" do
+        it "redirects to first page to add another" do
+          post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "yes" } }
+          expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/3")
+        end
+      end
+
+      context "when not adding another answer" do
+        it "redirects to next page" do
+          post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "no" } }
+          expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{second_page_in_form.id}")
+        end
+      end
+    end
+
+    context "with invalid params" do
+      it "renders the show template" do
+        post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "" } }
+        expect(response).to render_template(:show)
+      end
+
+      it "assigns @rows" do
+        post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "" } }
+        expect(assigns(:rows).count).to be_present
+      end
+    end
+  end
+
+  describe "redirect_if_not_repeating" do
+    context "when step is not RepeatableStep" do
+      it "redirects to form_page when not changing existing answer" do
+        get "/preview-draft/#{form.id}/#{form.form_slug}/#{second_page_in_form.id}/add-another-answer"
+        expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{second_page_in_form.id}")
+      end
+
+      it "redirects to form_change_answer_path when changing existing answer" do
+        get "/preview-draft/#{form.id}/#{form.form_slug}/#{second_page_in_form.id}/change-add-another-answer"
+        expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{second_page_in_form.id}/change")
+      end
+    end
+  end
+end

--- a/spec/requests/forms/add_another_answer_controller_spec.rb
+++ b/spec/requests/forms/add_another_answer_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Forms::AddAnotherAnswerController, type: :request do
       end
 
       it "redirects to form_change_answer_path when changing existing answer" do
-        get "/preview-draft/#{form.id}/#{form.form_slug}/#{second_page_in_form.id}/change-add-another-answer"
+        get "/preview-draft/#{form.id}/#{form.form_slug}/#{second_page_in_form.id}/add-another-answer/change"
         expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{second_page_in_form.id}/change")
       end
     end

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -170,7 +170,6 @@ RSpec.describe Forms::PageController, type: :request do
         "/form/2/1/leading_check_your_answers",
         "/form/2/1/1/check_your_answers",
         "/form/2/1/1/ChEck_YouR_aNswers",
-        "/form/2/1/1/0",
         "/form/2/1/1/%20123",
         "/form/2/1/__",
         "/form/2/1/debug.cgi",

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "Passes the changing answers parameter in its submit request" do
           get form_change_answer_path("preview-draft", 2, form_data.form_slug, 1)
-          expect(response.body).to include(save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true))
+          expect(response.body).to include(save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true, answer_id: 1))
         end
       end
 
@@ -243,7 +243,7 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "Passes the changing answers parameter in its submit request" do
           get form_change_answer_path("form", 2, form_data.form_slug, 1)
-          expect(response.body).to include(save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true))
+          expect(response.body).to include(save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true, answer_id: 1))
         end
       end
 

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "Passes the changing answers parameter in its submit request" do
           get form_change_answer_path("preview-draft", 2, form_data.form_slug, 1)
-          expect(response.body).to include(save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true, answer_id: 1))
+          expect(response.body).to include(save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true, answer_index: 1))
         end
       end
 
@@ -243,7 +243,7 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "Passes the changing answers parameter in its submit request" do
           get form_change_answer_path("form", 2, form_data.form_slug, 1)
-          expect(response.body).to include(save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true, answer_id: 1))
+          expect(response.body).to include(save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true, answer_index: 1))
         end
       end
 

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -131,11 +131,10 @@ RSpec.describe Forms::PageController, type: :request do
 
       context "with a page that has a previous page" do
         it "Displays a link to the previous page" do
-          allow_any_instance_of(Flow::Context).to receive(:can_visit?)
-                                              .and_return(true)
-          allow_any_instance_of(Flow::Context).to receive(:previous_step).and_return(1)
-          get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
-          expect(response.body).to include(form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
+          allow_any_instance_of(Flow::Context).to receive(:can_visit?).and_return(true)
+          allow_any_instance_of(Flow::Context).to receive(:previous_step).and_return(OpenStruct.new(page_id: 1))
+          get form_page_path("preview-draft", 2, form_data.form_slug, 2)
+          expect(response.body).to include(form_page_path(2, form_data.form_slug, 1))
         end
       end
 
@@ -231,7 +230,7 @@ RSpec.describe Forms::PageController, type: :request do
         it "Displays a link to the previous page" do
           allow_any_instance_of(Flow::Context).to receive(:can_visit?)
                                               .and_return(true)
-          allow_any_instance_of(Flow::Context).to receive(:previous_step).and_return(1)
+          allow_any_instance_of(Flow::Context).to receive(:previous_step).and_return(OpenStruct.new(page_id: 1))
           get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
           expect(response.body).to include(form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
         end

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -330,6 +330,20 @@ RSpec.describe Forms::PageController, type: :request do
         end
       end
     end
+
+    context "when page is repeatable" do
+      let(:first_page_in_form) { build :page, :with_repeatable, id: 1, next_page: second_page_in_form.id }
+
+      it "shows the page as normal when there are no stored answers" do
+        get form_page_path(mode: "form", form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, answer_index: 1)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns 404 when given an invalid answer_index" do
+        get form_page_path(mode: "form", form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, answer_index: 12)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe "#save" do
@@ -540,6 +554,20 @@ RSpec.describe Forms::PageController, type: :request do
       end
 
       # TODO: Need to add test to check how changing an existing routing answer value would work. Better off as a feature spec which we dont have.
+    end
+
+    context "when page is repeatable" do
+      let(:first_page_in_form) { build :page, :with_repeatable, id: 1, next_page: second_page_in_form.id }
+
+      it "redirects to the add another answer page when given valid answer" do
+        post save_form_page_path(mode: "form", form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, params: { question: { number: 12 } })
+        expect(response).to redirect_to(add_another_answer_path(mode: "form", form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id))
+      end
+
+      it "shows 404 if an invalid answer_index is given" do
+        post save_form_page_path(mode: "form", form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, answer_index: 3, params: { question: { number: 12 } })
+        expect(response).to have_http_status(:not_found)
+      end
     end
   end
 

--- a/spec/views/forms/add_another_answer/show.html.erb_spec.rb
+++ b/spec/views/forms/add_another_answer/show.html.erb_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+describe "forms/add_another_answer/show.html.erb" do
+  let(:form) { build :form, id: 1 }
+  let(:mode) { OpenStruct.new(preview_draft?: false, preview_archived?: false, preview_live?: false) }
+  let(:step) { OpenStruct.new({ form_id: 1, form_slug: "form-1", page_slug: "1", mode:, questions: [], question: OpenStruct.new({}) }) }
+  let(:add_another_answer_input) { AddAnotherAnswerInput.new }
+  let(:back_link) { "/back" }
+
+  let(:rows) { [{ key: { text: "Row 1" }, value: { text: "Value 1" } }] }
+
+  let(:form_path) { "form1/etc" }
+
+  before do
+    assign(:current_context, OpenStruct.new(form:))
+    assign(:mode, mode)
+    assign(:changeing_exsiting_answer, false)
+    assign(:rows, rows)
+    assign(:step, step)
+    assign(:back_link, back_link)
+    assign(:add_another_answer_input, add_another_answer_input)
+
+    without_partial_double_verification do
+      allow(view).to receive(:add_another_answer_path).and_return("/add_another_answer")
+    end
+
+    render
+  end
+
+  it "has a back link" do
+    expect(view.content_for(:back_link)).to have_link("Back", href: "/back")
+  end
+
+  context "when back link not preset" do
+    let(:back_link) { "" }
+
+    it "does not set back link" do
+      expect(view.content_for(:back_link)).to be_nil
+    end
+  end
+
+  it "has the correct heading" do
+    expect(rendered).to have_content("You have added one answer")
+  end
+
+  it "displays rows" do
+    expect(rendered).to have_content("Row 1")
+    expect(rendered).to have_content("Value 1")
+  end
+
+  context "when there are errors" do
+    before do
+      add_another_answer_input.errors.add(:base, "Error message")
+    end
+
+    it "renders the error summary" do
+      render
+      expect(rendered).to have_css(".govuk-error-summary")
+    end
+  end
+end


### PR DESCRIPTION
# Enable a single repeatable question to be created

Trello card: https://trello.com/c/3nMdZ3Pa/1676-13-implement-add-another-answer-in-forms-runner-for-single-question-only-13


There is a lot to consider in this branch and I'm trying to do it with minimal disruption/refactoring of the current code.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
