### PR TITLE
Add space to some phone numbers in CSV output

### DIFF
--- a/app/models/question/phone_number.rb
+++ b/app/models/question/phone_number.rb
@@ -13,6 +13,15 @@ module Question
     validate :phone_number, :not_enough_digits?
     validate :phone_number, :too_many_digits?
 
+    def show_answer_in_csv
+      return {} if phone_number.blank?
+      # numbers containing non-numeric characters, or starting with a non-0 digit, shouldn't need additional processing
+      return { question_text => phone_number } unless phone_number.match(/^0\d*$/)
+
+      # insert a space after the first 5 digits to force Excel to parse the phone number as a string
+      { question_text => phone_number.gsub(/(^\d{5})(\d*)$/, "\\1 \\2") }
+    end
+
   private
 
     def not_enough_digits?

--- a/spec/models/question/phone_number_spec.rb
+++ b/spec/models/question/phone_number_spec.rb
@@ -8,13 +8,21 @@ RSpec.describe Question::PhoneNumber, type: :model do
   let(:is_optional) { false }
   let(:question_text) { Faker::Lorem.question }
 
-  let(:valid_phone_numbers) do
+  let(:valid_numeric_phone_numbers) do
+    %w[
+      07123123123
+      457123123123
+      07123123
+      071231231231231
+    ]
+  end
+
+  let(:valid_non_numeric_phone_numbers) do
     [
       "+447123 123 123",
       "+407123 123 123",
       "+1 7123 123 123",
       "+447123123123",
-      "07123123123",
       "01234 123 123 --()+ ",
       "01234 123 123 ext 123",
       "01234 123 123 x123",
@@ -36,6 +44,10 @@ RSpec.describe Question::PhoneNumber, type: :model do
       "1234 123 1234  ext 123",
       "+44(0)123 12 12345",
     ]
+  end
+
+  let(:valid_phone_numbers) do
+    valid_numeric_phone_numbers.concat(valid_non_numeric_phone_numbers)
   end
 
   it_behaves_like "a question model"
@@ -74,9 +86,34 @@ RSpec.describe Question::PhoneNumber, type: :model do
       expect(question.show_answer).to eq "07123123123"
     end
 
-    it "shows the answer in show_answer_in_csv" do
-      question.phone_number = "07123123123"
-      expect(question.show_answer_in_csv).to eq(Hash[question_text, "07123123123"])
+    context "when the phone number has only numeric characters and begins with 0" do
+      it "show_answer_in_csv adds a space after the 5th digit" do
+        question.phone_number = "07123123123"
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "07123 123123"])
+      end
+    end
+
+    context "when the phone number has only numeric characters and does not begin with 0" do
+      it "show_answer_in_csv adds a space after the 5th digit" do
+        question.phone_number = "457123123123"
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "457123123123"])
+      end
+    end
+
+    context "when the phone number already has a space before the 5th digit" do
+      it "show_answer_in_csv does not add an extra space" do
+        question.phone_number = "0712 3123123"
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, "0712 3123123"])
+      end
+    end
+
+    context "when the phone number has at least one non-numeric character" do
+      it "show_answer_in_csv returns the number as it was entered" do
+        valid_non_numeric_phone_numbers.each do |phone_number|
+          question.phone_number = phone_number
+          expect(question.show_answer_in_csv).to eq(Hash[question_text, phone_number])
+        end
+      end
     end
   end
 
@@ -135,9 +172,34 @@ RSpec.describe Question::PhoneNumber, type: :model do
         expect(question.show_answer).to eq "07123123123"
       end
 
-      it "shows the answer in show_answer_in_csv" do
-        question.phone_number = "07123123123"
-        expect(question.show_answer_in_csv).to eq(Hash[question_text, "07123123123"])
+      context "when the phone number has only numeric characters and begins with 0" do
+        it "show_answer_in_csv adds a space after the 5th digit" do
+          question.phone_number = "07123123123"
+          expect(question.show_answer_in_csv).to eq(Hash[question_text, "07123 123123"])
+        end
+      end
+
+      context "when the phone number has only numeric characters and does not begin with 0" do
+        it "show_answer_in_csv adds a space after the 5th digit" do
+          question.phone_number = "457123123123"
+          expect(question.show_answer_in_csv).to eq(Hash[question_text, "457123123123"])
+        end
+      end
+
+      context "when the phone number already has a space before the 5th digit" do
+        it "show_answer_in_csv does not add an extra space" do
+          question.phone_number = "0712 3123123"
+          expect(question.show_answer_in_csv).to eq(Hash[question_text, "0712 3123123"])
+        end
+      end
+
+      context "when the phone number has at least one non-numeric character" do
+        it "show_answer_in_csv returns the number as it was entered" do
+          valid_non_numeric_phone_numbers.each do |phone_number|
+            question.phone_number = phone_number
+            expect(question.show_answer_in_csv).to eq(Hash[question_text, phone_number])
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/PoAbnOwy/1730-make-phone-number-show-correctly-in-csv-file

Adds logic to tweak the CSV output for phone numbers. This is to work around the default Excel behaviour, which is to interpret purely numeric phone numbers as numbers rather than strings when opening the CSV fileand format them without any leading zeroes at the beginning.

The CSV will now display the number with a space after the 5th digit for any numbers which are:
- entirely numeric (i.e. don't have any spaces, extensions or '+' characters), and
- begin with a zero

This will force Excel to interpret the numbers as strings, which will preserve their formatting.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
