### PR TITLE
Separate name fields in csv

### DIFF
--- a/app/models/question/name.rb
+++ b/app/models/question/name.rb
@@ -50,7 +50,11 @@ module Question
     end
 
     def show_answer_in_email
-      attribute_names.reject { |attribute| has_blank_values?(attribute) }.map { |attribute| generate_string_for_processing_email(attribute) }&.join("\n\n")
+      attributes_with_values.map { |attribute| generate_string_for_processing_email(attribute) }&.join("\n\n")
+    end
+
+    def show_answer_in_csv
+      attributes_with_values.to_h { |attribute| ["#{question_text} - #{friendly_name_for_attribute(attribute)}", send(attribute)] }
     end
 
     def has_blank_values?(attribute)
@@ -63,6 +67,12 @@ module Question
 
     def friendly_name_for_attribute(attribute)
       I18n.t("question/name.label.#{attribute}")
+    end
+
+  private
+
+    def attributes_with_values
+      attribute_names.reject { |attribute| has_blank_values?(attribute) }
     end
   end
 end

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -29,6 +29,12 @@ module Question
       show_answer
     end
 
+    def show_answer_in_csv
+      return {} if show_answer.blank?
+
+      Hash[question_text, show_answer]
+    end
+
     def is_optional?
       @is_optional == true
     end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -49,7 +49,7 @@ class Step
     question.errors.clear
   end
 
-  delegate :show_answer, :show_answer_in_email, :question_text, :hint_text, :answer_settings, to: :question
+  delegate :show_answer, :show_answer_in_email, :show_answer_in_csv, :question_text, :hint_text, :answer_settings, to: :question
 
   def end_page?
     next_page_slug.nil?

--- a/app/services/submission_csv_service.rb
+++ b/app/services/submission_csv_service.rb
@@ -13,8 +13,8 @@ class SubmissionCsvService
     headers = ["Reference", "Submitted at"]
     values = [@submission_reference, @timestamp.iso8601]
     @current_context.completed_steps.map do |page|
-      headers << page.question_text
-      values << page.show_answer
+      headers.push(*page.show_answer_in_csv.keys)
+      values.push(*page.show_answer_in_csv.values)
     end
 
     CSV.open(@output_file_path, "w") do |csv|

--- a/spec/models/question/address_spec.rb
+++ b/spec/models/question/address_spec.rb
@@ -3,12 +3,13 @@ require "rails_helper"
 RSpec.describe Question::Address, type: :model do
   subject(:question) { described_class.new({}, options) }
 
-  let(:options) { { is_optional:, answer_settings: } }
+  let(:options) { { is_optional:, answer_settings:, question_text: } }
   let(:answer_settings) { OpenStruct.new({ input_type: }) }
   let(:input_type) { OpenStruct.new({ international_address:, uk_address: }) }
   let(:is_optional) { false }
   let(:international_address) { "false" }
   let(:uk_address) { "true" }
+  let(:question_text) { Faker::Lorem.question }
 
   it_behaves_like "a question model"
 
@@ -32,6 +33,10 @@ RSpec.describe Question::Address, type: :model do
       it "returns \"\" for show_answer" do
         expect(question.show_answer).to eq ""
       end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
+      end
     end
 
     context "when an address has all mandatory fields filled" do
@@ -49,6 +54,10 @@ RSpec.describe Question::Address, type: :model do
 
       it "prints correct details" do
         expect(question.show_answer).to eq "The mews, Leeds, LS1 1AF"
+      end
+
+      it "returns the whole address as one item in show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "The mews, Leeds, LS1 1AF"])
       end
     end
 
@@ -94,6 +103,10 @@ RSpec.describe Question::Address, type: :model do
         it "returns \"\" for show_answer" do
           expect(question.show_answer).to eq ""
         end
+
+        it "returns an empty hash for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq({})
+        end
       end
 
       context "when an address has all mandatory fields filled" do
@@ -111,6 +124,10 @@ RSpec.describe Question::Address, type: :model do
 
         it "prints correct details" do
           expect(question.show_answer).to eq "The mews, Leeds, LS1 1AF"
+        end
+
+        it "returns the whole address as one item in show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq(Hash[question_text, "The mews, Leeds, LS1 1AF"])
         end
       end
 
