### PR TITLE
1718 stop form fillers from adding more than x answers

### DIFF
--- a/app/controllers/forms/add_another_answer_controller.rb
+++ b/app/controllers/forms/add_another_answer_controller.rb
@@ -9,7 +9,7 @@ module Forms
     end
 
     def save
-      @add_another_answer_input = AddAnotherAnswerInput.new(add_another_input_params)
+      @add_another_answer_input = AddAnotherAnswerInput.new(add_another_input_params.merge(max_answers: @step.max_answers?))
 
       if @add_another_answer_input.invalid?
         @rows = rows

--- a/app/input_objects/add_another_answer_input.rb
+++ b/app/input_objects/add_another_answer_input.rb
@@ -2,11 +2,12 @@ class AddAnotherAnswerInput
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  attr_accessor :add_another_answer
+  attr_accessor :add_another_answer, :max_answers
 
   RADIO_OPTIONS = { yes: "yes", no: "no" }.freeze
 
   validates :add_another_answer, presence: true, inclusion: { in: RADIO_OPTIONS.values }
+  validate :max_answers_reached, if: :add_another_answer?
 
   def add_another_answer?
     add_another_answer == RADIO_OPTIONS[:yes]
@@ -14,5 +15,11 @@ class AddAnotherAnswerInput
 
   def values
     RADIO_OPTIONS.keys
+  end
+
+private
+
+  def max_answers_reached
+    errors.add :add_another_answer, :max_answers_reached if max_answers
   end
 end

--- a/app/models/repeatable_step.rb
+++ b/app/models/repeatable_step.rb
@@ -5,6 +5,8 @@ class RepeatableStep < Step
 
   class AnswerIndexError < IndexError; end
 
+  MAX_ANSWERS = 10
+
   attr_accessor :answer_index, :questions
 
   def initialize(...)
@@ -51,6 +53,10 @@ class RepeatableStep < Step
 
   def next_answer_index
     questions.length + 1
+  end
+
+  def max_answers?
+    questions.length >= MAX_ANSWERS
   end
 
   def show_answer

--- a/app/views/forms/add_another_answer/show.html.erb
+++ b/app/views/forms/add_another_answer/show.html.erb
@@ -17,12 +17,20 @@
 
       <%= govuk_summary_list(classes: "add-another-answer", rows: @rows) %>
 
-      <%= f.govuk_collection_radio_buttons :add_another_answer,
-        @add_another_answer_input.values, ->(option) { option }, ->(option) { t('helpers.label.add_another_answer_input.options.' + "#{option}") },
-        legend: { text: t('.radios_legend'), size: 'm' },
-        inline: true %>
+      <% unless @step.max_answers? %>
+        <%= f.govuk_collection_radio_buttons :add_another_answer,
+          @add_another_answer_input.values, ->(option) { option }, ->(option) { t('helpers.label.add_another_answer_input.options.' + "#{option}") },
+          legend: { text: t('.radios_legend'), size: 'm' },
+          inline: true %>
 
-      <%= f.govuk_submit %>
+        <%= f.govuk_submit %>
+      <% else %>
+        <div class="govuk-inset-text">
+          <%= t('.max_answers', max_answers: RepeatableStep::MAX_ANSWERS) %>
+        </div>
+        <%= f.hidden_field :add_another_answer, value: "no" %>
+        <%= f.govuk_submit %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,7 @@ en:
           other: You have added %{count} answers
           zero: You have added no answers
         radios_legend: Do you need to add another answer?
+        max_answers: You cannot add another answer to this question as you've entered the maximum of %{max_answers}
     back: Back
   helpers:
     hint:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
           attributes:
             add_another_answer:
               blank: You must select an option
+              max_answers_reached: You cannot add another answer
         email_confirmation_input:
           attributes:
             confirmation_email_address:
@@ -123,8 +124,8 @@ en:
           one: You have added one answer
           other: You have added %{count} answers
           zero: You have added no answers
+        max_answers: You cannot add another answer to this question as you’ve entered the maximum of %{max_answers}
         radios_legend: Do you need to add another answer?
-        max_answers: You cannot add another answer to this question as you've entered the maximum of %{max_answers}
     back: Back
   helpers:
     hint:

--- a/spec/input_objects/add_another_answer_input_spec.rb
+++ b/spec/input_objects/add_another_answer_input_spec.rb
@@ -1,34 +1,33 @@
 require "rails_helper"
 
 RSpec.describe AddAnotherAnswerInput do
-  let(:valid_attributes) { { add_another_answer: "yes" } }
+  let(:input) { described_class.new({ add_another_answer: "yes", max_answers: false }) }
 
   describe "validations" do
     it "is valid with valid attributes" do
-      input = described_class.new(valid_attributes)
       expect(input).to be_valid
     end
 
     it "is not valid without an add_another_answer" do
-      input = described_class.new(add_another_answer: nil)
+      input.add_another_answer = nil
       expect(input).not_to be_valid
       expect(input.errors[:add_another_answer]).to include(I18n.t("activemodel.errors.models.add_another_answer_input.attributes.add_another_answer.blank"))
     end
 
     it "is not valid with an invalid add_another_answer" do
