### PR TITLE
Update check your answers page and next page logic to handle optional repeatable questions

### DIFF
--- a/app/controllers/forms/add_another_answer_controller.rb
+++ b/app/controllers/forms/add_another_answer_controller.rb
@@ -44,7 +44,7 @@ module Forms
       end
     end
 
-    def repeating?
+    def should_show_add_another?(_step)
       false
     end
 

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -50,7 +50,7 @@ module Forms
   private
 
     def page_to_row(page)
-      change_link = if page.repeatable?
+      change_link = if page.repeatable? && page.show_answer.present?
                       change_add_another_answer_path(page.form_id, page.form_slug, page.page_id)
                     else
                       form_change_answer_path(page.form_id, page.form_slug, page.page_id)

--- a/app/lib/flow/context.rb
+++ b/app/lib/flow/context.rb
@@ -43,6 +43,12 @@ module Flow
       completed_steps.last&.next_page_slug_after_routing || @step_factory.start_step.page_slug
     end
 
+    def next_step
+      return nil if completed_steps.last&.end_page?
+
+      find_or_create(completed_steps.last&.next_page_slug_after_routing) || @step_factory.start_step
+    end
+
     def can_visit?(page_slug)
       (completed_steps.map(&:page_slug).include? page_slug) || page_slug == next_page_slug
     end

--- a/app/models/repeatable_step.rb
+++ b/app/models/repeatable_step.rb
@@ -60,11 +60,13 @@ class RepeatableStep < Step
   end
 
   def show_answer
-    if questions.present?
+    answers = questions.map(&:show_answer).compact_blank
+
+    if answers.present?
       content_tag(:ol, class: "govuk-list govuk-list--number") do
         safe_join(
-          questions.map do |question|
-            content_tag(:li, sanitize(question.show_answer))
+          answers.map do |answer|
+            content_tag(:li, sanitize(answer))
           end,
         )
       end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -73,4 +73,8 @@ class Step
   def repeatable?
     false
   end
+
+  def skipped?
+    question.is_optional? && question.show_answer.blank?
+  end
 end

--- a/spec/models/repeatable_step_spec.rb
+++ b/spec/models/repeatable_step_spec.rb
@@ -133,6 +133,14 @@ RSpec.describe RepeatableStep, type: :model do
     it "returns an ordered list of answers" do
       expect(repeatable_step.show_answer).to eq('<ol class="govuk-list govuk-list--number"><li>first answer</li><li>second answer</li></ol>')
     end
+
+    context "when the question is optional and has been skipped" do
+      let(:questions) { [OpenStruct.new({ show_answer: "" })] }
+
+      it "returns blank" do
+        expect(repeatable_step.show_answer).to be_blank
+      end
+    end
   end
 
   describe "#show_answer_in_email" do

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           get check_your_answers_path(mode: "form", form_id: 2, form_slug: form_data.form_slug)
         end
 
-        it "returns returns 'ok' status code" do
+        it "returns 'ok' status code" do
           expect(response).to have_http_status(:ok)
         end
 

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -137,6 +137,25 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       end
     end
 