@@ -145,6 +162,10 @@ RSpec.describe Question::Address, type: :model do
       it "returns \"\" for show_answer" do
         expect(question.show_answer).to eq ""
       end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
+      end
     end
 
     context "when an address has all mandatory fields filled" do
@@ -159,6 +180,10 @@ RSpec.describe Question::Address, type: :model do
 
       it "prints correct details" do
         expect(question.show_answer).to eq "Laskerstraße 5, 10245 Berlin, Germany"
+      end
+
+      it "returns the whole address as one item in show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "Laskerstraße 5, 10245 Berlin, Germany"])
       end
     end
 
@@ -188,6 +213,10 @@ RSpec.describe Question::Address, type: :model do
         it "returns \"\" for show_answer" do
           expect(question.show_answer).to eq ""
         end
+
+        it "returns an empty hash for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq({})
+        end
       end
 
       context "when an address has all mandatory fields filled" do
@@ -202,6 +231,10 @@ RSpec.describe Question::Address, type: :model do
 
         it "prints correct details" do
           expect(question.show_answer).to eq "Laskerstraße 5, 10245 Berlin, Germany"
+        end
+
+        it "returns the whole address as one item in show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq(Hash[question_text, "Laskerstraße 5, 10245 Berlin, Germany"])
         end
       end
     end

--- a/spec/models/question/date_spec.rb
+++ b/spec/models/question/date_spec.rb
@@ -3,7 +3,10 @@ require "rails_helper"
 RSpec.describe Question::Date, type: :model do
   subject(:question) { described_class.new({}, options) }
 
-  let(:options) { {} }
+  let(:options) { { is_optional:, question_text: } }
+
+  let(:is_optional) { false }
+  let(:question_text) { Faker::Lorem.question }
 
   it_behaves_like "a question model"
 
@@ -21,6 +24,10 @@ RSpec.describe Question::Date, type: :model do
 
     it "shows as a blank string" do
       expect(question.show_answer).to eq ""
+    end
+
+    it "returns an empty hash for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq({})
     end
   end
 
@@ -52,6 +59,10 @@ RSpec.describe Question::Date, type: :model do
     it "is valid" do
       expect(question).to be_valid
     end
+
+    it "returns the whole date as one item in show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, "31/12/2021"])
+    end
   end
 
   context "when a date has a day, month or year but it's not a real date" do
@@ -62,6 +73,10 @@ RSpec.describe Question::Date, type: :model do
     it "isn't valid" do
       expect(question).not_to be_valid
       expect(question.errors[:date]).to include(I18n.t("activemodel.errors.models.question/date.attributes.date.invalid_date"))
+    end
+
+    it "returns an empty hash for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq({})
     end
   end
 
@@ -151,7 +166,7 @@ RSpec.describe Question::Date, type: :model do
   end
 
   context "when question is optional" do
-    let(:options) { { is_optional: true } }
+    let(:is_optional) { true }
 
     it "returns valid with blank date" do
       expect(question).to be_valid
@@ -191,6 +206,10 @@ RSpec.describe Question::Date, type: :model do
 
       it "is valid" do
         expect(question).to be_valid
+      end
+
+      it "returns the whole date as one item in show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "31/12/2021"])
       end
     end
 

--- a/spec/models/question/email_spec.rb
+++ b/spec/models/question/email_spec.rb
@@ -1,7 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Question::Email, type: :model do
-  let(:question) { described_class.new }
+  subject(:question) { described_class.new({}, options) }
+
+  let(:options) { { is_optional:, question_text: } }
+
+  let(:is_optional) { false }
+  let(:question_text) { Faker::Lorem.question }
 
   it_behaves_like "a question model"
 
@@ -21,12 +26,27 @@ RSpec.describe Question::Email, type: :model do
     it "shows as a blank string" do
       expect(question.show_answer).to eq ""
     end
+
+    it "returns an empty hash for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq({})
+    end
   end
 
   context "when given a string with an @ symbol in" do
-    it "validates" do
+    before do
       question.email = " @ "
+    end
+
+    it "validates" do
       expect(question).to be_valid
+    end
+
+    it "is included in show_answer" do
+      expect(question.show_answer).to eq " @ "
+    end
+
+    it "returns the email address in show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, " @ "])
     end
   end
 
@@ -39,7 +59,7 @@ RSpec.describe Question::Email, type: :model do
   end
 
   context "when question is optional" do
