### PR TITLE
Retry sending submission email without file upon error

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,8 +33,7 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,9 +65,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/myozrQtS/1743-bug-notify-error-due-to-csv-filename-exceeding-100-characters

When the NotificationClient raises a `Notifications::Client::BadRequestError` upon attempting to deliver the submission email when a CSV file is attached, try the request again without the CSV file attached.

The intention of this is to allow submissions to go through if there is an unexpected error with the CSV file attachment. This could be due to the file failing a virus scan, or another unanticipated issue with the file we have attached.

Send the exception to Sentry and log at error level when this happens, as we want to be notified if we fail to attach the CSV file.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