+    shared_examples "check your answers page" do
+      it "returns 'ok' status code" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "Displays a back link to the last page of the form" do
+        expect(response.body).to include(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
+      end
+
+      it "Returns the correct X-Robots-Tag header" do
+        expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
+      end
+
+      it "Contains a change link for each page" do
+        expect(response.body).to include(form_change_answer_path(2, form_data.form_slug, 1))
+        expect(response.body).to include(form_change_answer_path(2, form_data.form_slug, 2))
+      end
+    end
+
     context "with preview mode on" do
       let(:api_url_suffix) { "/draft" }
       let(:mode) { "preview-draft" }
@@ -149,22 +168,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           get check_your_answers_path(mode:, form_id: 2, form_slug: form_data.form_slug)
         end
 
-        it "returns 'ok' status code" do
-          expect(response).to have_http_status(:ok)
-        end
-
-        it "Displays a back link to the last page of the form" do
-          expect(response.body).to include(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
-        end
-
-        it "Returns the correct X-Robots-Tag header" do
-          expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
-        end
-
-        it "Contains a change link for each page" do
-          expect(response.body).to include(form_change_answer_path(2, form_data.form_slug, 1))
-          expect(response.body).to include(form_change_answer_path(2, form_data.form_slug, 2))
-        end
+        it_behaves_like "check your answers page"
 
         it "does not log the form_check_answers event" do
           expect(EventLogger).not_to have_received(:log)
@@ -197,22 +201,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           get check_your_answers_path(mode:, form_id: 2, form_slug: form_data.form_slug)
         end
 
-        it "returns 'ok' status code" do
-          expect(response).to have_http_status(:ok)
-        end
-
-        it "Displays a back link to the last page of the form" do
-          expect(response.body).to include(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
-        end
-
-        it "Returns the correct X-Robots-Tag header" do
-          expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
-        end
-
-        it "Contains a change link for each page" do
-          expect(response.body).to include(form_change_answer_path(2, form_data.form_slug, 1))
-          expect(response.body).to include(form_change_answer_path(2, form_data.form_slug, 2))
-        end
+        it_behaves_like "check your answers page"
 
         it "Logs the form_check_answers event" do
           expect(EventLogger).to have_received(:log_form_event).with("check_answers")

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -196,9 +196,6 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
       context "with all questions answered and valid" do
         before do
-          post save_form_page_path(mode: "form", form_id: 2, form_slug: "form-1", page_slug: 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-          post save_form_page_path(mode: "form", form_id: 2, form_slug: "form-1", page_slug: 2), params: { question: { text: "answer text" }, changing_existing_answer: false }
-
           allow(EventLogger).to receive(:log_form_event).at_least(:once)
 
           get check_your_answers_path(mode: "form", form_id: 2, form_slug: form_data.form_slug)

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -154,6 +154,68 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(response.body).to include(form_change_answer_path(2, form_data.form_slug, 1))
         expect(response.body).to include(form_change_answer_path(2, form_data.form_slug, 2))
       end
+
+      context "when the form has a question that can be answered more than once" do
+        let(:pages_data) do
+          [
+            {
+              id: 1,
+              position: 1,
+              question_text: "Question one",
+              answer_type: "date",
+              next_page: 2,
+              is_optional: nil,
+            },
+            {
+              id: 2,
+              position: 2,
+              question_text: "Question two",
+              answer_type: "date",
+              next_page: 3,
+              is_optional: nil,
+            },
+            {
+              id: 3,
+              position: 3,
+              question_text: "Question three",
+              answer_type: "date",
+              is_optional: nil,
+              is_repeatable: true,
+            },
+          ]
+        end
+
+        let(:store) do
+          {
+            answers: {
+              "2" => {
+                "1" => {
+                  "date_year" => "2000",
+                  "date_month" => "1",
+                  "date_day" => "1",
+                },
+                "2" => {
+                  "date_year" => "2023",
+                  "date_month" => "6",
+                  "date_day" => "9",
+                },
+                "3" => [
+                  {
+                    "date_year" => "2024",
+                    "date_month" => "9",
+                    "date_day" => "6",
+                  },
+                ],
+              },
+            },
+          }
+        end
+
+        it "contains a change link to the add another answer page" do
+          expect(response.body)
+            .to include(change_add_another_answer_path(2, form_data.form_slug, 3))
+        end
+      end
     end
 
     context "with preview mode on" do

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -215,6 +215,68 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           expect(response.body)
             .to include(change_add_another_answer_path(2, form_data.form_slug, 3))
         end
+
+        context "and that question is optional and has been skipped" do
+          let(:pages_data) do
+            [
+              {
+                id: 1,
+                position: 1,
+                question_text: "Question one",
+                answer_type: "date",
+                next_page: 2,
+                is_optional: nil,
+              },
+              {
+                id: 2,
+                position: 2,
+                question_text: "Question two",
+                answer_type: "date",
+                next_page: 3,
+                is_optional: nil,
+              },
+              {
+                id: 3,
+                position: 3,
+                question_text: "Question three",
+                answer_type: "date",
+                is_optional: true,
+                is_repeatable: true,
+              },
+            ]
+          end
+
+          let(:store) do
+            {
+              answers: {
+                "2" => {
+                  "1" => {
+                    "date_year" => "2000",
+                    "date_month" => "1",
+                    "date_day" => "1",
+                  },
+                  "2" => {
+                    "date_year" => "2023",
+                    "date_month" => "6",
+                    "date_day" => "9",
+                  },
+                  "3" => [
+                    {
+                      "date_year" => "",
+                      "date_month" => "",
+                      "date_day" => "",
+                    },
+                  ],
+                },
+              },
+            }
+          end
+
+          it "shows the question as not completed" do
+            expect(response.body)
+              .to include "Not completed"
+          end
+        end
       end
     end
 

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -121,10 +121,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       end
     end
 
-    context "with preview mode on" do
-      let(:api_url_suffix) { "/draft" }
-      let(:mode) { "preview-draft" }
-
+    shared_examples "for redirecting if the form is incomplete" do
       context "without any questions answered" do
         let(:store) do
           {
@@ -138,6 +135,13 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           expect(response.location).to eq(form_page_url(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
         end
       end
+    end
+
+    context "with preview mode on" do
+      let(:api_url_suffix) { "/draft" }
+      let(:mode) { "preview-draft" }
+
+      include_examples "for redirecting if the form is incomplete"
 
       context "with all questions answered and valid" do
         before do
@@ -185,19 +189,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       let(:api_url_suffix) { "/live" }
       let(:mode) { "form" }
 
-      context "without any questions answered" do
-        let(:store) do
-          {
-            answers: {},
-          }
-        end
-
-        it "redirects to first incomplete page of form" do
-          get check_your_answers_path(mode:, form_id: 2, form_slug: form_data.form_slug)
-          expect(response).to have_http_status(:found)
-          expect(response.location).to eq(form_page_url(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
-        end
-      end
+      include_examples "for redirecting if the form is incomplete"
 
       context "with all questions answered and valid" do
         before do

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -276,6 +276,11 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
             expect(response.body)
               .to include "Not completed"
           end
+
+          it "contains a change link to the question page" do
+            expect(response.body)
+              .to include(form_change_answer_path(2, form_data.form_slug, 3))
+          end
         end
       end
     end

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -383,7 +383,7 @@ RSpec.describe Forms::PageController, type: :request do
       end
 
       context "with the first page" do
-        it "Logs the first_page_save event" do
+        it "does not log the first_page_save event" do
           expect(EventLogger).not_to receive(:log)
           post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" } }
         end
@@ -395,7 +395,7 @@ RSpec.describe Forms::PageController, type: :request do
       end
 
       context "with a subsequent page" do
-        it "Logs the page_save event" do
+        it "does not log the page_save event" do
           expect(EventLogger).not_to receive(:log)
           post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
         end

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -96,6 +96,13 @@ RSpec.describe Forms::PageController, type: :request do
     end
   end
 
+  shared_examples "ordered steps" do
+    it "redirects to first page if second request before first complete" do
+      get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
+      expect(response).to redirect_to(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
+    end
+  end
+
   shared_examples "page with footer" do
     it "Displays the privacy policy link on the page" do
       get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
@@ -123,10 +130,7 @@ RSpec.describe Forms::PageController, type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      it "redirects to first page if second request before first complete" do
-        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
-        expect(response).to redirect_to(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
-      end
+      it_behaves_like "ordered steps"
 
       it "Displays the question text on the page" do
         get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
@@ -209,10 +213,7 @@ RSpec.describe Forms::PageController, type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      it "redirects to first page if second request before first complete" do
-        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
-        expect(response).to redirect_to(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
-      end
+      it_behaves_like "ordered steps"
 
       it "Displays the question text on the page" do
         get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -314,6 +314,21 @@ RSpec.describe Forms::PageController, type: :request do
       allow_any_instance_of(Flow::Context).to receive(:clear_submission_details)
     end
 
+    shared_examples "for validating answer" do
+      context "when the form is invalid" do
+        before do
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "" }, changing_existing_answer: false }
+        end
+
+        it "renders the show page template" do
+          expect(response).to render_template("forms/page/show")
+        end
+
+        it "returns 422" do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
 
     shared_examples "for redirecting after saving answer" do
       it "Redirects to the next page" do
@@ -340,6 +355,7 @@ RSpec.describe Forms::PageController, type: :request do
       let(:api_url_suffix) { "/draft" }
       let(:mode) { "preview-draft" }
 
+      include_examples "for validating answer"
       include_examples "for redirecting after saving answer"
 
       context "when changing an existing answer" do
@@ -383,26 +399,13 @@ RSpec.describe Forms::PageController, type: :request do
           expect(response).not_to have_http_status(:not_found)
         end
       end
-
-      context "when the form is invalid" do
-        before do
-          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "" }, changing_existing_answer: false }
-        end
-
-        it "renders the show page template" do
-          expect(response).to render_template("forms/page/show")
-        end
-
-        it "returns 422" do
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
-      end
     end
 
     context "with preview mode off" do
       let(:api_url_suffix) { "/live" }
       let(:mode) { "form" }
 
+      include_examples "for validating answer"
       include_examples "for redirecting after saving answer"
 
       context "when changing an existing answer" do
@@ -441,20 +444,6 @@ RSpec.describe Forms::PageController, type: :request do
             expect(EventLogger).to receive(:log_page_event).with("optional_save", second_page_in_form.question_text, false)
             post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
           end
-        end
-      end
-
-      context "when the form is invalid" do
-        before do
-          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "" }, changing_existing_answer: false }
-        end
-
-        it "renders the show page template" do
-          expect(response).to render_template("forms/page/show")
-        end
-
-        it "returns 422" do
-          expect(response).to have_http_status(:unprocessable_entity)
         end
       end
     end

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Forms::PageController, type: :request do
   end
 
   let(:api_url_suffix) { "/live" }
+  let(:mode) { "form" }
 
   let(:output) { StringIO.new }
   let(:logger) { ActiveSupport::Logger.new(output) }
@@ -83,7 +84,7 @@ RSpec.describe Forms::PageController, type: :request do
         mock.get "/api/v1/forms/200#{api_url_suffix}", req_headers, form_data.to_json, 200
       end
 
-      get form_page_path("form", 200, form_data.form_slug, page_id)
+      get form_page_path(200, form_data.form_slug, page_id, mode:)
     end
 
     it "adds the page ID to the instrumentation payload" do
@@ -98,34 +99,35 @@ RSpec.describe Forms::PageController, type: :request do
   describe "#show" do
     context "with preview mode on" do
       let(:api_url_suffix) { "/draft" }
+      let(:mode) { "preview-draft" }
 
       it "Returns a 200" do
-        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response).to have_http_status(:ok)
       end
 
       it "redirects to first page if second request before first complete" do
-        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
-        expect(response).to redirect_to(form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
+        expect(response).to redirect_to(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
       end
 
       it "Displays the question text on the page" do
-        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include(form_data.pages.first.question_text)
       end
 
       it "Displays the privacy policy link on the page" do
-        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include("Privacy")
       end
 
       it "Displays the accessibility statement link on the page" do
-        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include("Accessibility statement")
       end
 
       it "Displays the Cookies link on the page" do
-        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include("Cookies")
       end
 
@@ -133,38 +135,41 @@ RSpec.describe Forms::PageController, type: :request do
         it "Displays a link to the previous page" do
           allow_any_instance_of(Flow::Context).to receive(:can_visit?).and_return(true)
           allow_any_instance_of(Flow::Context).to receive(:previous_step).and_return(OpenStruct.new(page_id: 1))
-          get form_page_path("preview-draft", 2, form_data.form_slug, 2)
+          get form_page_path(2, form_data.form_slug, 2, mode:)
           expect(response.body).to include(form_page_path(2, form_data.form_slug, 1))
         end
       end
 
       context "with a change answers page" do
         it "Displays a back link to the check your answers page" do
-          get form_change_answer_path("preview-draft", 2, form_data.form_slug, 1)
-          expect(response.body).to include(check_your_answers_path("preview-draft", 2, form_data.form_slug))
+          get form_change_answer_path(2, form_data.form_slug, 1, mode:)
+          expect(response.body).to include(check_your_answers_path(2, form_data.form_slug, mode:))
         end
 
         it "Passes the changing answers parameter in its submit request" do
-          get form_change_answer_path("preview-draft", 2, form_data.form_slug, 1)
-          expect(response.body).to include(save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true, answer_index: 1))
+          get form_change_answer_path(2, form_data.form_slug, 1, mode:)
+          expect(response.body).to include(save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true, answer_index: 1))
         end
       end
 
       it "Returns the correct X-Robots-Tag header" do
-        get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
       end
 
       context "with no questions answered" do
         it "redirects if a later page is requested" do
-          get check_your_answers_path("preview-draft", 2, form_data.form_slug)
+          get check_your_answers_path(2, form_data.form_slug, mode:)
           expect(response).to have_http_status(:found)
-          expect(response.location).to eq(form_page_url(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
+          expect(response.location).to eq(form_page_url(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
         end
       end
     end
 
     context "with preview mode off" do
+      let(:api_url_suffix) { "/live" }
+      let(:mode) { "form" }
+
       [
         "/form/2/1/check_your_answers_trailing",
         "/form/2/1/leading_check_your_answers",
@@ -196,32 +201,32 @@ RSpec.describe Forms::PageController, type: :request do
       end
 
       it "Returns a 200" do
-        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response).to have_http_status(:ok)
       end
 
       it "redirects to first page if second request before first complete" do
-        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
-        expect(response).to redirect_to(form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
+        expect(response).to redirect_to(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
       end
 
       it "Displays the question text on the page" do
-        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include(form_data.pages.first.question_text)
       end
 
       it "Displays the privacy policy link on the page" do
-        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include("Privacy")
       end
 
       it "Displays the accessibility statement link on the page" do
-        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include("Accessibility statement")
       end
 
       it "Displays the Cookies link on the page" do
-        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.body).to include("Cookies")
       end
 
@@ -230,33 +235,33 @@ RSpec.describe Forms::PageController, type: :request do
           allow_any_instance_of(Flow::Context).to receive(:can_visit?)
                                               .and_return(true)
           allow_any_instance_of(Flow::Context).to receive(:previous_step).and_return(OpenStruct.new(page_id: 1))
-          get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
-          expect(response.body).to include(form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
+          get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2)
+          expect(response.body).to include(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
         end
       end
 
       context "with a change answers page" do
         it "Displays a back link to the check your answers page" do
-          get form_change_answer_path("form", 2, form_data.form_slug, 1)
-          expect(response.body).to include(check_your_answers_path("form", 2, form_data.form_slug))
+          get form_change_answer_path(2, form_data.form_slug, 1, mode:)
+          expect(response.body).to include(check_your_answers_path(2, form_data.form_slug, mode:))
         end
 
         it "Passes the changing answers parameter in its submit request" do
-          get form_change_answer_path("form", 2, form_data.form_slug, 1)
-          expect(response.body).to include(save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true, answer_index: 1))
+          get form_change_answer_path(2, form_data.form_slug, 1, mode:)
+          expect(response.body).to include(save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true, answer_index: 1))
         end
       end
 
       it "Returns the correct X-Robots-Tag header" do
-        get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
       end
 
       context "with no questions answered" do
         it "redirects if a later page is requested" do
-          get check_your_answers_path("form", 2, form_data.form_slug)
+          get check_your_answers_path(2, form_data.form_slug, mode:)
           expect(response).to have_http_status(:found)
-          expect(response.location).to eq(form_page_url(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
+          expect(response.location).to eq(form_page_url(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
         end
       end
 
@@ -265,7 +270,7 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "returns 404" do
           travel_to timestamp_of_request do
-            get form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+            get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
           end
 
           expect(response).to have_http_status(:not_found)
@@ -274,6 +279,8 @@ RSpec.describe Forms::PageController, type: :request do
     end
 
     context "when viewing a live form with no routing_conditions" do
+      let(:mode) { "preview-live" }
+
       let(:first_page_in_form) do
         page_without_routing_condition = build(:page, :with_text_settings,
                                                id: 1,
@@ -284,7 +291,7 @@ RSpec.describe Forms::PageController, type: :request do
       end
 
       it "Returns a 200" do
-        get form_page_path(mode: "preview-live", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         expect(response).to have_http_status(:ok)
       end
     end
@@ -312,18 +319,19 @@ RSpec.describe Forms::PageController, type: :request do
       let(:pages_data) { [third_page_in_form, first_page_in_form, second_page_in_form] }
 
       let(:api_url_suffix) { "/draft" }
+      let(:mode) { "preview-draft" }
 
       context "when the routing has a cannot_have_goto_page_before_routing_page error" do
         let(:pages_data) { [first_page_in_form, second_page_in_form, third_page_in_form] }
         let(:validation_errors) { [{ name: "cannot_have_goto_page_before_routing_page" }] }
 
         it "returns a 422 response" do
-          get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+          get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
           expect(response).to have_http_status(:unprocessable_entity)
         end
 
         it "shows the error page" do
-          get form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+          get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
           link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/conditions/1"
           question_number = first_page_in_form.position
           expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))
@@ -332,15 +340,17 @@ RSpec.describe Forms::PageController, type: :request do
     end
 
     context "when page is repeatable" do
+      let(:mode) { "form" }
+
       let(:first_page_in_form) { build :page, :with_repeatable, id: 1, next_page: second_page_in_form.id }
 
       it "shows the page as normal when there are no stored answers" do
-        get form_page_path(mode: "form", form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, answer_index: 1)
+        get form_page_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, answer_index: 1)
         expect(response).to have_http_status(:ok)
       end
 
       it "returns 404 when given an invalid answer_index" do
-        get form_page_path(mode: "form", form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, answer_index: 12)
+        get form_page_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, answer_index: 12)
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -353,51 +363,52 @@ RSpec.describe Forms::PageController, type: :request do
 
     context "with preview mode on" do
       let(:api_url_suffix) { "/draft" }
+      let(:mode) { "preview-draft" }
 
       it "Redirects to the next page" do
-        post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
+        post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
       end
 
       context "when changing an existing answer" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
-          expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, form_data.form_slug))
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          expect(response).to redirect_to(check_your_answers_path(2, form_data.form_slug, mode:))
         end
 
         it "does not log the change_answer_page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
         end
       end
 
       context "with the first page" do
         it "Logs the first_page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" } }
         end
 
         it "clears the submission reference from the session" do
           expect_any_instance_of(Flow::Context).to receive(:clear_submission_details).once
-          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" } }
         end
       end
 
       context "with a subsequent page" do
         it "Logs the page_save event" do
           expect(EventLogger).not_to receive(:log)
-          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
         end
 
         it "does not clear the submission reference from the session" do
           expect_any_instance_of(Flow::Context).not_to receive(:clear_submission_details)
-          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
         end
       end
 
       context "with the final page" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
           expect(response).to redirect_to(check_your_answers_path("preview-draft", 2, form_data.form_slug))
         end
       end
@@ -407,7 +418,7 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "does not return 404" do
           travel_to timestamp_of_request do
-            post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+            post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
           end
           expect(response).not_to have_http_status(:not_found)
         end
@@ -415,7 +426,7 @@ RSpec.describe Forms::PageController, type: :request do
 
       context "when the form is invalid" do
         before do
-          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "" }, changing_existing_answer: false }
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "" }, changing_existing_answer: false }
         end
 
         it "renders the show page template" do
@@ -429,41 +440,44 @@ RSpec.describe Forms::PageController, type: :request do
     end
 
     context "with preview mode off" do
+      let(:api_url_suffix) { "/live" }
+      let(:mode) { "form" }
+
       it "Redirects to the next page" do
-        post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
+        post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
       end
 
       context "when changing an existing answer" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
-          expect(response).to redirect_to(check_your_answers_path("form", 2, form_data.form_slug))
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          expect(response).to redirect_to(check_your_answers_path(2, form_data.form_slug, mode:))
         end
 
         it "Logs the change_answer_page_save event" do
           expect(EventLogger).to receive(:log_page_event).with("change_answer_page_save", first_page_in_form.question_text, nil)
-          post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1, params: { question: { text: "answer text" }, changing_existing_answer: true })
         end
       end
 
       context "with the first page" do
         it "Logs the first_page_save event" do
           expect(EventLogger).to receive(:log_page_event).with("first_page_save", first_page_in_form.question_text, nil)
-          post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" } }
         end
       end
 
       context "with a subsequent page" do
         it "Logs the page_save event" do
           expect(EventLogger).to receive(:log_page_event).with("page_save", second_page_in_form.question_text, nil)
-          post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
         end
       end
 
       context "with the final page" do
         it "Redirects to the check your answers page" do
-          post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
-          expect(response).to redirect_to(check_your_answers_path("form", 2, form_data.form_slug))
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
+          expect(response).to redirect_to(check_your_answers_path(2, form_data.form_slug, mode:))
         end
       end
 
@@ -473,21 +487,21 @@ RSpec.describe Forms::PageController, type: :request do
         context "when an optional question is completed" do
           it "Logs the optional_save event with skipped_question as true" do
             expect(EventLogger).to receive(:log_page_event).with("optional_save", second_page_in_form.question_text, true)
-            post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "" } }
+            post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "" } }
           end
         end
 
         context "when an optional question is skipped" do
           it "Logs the optional_save event with skipped_question as false" do
             expect(EventLogger).to receive(:log_page_event).with("optional_save", second_page_in_form.question_text, false)