-    let(:question) { described_class.new({}, { is_optional: true }) }
+    let(:is_optional) { true }
 
     it "returns valid with blank email" do
       expect(question).to be_valid
@@ -57,10 +77,25 @@ RSpec.describe Question::Email, type: :model do
       expect(question.show_answer).to eq ""
     end
 
+    it "returns an empty hash for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq({})
+    end
+
     context "when given a string with an @ symbol in" do
-      it "validates" do
+      before do
         question.email = " @ "
+      end
+
+      it "validates" do
         expect(question).to be_valid
+      end
+
+      it "is included in show_answer" do
+        expect(question.show_answer).to eq " @ "
+      end
+
+      it "returns the email address in show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, " @ "])
       end
     end
 

--- a/spec/models/question/name_spec.rb
+++ b/spec/models/question/name_spec.rb
@@ -3,10 +3,11 @@ require "rails_helper"
 RSpec.describe Question::Name, type: :model do
   subject(:question) { described_class.new({}, options) }
 
-  let(:options) { { is_optional:, answer_settings: } }
+  let(:options) { { is_optional:, answer_settings:, question_text: } }
   let(:answer_settings) { OpenStruct.new({ input_type:, title_needed: }) }
   let(:input_type) { "full_name" }
   let(:title_needed) { "false" }
+  let(:question_text) { "What is your name?" }
   let(:is_optional) { false }
 
   it_behaves_like "a question model"
@@ -26,6 +27,10 @@ RSpec.describe Question::Name, type: :model do
 
       it "returns \"\" for show_answer" do
         expect(question.show_answer).to eq ""
+      end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
       end
     end
 
@@ -47,6 +52,10 @@ RSpec.describe Question::Name, type: :model do
 
       it "returns the labelled individual parts in show_answer_for_email" do
         expect(question.show_answer_in_email).to eq("Full name: #{name}")
+      end
+
+      it "returns a hash with the full name for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({ "#{question_text} - Full name" => name })
       end
     end
   end
@@ -72,6 +81,10 @@ RSpec.describe Question::Name, type: :model do
       it "returns \"\" for show_answer" do
         expect(question.show_answer).to eq ""
       end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
+      end
     end
 
     context "when the question is optional" do
@@ -90,6 +103,10 @@ RSpec.describe Question::Name, type: :model do
         question.last_name = ""
         expect(question).not_to be_valid
         expect(question.errors[:last_name]).to include(I18n.t("activemodel.errors.models.question/name.attributes.last_name.blank"))
+      end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
       end
     end
 
@@ -116,6 +133,13 @@ RSpec.describe Question::Name, type: :model do
       it "returns the labelled individual parts in show_answer_for_email" do
         expect(question.show_answer_in_email).to eq("First name: #{first_name}\n\nLast name: #{last_name}")
       end
+
+      it "returns a hash with the first and last name for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({
+          "#{question_text} - First name" => first_name,
+          "#{question_text} - Last name" => last_name,
+        })
+      end
     end
   end
 
@@ -139,6 +163,10 @@ RSpec.describe Question::Name, type: :model do
 
       it "returns \"\" for show_answer" do
         expect(question.show_answer).to eq ""
+      end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
       end
     end
 
@@ -168,6 +196,14 @@ RSpec.describe Question::Name, type: :model do
       it "returns the labelled individual parts in show_answer_for_email" do
         expect(question.show_answer_in_email).to eq("First name: #{first_name}\n\nMiddle names: #{middle_name}\n\nLast name: #{last_name}")
       end
+
+      it "returns a hash with the first, middle and last name for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({
+          "#{question_text} - First name" => first_name,
+          "#{question_text} - Middle names" => middle_name,
+          "#{question_text} - Last name" => last_name,
+        })
+      end
     end
   end
 
@@ -194,6 +230,10 @@ RSpec.describe Question::Name, type: :model do
         it "returns the labelled individual parts in show_answer_for_email" do
           expect(question.show_answer_in_email).to eq("Full name: #{name}")
         end
+
+        it "returns a hash with the full name for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq({ "#{question_text} - Full name" => name })
+        end
       end
 
       context "when title is set" do