-      input = described_class.new(add_another_answer: "invalid")
+      input.add_another_answer = "invalid"
       expect(input).not_to be_valid
       expect(input.errors[:add_another_answer]).to include("is not included in the list")
     end
 
-    it 'is valid with "yes" as add_another_answer' do
-      input = described_class.new(add_another_answer: "yes")
+    it 'is valid with "no" as add_another_answer' do
+      input.add_another_answer = "no"
       expect(input).to be_valid
     end
 
-    it 'is valid with "no" as add_another_answer' do
-      input = described_class.new(add_another_answer: "no")
-      expect(input).to be_valid
+    it "is not valid when max_answers is true" do
+      input.max_answers = true
+      expect(input).not_to be_valid
     end
   end
 

--- a/spec/models/repeatable_step_spec.rb
+++ b/spec/models/repeatable_step_spec.rb
@@ -103,6 +103,26 @@ RSpec.describe RepeatableStep, type: :model do
     end
   end
 
+  describe "#max_answers?" do
+    before { repeatable_step.questions = questions }
+
+    context "with 9 or fewer questions" do
+      let(:questions) { [1, 2, 3, 4, 5, 6, 7, 8, 9] }
+
+      it "returns false" do
+        expect(repeatable_step.max_answers?).to be(false)
+      end
+    end
+
+    context "with 10 questions" do
+      let(:questions) { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] }
+
+      it "returns true" do
+        expect(repeatable_step.max_answers?).to be(true)
+      end
+    end
+  end
+
   describe "#show_answer" do
     let(:questions) { [first_question, second_question] }
     let(:first_question) { OpenStruct.new({ show_answer: "first answer" }) }

--- a/spec/requests/forms/add_another_answer_controller_spec.rb
+++ b/spec/requests/forms/add_another_answer_controller_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe Forms::AddAnotherAnswerController, type: :request do
         expect(assigns(:rows).count).to be_present
       end
     end
+
+    context "with the maximum number of answers" do
+      let(:stored_answers) { Array.new(RepeatableStep::MAX_ANSWERS) { |i| { text: i.to_s } } }
+
+      it "renders the show template with an error" do
+        post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "yes" } }
+        expect(response).to render_template(:show)
+        expect(response.body).to include("You cannot add another answer")
+      end
+    end
   end
 
   describe "redirect_if_not_repeating" do

--- a/spec/views/forms/add_another_answer/show.html.erb_spec.rb
+++ b/spec/views/forms/add_another_answer/show.html.erb_spec.rb
@@ -65,7 +65,7 @@ describe "forms/add_another_answer/show.html.erb" do
     let(:max_answers) { true }
 
     it "renders the max answers text" do
-      expect(rendered).to have_content("You cannot add another answer to this question as you've entered the maximum of 10")
+      expect(rendered).to have_content("You cannot add another answer to this question as you’ve entered the maximum of 10")
     end
   end
 end

--- a/spec/views/forms/add_another_answer/show.html.erb_spec.rb
+++ b/spec/views/forms/add_another_answer/show.html.erb_spec.rb
@@ -3,9 +3,11 @@ require "rails_helper"
 describe "forms/add_another_answer/show.html.erb" do
   let(:form) { build :form, id: 1 }
   let(:mode) { OpenStruct.new(preview_draft?: false, preview_archived?: false, preview_live?: false) }
-  let(:step) { OpenStruct.new({ form_id: 1, form_slug: "form-1", page_slug: "1", mode:, questions: [], question: OpenStruct.new({}) }) }
+  let(:step) { OpenStruct.new({ form_id: 1, form_slug: "form-1", page_slug: "1", mode:, questions:, question: OpenStruct.new({}), max_answers?: max_answers }) }
   let(:add_another_answer_input) { AddAnotherAnswerInput.new }
   let(:back_link) { "/back" }
+  let(:questions) { [] }
+  let(:max_answers) { false }
 
   let(:rows) { [{ key: { text: "Row 1" }, value: { text: "Value 1" } }] }
 
@@ -56,6 +58,14 @@ describe "forms/add_another_answer/show.html.erb" do
     it "renders the error summary" do
       render
       expect(rendered).to have_css(".govuk-error-summary")
+    end
+  end
+
+  context "when the maximum number of answers have been added" do
+    let(:max_answers) { true }
+
+    it "renders the max answers text" do
+      expect(rendered).to have_content("You cannot add another answer to this question as you've entered the maximum of 10")
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/qAJNULMm/1718-stop-form-fillers-from-adding-more-than-x-answers

When adding another answers, you should hit a limit that's set in `RepeatableStep::MAX_ANSWERS` now. This will alter the add_another_answer form so that it only submits with "no", thus continuing to the next question. 

This felt like the simplest way of getting users onto the next question, as it mimics them selecting 'no' to adding another answer, and removes the 'yes' option. 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