-            post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
+            post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
           end
         end
       end
 
       context "when the form is invalid" do
         before do
-          post save_form_page_path(mode: "form", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "" }, changing_existing_answer: false }
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "" }, changing_existing_answer: false }
         end
 
         it "renders the show page template" do
@@ -523,16 +537,17 @@ RSpec.describe Forms::PageController, type: :request do
       let(:pages_data) { [first_page_in_form, second_page_in_form, third_page_in_form] }
 
       let(:api_url_suffix) { "/draft" }
+      let(:mode) { "preview-draft" }
 
       it "redirects to the goto page if answer value matches condition" do
-        post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 1" }, changing_existing_answer: false }
-        expect(response).to redirect_to(form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 3))
+        post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 1" }, changing_existing_answer: false }
+        expect(response).to redirect_to(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 3))
       end
 
       context "when the answer_value does not match the condition" do
         it "redirects to the next page in the journey" do
-          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
-          expect(response).to redirect_to(form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
+          expect(response).to redirect_to(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2))
         end
       end
 
@@ -541,12 +556,12 @@ RSpec.describe Forms::PageController, type: :request do
         let(:validation_errors) { [{ name: "cannot_have_goto_page_before_routing_page" }] }
 
         it "returns a 422 response" do
-          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
           expect(response).to have_http_status(:unprocessable_entity)
         end
 
         it "shows the error page" do