@@ -210,6 +250,13 @@ RSpec.describe Question::Name, type: :model do
 
         it "returns the labelled individual parts in show_answer_for_email" do
           expect(question.show_answer_in_email).to eq("Title: #{title}\n\nFull name: #{name}")
+        end
+
+        it "returns a hash with the full name and title for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq({
+            "#{question_text} - Full name" => name,
+            "#{question_text} - Title" => title,
+          })
         end
       end
     end
@@ -239,6 +286,13 @@ RSpec.describe Question::Name, type: :model do
         it "returns the labelled individual parts in show_answer_for_email" do
           expect(question.show_answer_in_email).to eq("First name: #{first_name}\n\nLast name: #{last_name}")
         end
+
+        it "returns a hash with the first and last name for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq({
+            "#{question_text} - First name" => first_name,
+            "#{question_text} - Last name" => last_name,
+          })
+        end
       end
 
       context "when title is set" do
@@ -256,6 +310,14 @@ RSpec.describe Question::Name, type: :model do
 
         it "returns the labelled individual parts in show_answer_for_email" do
           expect(question.show_answer_in_email).to eq("Title: #{title}\n\nFirst name: #{first_name}\n\nLast name: #{last_name}")
+        end
+
+        it "returns a hash with the first and last name for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq({
+            "#{question_text} - First name" => first_name,
+            "#{question_text} - Last name" => last_name,
+            "#{question_text} - Title" => title,
+          })
         end
       end
     end
@@ -287,6 +349,14 @@ RSpec.describe Question::Name, type: :model do
         it "returns the labelled individual parts in show_answer_for_email" do
           expect(question.show_answer_in_email).to eq("First name: #{first_name}\n\nMiddle names: #{middle_name}\n\nLast name: #{last_name}")
         end
+
+        it "returns a hash with the first, middle and last name for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq({
+            "#{question_text} - First name" => first_name,
+            "#{question_text} - Middle names" => middle_name,
+            "#{question_text} - Last name" => last_name,
+          })
+        end
       end
 
       context "when title is set" do
@@ -305,6 +375,15 @@ RSpec.describe Question::Name, type: :model do
 
         it "returns the labelled individual parts in show_answer_for_email" do
           expect(question.show_answer_in_email).to eq("Title: #{title}\n\nFirst name: #{first_name}\n\nMiddle names: #{middle_name}\n\nLast name: #{last_name}")
+        end
+
+        it "returns a hash with the first, middle and last name for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq({
+            "#{question_text} - First name" => first_name,
+            "#{question_text} - Middle names" => middle_name,
+            "#{question_text} - Last name" => last_name,
+            "#{question_text} - Title" => title,
+          })
         end
       end
     end

--- a/spec/models/question/national_insurance_number_spec.rb
+++ b/spec/models/question/national_insurance_number_spec.rb
@@ -1,7 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Question::NationalInsuranceNumber, type: :model do
-  let(:question) { described_class.new }
+  subject(:question) { described_class.new({}, options) }
+
+  let(:options) { { is_optional:, question_text: } }
+
+  let(:is_optional) { false }
+  let(:question_text) { Faker::Lorem.question }
 
   it_behaves_like "a question model"
 
@@ -20,6 +25,10 @@ RSpec.describe Question::NationalInsuranceNumber, type: :model do
     it "shows an answer if blank" do
       expect(question.show_answer).to eq ""
     end
+
+    it "returns an empty hash for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq({})
+    end
   end
 
   context "when given a correct number" do
@@ -33,6 +42,10 @@ RSpec.describe Question::NationalInsuranceNumber, type: :model do
 
     it "shows answer in correct format" do
       expect(question.show_answer).to eq "JG 12 34 56 C"
+    end
+
+    it "returns the answer in show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, "JG 12 34 56 C"])
     end
 
     it "ignores case" do
@@ -54,7 +67,7 @@ RSpec.describe Question::NationalInsuranceNumber, type: :model do
   end
 
   context "when question is optional" do
-    let(:question) { described_class.new({}, { is_optional: true }) }
+    let(:is_optional) { true }
 
     context "when given an empty string or nil" do
       it "returns invalid with blank ni number" do
@@ -71,6 +84,10 @@ RSpec.describe Question::NationalInsuranceNumber, type: :model do
       it "shows an answer if blank" do
         expect(question.show_answer).to eq ""
       end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
+      end
     end
 
     context "when given a correct number" do
