### PR TITLE
Limit Notify attachment filename to 100 characters

### DIFF
--- a/app/mailers/form_submission_mailer.rb
+++ b/app/mailers/form_submission_mailer.rb
@@ -1,4 +1,8 @@
 class FormSubmissionMailer < GovukNotifyRails::Mailer
+  NOTIFY_MAX_FILENAME_LENGTH = 100
+  CSV_EXTENSION = ".csv".freeze
+  CSV_FILENAME_PREFIX = "govuk_forms_".freeze
+
   def email_confirmation_input(text_input:, notify_response_id:, submission_email:, mailer_options:, csv_file: nil)
     set_template(Settings.govuk_notify.form_submission_email_template_id)
 
@@ -36,8 +40,13 @@ private
   end
 
   def csv_filename(mailer_options)
-    title_part = mailer_options.title.parameterize(separator: "_")
-    reference = mailer_options.submission_reference
-    "govuk_forms_submission_#{title_part}_#{reference}.csv"
+    reference_part = "_#{mailer_options.submission_reference}"
+
+    title_part_max_length = NOTIFY_MAX_FILENAME_LENGTH - CSV_EXTENSION.length - CSV_FILENAME_PREFIX.length - reference_part.length
+
+    title_part = mailer_options.title
+                               .parameterize(separator: "_")
+                               .truncate(title_part_max_length, separator: "_", omission: "")
+    "#{CSV_FILENAME_PREFIX}#{title_part}#{reference_part}#{CSV_EXTENSION}"
   end
 end

--- a/spec/mailers/form_submission_mailer_spec.rb
+++ b/spec/mailers/form_submission_mailer_spec.rb
@@ -80,7 +80,27 @@ describe FormSubmissionMailer, type: :mailer do
 
       it "calls Notify library to prepare the file upload" do
         mail.message
-        expect(Notifications).to have_received(:prepare_upload).with(test_file, filename: "govuk_forms_submission_form_1_#{submission_reference}.csv", retention_period: "1 week")
+        expect(Notifications).to have_received(:prepare_upload).with(test_file, filename: "govuk_forms_form_1_#{submission_reference}.csv", retention_period: "1 week")
+      end
+
+      context "when there is a long form name that would cause the filename to be longer than 100 characters" do
+        let(:title) { "A form name that will cause the filename to be truncated to obey the limittt" }
+
+        it "truncates the form name in the filename" do
+          mail.message
+          expected_filename = "govuk_forms_a_form_name_that_will_cause_the_filename_to_be_truncated_to_obey_the_#{submission_reference}.csv"
+          expect(Notifications).to have_received(:prepare_upload).with(test_file, filename: expected_filename, retention_period: "1 week")
+        end
+      end
+
+      context "when the form name would cause the filename to be exactly 100 characters long" do
+        let(:title) { "A form name that will cause the filename to be 100 characters long exactlyy" }
+
+        it "does not truncate the form name in the filename" do
+          mail.message
+          expected_filename = "govuk_forms_a_form_name_that_will_cause_the_filename_to_be_100_characters_long_exactlyy_#{submission_reference}.csv"
+          expect(Notifications).to have_received(:prepare_upload).with(test_file, filename: expected_filename, retention_period: "1 week")
+        end
       end
 
       it "includes the link_to_file in the personalisation" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

Notify has a limit of 100 characters for filenames for files attached to emails. We include the form name in the filename, which caused an exception to be thrown for long form names that would cause the filename length to exceed 100 characters.

Truncate the filename so it will be less than or equal to 100 characters. Truncate the filename at the last full word in the form name rather than partway through a word.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