-          post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
           link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/conditions/1"
           question_number = first_page_in_form.position
           expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))
@@ -560,12 +575,12 @@ RSpec.describe Forms::PageController, type: :request do
       let(:first_page_in_form) { build :page, :with_repeatable, id: 1, next_page: second_page_in_form.id }
 
       it "redirects to the add another answer page when given valid answer" do
-        post save_form_page_path(mode: "form", form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, params: { question: { number: 12 } })
-        expect(response).to redirect_to(add_another_answer_path(mode: "form", form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id))
+        post save_form_page_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, params: { question: { number: 12 } })
+        expect(response).to redirect_to(add_another_answer_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id))
       end
 
       it "shows 404 if an invalid answer_index is given" do
-        post save_form_page_path(mode: "form", form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, answer_index: 3, params: { question: { number: 12 } })
+        post save_form_page_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, answer_index: 3, params: { question: { number: 12 } })
         expect(response).to have_http_status(:not_found)
       end
     end

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -517,6 +517,15 @@ RSpec.describe Forms::PageController, type: :request do
         post save_form_page_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, answer_index: 3, params: { question: { number: 12 } })
         expect(response).to have_http_status(:not_found)
       end
+
+      context "and is optional" do
+        let(:first_page_in_form) { build :page, :with_repeatable, is_optional: true, id: 1, next_page: second_page_in_form.id }
+
+        it "redirects to the next page when not given an answer" do
+          post save_form_page_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug: first_page_in_form.id, params: { question: { number: nil } })
+          expect(response).to redirect_to(form_page_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug: second_page_in_form.id))
+        end
+      end
     end
   end
 

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -96,6 +96,23 @@ RSpec.describe Forms::PageController, type: :request do
     end
   end
 