@@ -84,6 +101,10 @@ RSpec.describe Question::NationalInsuranceNumber, type: :model do
 
       it "shows answer in correct format" do
         expect(question.show_answer).to eq "JG 12 34 56 C"
+      end
+
+      it "returns the answer in show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "JG 12 34 56 C"])
       end
 
       it "ignores case" do

--- a/spec/models/question/number_spec.rb
+++ b/spec/models/question/number_spec.rb
@@ -1,7 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Question::Number, type: :model do
-  let(:question) { described_class.new }
+  subject(:question) { described_class.new({}, options) }
+
+  let(:options) { { is_optional:, question_text: } }
+
+  let(:is_optional) { false }
+  let(:question_text) { Faker::Lorem.question }
 
   it_behaves_like "a question model"
 
@@ -20,19 +25,45 @@ RSpec.describe Question::Number, type: :model do
     it "shows as a blank string" do
       expect(question.show_answer).to eq ""
     end
+
+    it "returns an empty hash for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq({})
+    end
   end
 
   context "when given a whole number" do
-    it "validates without errors" do
+    before do
       question.number = "299792458"
+    end
+
+    it "validates without errors" do
       expect(question).to be_valid
+    end
+
+    it "shows the answer" do
+      expect(question.show_answer).to eq "299792458"
+    end
+
+    it "shows the answer in show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, "299792458"])
     end
   end
 
   context "when given a decimal number" do
-    it "validates without errors" do
+    before do
       question.number = "8.5"
+    end
+
+    it "validates without errors" do
       expect(question).to be_valid
+    end
+
+    it "shows the answer" do
+      expect(question.show_answer).to eq "8.5"
+    end
+
+    it "shows the answer in show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, "8.5"])
     end
   end
 
@@ -53,7 +84,7 @@ RSpec.describe Question::Number, type: :model do
   end
 
   context "when question is optional" do
-    let(:question) { described_class.new({}, { is_optional: true }) }
+    let(:is_optional) { true }
 
     context "when given an empty string or nil" do
       it "returns invalid with blank message" do
@@ -70,19 +101,45 @@ RSpec.describe Question::Number, type: :model do
       it "shows as a blank string" do
         expect(question.show_answer).to eq ""
       end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
+      end
     end
 
     context "when given a whole number" do
-      it "validates without errors" do
+      before do
         question.number = "299792458"
+      end
+
+      it "validates without errors" do
         expect(question).to be_valid
+      end
+
+      it "shows the answer" do
+        expect(question.show_answer).to eq "299792458"
+      end
+
+      it "shows the answer in show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "299792458"])
       end
     end
 
     context "when given a decimal number" do
-      it "validates without errors" do
+      before do
         question.number = "8.5"
+      end
+
+      it "validates without errors" do
         expect(question).to be_valid
+      end
+
+      it "shows the answer" do
+        expect(question.show_answer).to eq "8.5"
+      end
+
+      it "shows the answer in show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "8.5"])
       end
     end
 

--- a/spec/models/question/organisation_name_spec.rb
+++ b/spec/models/question/organisation_name_spec.rb
@@ -1,7 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Question::OrganisationName, type: :model do
-  let(:question) { described_class.new }
+  subject(:question) { described_class.new({}, options) }
+
+  let(:options) { { is_optional:, question_text: } }
+
+  let(:is_optional) { false }
+  let(:question_text) { Faker::Lorem.question }
 
   it_behaves_like "a question model"
 
@@ -20,17 +25,33 @@ RSpec.describe Question::OrganisationName, type: :model do
     it "shows as a blank string" do
       expect(question.show_answer).to eq ""
     end
+
+    it "returns an empty hash for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq({})
+    end
   end
 
   context "when given a short string" do
+    before do
+      question.text = "testing"
+    end
+
     it "validates without errors" do
       question.text = "testing"
       expect(question).to be_valid
     end
+
+    it "shows the answer" do
+      expect(question.show_answer).to eq("testing")
+    end
+
+    it "shows the answer in show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, "testing"])
+    end
   end
 
   context "when given a string which is too long" do
-    it "validates without errors" do
+    it "returns invalid with too long message" do
       question.text = "a" * 500
       expect(question).not_to be_valid
       expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/organisation_name.attributes.text.too_long"))