+  shared_examples "page with footer" do
+    it "Displays the privacy policy link on the page" do
+      get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+      expect(response.body).to include("Privacy")
+    end
+
+    it "Displays the accessibility statement link on the page" do
+      get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+      expect(response.body).to include("Accessibility statement")
+    end
+
+    it "Displays the Cookies link on the page" do
+      get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+      expect(response.body).to include("Cookies")
+    end
+  end
+
   describe "#show" do
     context "with preview mode on" do
       let(:api_url_suffix) { "/draft" }
@@ -116,20 +133,7 @@ RSpec.describe Forms::PageController, type: :request do
         expect(response.body).to include(form_data.pages.first.question_text)
       end
 
-      it "Displays the privacy policy link on the page" do
-        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
-        expect(response.body).to include("Privacy")
-      end
-
-      it "Displays the accessibility statement link on the page" do
-        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
-        expect(response.body).to include("Accessibility statement")
-      end
-
-      it "Displays the Cookies link on the page" do
-        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
-        expect(response.body).to include("Cookies")
-      end
+      it_behaves_like "page with footer"
 
       context "with a page that has a previous page" do
         it "Displays a link to the previous page" do
@@ -215,20 +219,7 @@ RSpec.describe Forms::PageController, type: :request do
         expect(response.body).to include(form_data.pages.first.question_text)
       end
 
-      it "Displays the privacy policy link on the page" do
-        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
-        expect(response.body).to include("Privacy")
-      end
-
-      it "Displays the accessibility statement link on the page" do
-        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
-        expect(response.body).to include("Accessibility statement")
-      end
-
-      it "Displays the Cookies link on the page" do
-        get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
-        expect(response.body).to include("Cookies")
-      end
+      it_behaves_like "page with footer"
 
       context "with a page that has a previous page" do
         it "Displays a link to the previous page" do


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

If a question is optional and can be answered multiple times we want the form filler to skip over the add another answer page if they do not answer the question the first time they are presented with it.

We also need the "Not answered" text to show up on the check your answers page, which isn't happening currently.

This PR is based on commits by @thomasiles in #900, with some extra tests and a bunch of refactors to the changed spec files.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?