@@ -38,7 +59,7 @@ RSpec.describe Question::OrganisationName, type: :model do
   end
 
   context "when question is optional" do
-    let(:question) { described_class.new({}, { is_optional: true }) }
+    let(:is_optional) { true }
 
     context "when given an empty string or nil" do
       it "returns valid with blank message" do
@@ -55,12 +76,27 @@ RSpec.describe Question::OrganisationName, type: :model do
       it "shows as a blank string" do
         expect(question.show_answer).to eq ""
       end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
+      end
     end
 
     context "when given a short string" do
-      it "validates without errors" do
+      before do
         question.text = "testing"
+      end
+
+      it "validates without errors" do
         expect(question).to be_valid
+      end
+
+      it "shows the answer" do
+        expect(question.show_answer).to eq("testing")
+      end
+
+      it "shows the answer in show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "testing"])
       end
     end
 

--- a/spec/models/question/phone_number_spec.rb
+++ b/spec/models/question/phone_number_spec.rb
@@ -1,7 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Question::PhoneNumber, type: :model do
-  let(:question) { described_class.new }
+  subject(:question) { described_class.new({}, options) }
+
+  let(:options) { { is_optional:, question_text: } }
+
+  let(:is_optional) { false }
+  let(:question_text) { Faker::Lorem.question }
 
   let(:valid_phone_numbers) do
     [
@@ -46,6 +51,14 @@ RSpec.describe Question::PhoneNumber, type: :model do
       expect(question).not_to be_valid
       expect(question.errors[:phone_number]).to include(I18n.t("activemodel.errors.models.question/phone_number.attributes.phone_number.blank"))
     end
+
+    it "shows as a blank string" do
+      expect(question.show_answer).to eq ""
+    end
+
+    it "returns an empty hash for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq({})
+    end
   end
 
   context "when a phone number is valid" do
@@ -54,6 +67,16 @@ RSpec.describe Question::PhoneNumber, type: :model do
         question.phone_number = number
         expect(question).to be_valid
       end
+    end
+
+    it "shows the answer" do
+      question.phone_number = "07123123123"
+      expect(question.show_answer).to eq "07123123123"
+    end
+
+    it "shows the answer in show_answer_in_csv" do
+      question.phone_number = "07123123123"
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, "07123123123"])
     end
   end
 
@@ -76,7 +99,7 @@ RSpec.describe Question::PhoneNumber, type: :model do
   end
 
   context "when question is optional" do
-    let(:question) { described_class.new({}, { is_optional: true }) }
+    let(:is_optional) { true }
 
     context "when a phone number is empty or blank" do
       it "returns valid with blank phone number" do
@@ -89,6 +112,14 @@ RSpec.describe Question::PhoneNumber, type: :model do
         expect(question).to be_valid
         expect(question.errors[:phone_number]).not_to include(I18n.t("activemodel.errors.models.question/phone_number.attributes.phone_number.blank"))
       end
+
+      it "shows as a blank string" do
+        expect(question.show_answer).to eq ""
+      end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
+      end
     end
 
     context "when a phone number is valid" do
@@ -97,6 +128,16 @@ RSpec.describe Question::PhoneNumber, type: :model do
           question.phone_number = number
           expect(question).to be_valid
         end
+      end
+
+      it "shows the answer" do
+        question.phone_number = "07123123123"
+        expect(question.show_answer).to eq "07123123123"
+      end
+
+      it "shows the answer in show_answer_in_csv" do
+        question.phone_number = "07123123123"
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "07123123123"])
       end
     end
 

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -3,7 +3,17 @@ require "rails_helper"
 RSpec.describe Question::Selection, type: :model do
   subject(:question) { described_class.new({}, options) }
 
-  let(:options) { { is_optional:, answer_settings: OpenStruct.new({ only_one_option:, selection_options: [OpenStruct.new({ name: "option 1" }), OpenStruct.new({ name: "option 2" })] }) } }
+  let(:options) do
+    {
+      is_optional:,
+      answer_settings: OpenStruct.new({
+        only_one_option:,
+        selection_options: [OpenStruct.new({ name: "option 1" }), OpenStruct.new({ name: "option 2" })],
+      }),
+      question_text:,
+    }
+  end
+  let(:question_text) { Faker::Lorem.question }
 
   context "when the selection question is a checkbox" do
     let(:only_one_option) { "false" }
@@ -15,10 +25,37 @@ RSpec.describe Question::Selection, type: :model do
 
     it_behaves_like "a question model"
 
-    it "returns invalid with blank selection" do
-      question.selection = [""]
-      expect(question).not_to be_valid
-      expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.checkbox_blank"))
+    context "when selection is blank" do
+      before do
+        question.selection = [""]
+      end
+
+      it "returns invalid" do
+        expect(question).not_to be_valid
+        expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.checkbox_blank"))
+      end
+
+      it "shows as a blank string" do
+        expect(question.show_answer).to eq ""
+      end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
+      end
+    end
+
+    context "when selection has a value" do
+      before do
+        question.selection = %w[something]
+      end
+
+      it "shows the answer" do
+        expect(question.show_answer).to eq("something")
+      end
+
+      it "shows the answer in show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "something"])
+      end
     end
 
     it "returns invalid when selection is not one of the options" do
@@ -46,6 +83,25 @@ RSpec.describe Question::Selection, type: :model do
     context "when question is optional" do
       let(:is_optional) { true }
 
+      context "when selection is blank" do
+        before do
+          question.selection = [""]
+        end
+
+        it "returns invalid with blank selection" do
+          expect(question).not_to be_valid
+          expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.both_none_and_value_selected"))
+        end
+
+        it "shows as a blank string" do
+          expect(question.show_answer).to eq ""
+        end
+
+        it "returns an empty hash for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq({})
+        end
+      end
+
       it "returns valid with none of the above selected" do
         question.selection = [:none_of_the_above.to_s]
         expect(question).to be_valid
@@ -61,6 +117,20 @@ RSpec.describe Question::Selection, type: :model do
       it "does not include '(optional)' in the question text" do
         expect(question.question_text_with_optional_suffix).to eq(question.question_text)
       end
+
+      context "when selection has a value" do
+        before do
+          question.selection = %w[something]
+        end
+
+        it "shows the answer" do
+          expect(question.show_answer).to eq("something")
+        end
+
+        it "shows the answer in show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq(Hash[question_text, "something"])
+        end
+      end
     end
   end
 
@@ -74,10 +144,37 @@ RSpec.describe Question::Selection, type: :model do
 
     it_behaves_like "a question model"
 
-    it "returns invalid with blank selection" do
-      question.selection = ""
-      expect(question).not_to be_valid
-      expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.blank"))
+    context "when selection is blank" do
+      before do
+        question.selection = ""
+      end
+
+      it "returns invalid" do
+        expect(question).not_to be_valid
+        expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.blank"))
+      end
+
+      it "shows as a blank string" do
+        expect(question.show_answer).to eq ""
+      end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
+      end
+    end
+
+    context "when selection has a value" do
+      before do
+        question.selection = %w[something]
+      end
+
+      it "shows the answer" do
+        expect(question.show_answer).to eq(%w[something])
+      end
+
+      it "shows the answer in show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, %w[something]])
+      end
     end
 
     it "returns invalid when selection is not one of the options" do
@@ -103,6 +200,39 @@ RSpec.describe Question::Selection, type: :model do
         question.selection = :none_of_the_above.to_s
         expect(question).to be_valid
         expect(question.errors[:selection]).to be_empty
+      end
+
+      context "when selection is blank" do
+        before do
+          question.selection = ""
+        end
+
+        it "returns invalid" do
+          expect(question).not_to be_valid
+          expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.blank"))
+        end
+
+        it "shows as a blank string" do
+          expect(question.show_answer).to eq ""
+        end
+
+        it "returns an empty hash for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq({})
+        end
+      end
+
+      context "when selection has a value" do
+        before do
+          question.selection = %w[something]
+        end
+
+        it "shows the answer" do
+          expect(question.show_answer).to eq(%w[something])
+        end
+
+        it "shows the answer in show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq(Hash[question_text, %w[something]])
+        end
       end
     end
   end

--- a/spec/models/question/text_spec.rb
+++ b/spec/models/question/text_spec.rb
@@ -3,24 +3,50 @@ require "rails_helper"
 RSpec.describe Question::Text, type: :model do
   subject(:question) { described_class.new({}, options) }
 
-  let(:options) { { is_optional:, answer_settings: OpenStruct.new(input_type:) } }
+  let(:options) { { is_optional:, answer_settings: OpenStruct.new(input_type:), question_text: } }
 
   let(:is_optional) { false }
+
+  let(:question_text) { Faker::Lorem.question }
 
   context "with input type set to single_line" do
     let(:input_type) { "single_line" }
 
     it_behaves_like "a question model"
 
-    it "returns invalid with nil text" do
-      expect(question).not_to be_valid
-      expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/text.attributes.text.blank"))
+    context "when text is blank" do
+      it "returns invalid with nil text" do
+        expect(question).not_to be_valid
+        expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/text.attributes.text.blank"))
+      end
+
+      it "returns invalid with blank text" do
+        question.text = ""
+        expect(question).not_to be_valid
+        expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/text.attributes.text.blank"))
+      end
+
+      it "shows as a blank string" do
+        expect(question.show_answer).to eq ""
+      end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
+      end
     end
 
-    it "returns invalid with blank text" do
-      question.text = ""
-      expect(question).not_to be_valid
-      expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/text.attributes.text.blank"))
+    context "when text has a value" do
+      before do
+        question.text = "some text"
+      end
+
+      it "shows the answer" do
+        expect(question.show_answer).to eq("some text")
+      end
+
+      it "shows the answer in show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "some text"])
+      end
     end
 
     it "returns invalid with text length over 499 characters" do
@@ -40,6 +66,41 @@ RSpec.describe Question::Text, type: :model do
     let(:input_type) { "long_text" }
 
     it_behaves_like "a question model"
+
+    context "when text is blank" do
+      it "returns invalid with nil text" do
+        expect(question).not_to be_valid
+        expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/text.attributes.text.blank"))
+      end
+
+      it "returns invalid with blank text" do
+        question.text = ""
+        expect(question).not_to be_valid
+        expect(question.errors[:text]).to include(I18n.t("activemodel.errors.models.question/text.attributes.text.blank"))
+      end
+
+      it "shows as a blank string" do
+        expect(question.show_answer).to eq ""
+      end
+
+      it "returns an empty hash for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({})
+      end
+    end
+
+    context "when text has a value" do
+      before do
+        question.text = "some text"
+      end
+
+      it "shows the answer" do
+        expect(question.show_answer).to eq("some text")
+      end
+
+      it "shows the answer in show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "some text"])
+      end
+    end
 
     it "returns invalid with text length over 5000 characters" do
       question.text = "a" * 5000

--- a/spec/services/submission_csv_service_spec.rb
+++ b/spec/services/submission_csv_service_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe SubmissionCsvService do
   subject(:service) { described_class.new(current_context:, submission_reference:, timestamp:, output_file_path: test_file.path) }
 
   let(:form) { build(:form, id: 1) }
-  let(:first_step) { OpenStruct.new({ question_text: "What is the meaning of life?", show_answer: "42" }) }
-  let(:second_step) { OpenStruct.new({ question_text: "What is your email address?", show_answer: "someone@example.com" }) }
+  let(:first_step) { OpenStruct.new({ show_answer_in_csv: { "What is the meaning of life?": "42" } }) }
+  let(:second_step) { OpenStruct.new({ show_answer_in_csv: { "What is your email address?": "someone@example.com" } }) }
   let(:current_context) { OpenStruct.new(form:, completed_steps: [first_step, second_step], support_details: OpenStruct.new(call_back_url: "http://gov.uk")) }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
   let(:timestamp) do

--- a/spec/support/shared_examples/question_models.rb
+++ b/spec/support/shared_examples/question_models.rb
@@ -7,6 +7,10 @@ RSpec.shared_examples "a question model" do |_parameter|
     expect(question.show_answer_in_email).to be_a(String)
   end
 
+  it "responds with a hash to .show_answer_in_csv" do
+    expect(question.show_answer_in_csv).to be_a(Hash)
+  end
+
   it "responds serializable_hash with a hash" do
     expect(question.serializable_hash).to be_a(Hash)
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/PhJ9djZ7/1732-tweak-csv-output-so-the-name-fields-are-separated-as-expected

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Separates out the name field into separate columns in thge CSV output. To do this it adds a new method `show_answer_in_csv` to the question model. This returns a hash with one key/value pair per column. 

Touches quite a few files but most of those are adding tests.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
