### PR TITLE
Update add another title and error text

### DIFF
--- a/app/views/forms/add_another_answer/show.html.erb
+++ b/app/views/forms/add_another_answer/show.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(form_title(form_name: @current_context.form.name, page_name: (@step.question.page_heading.present? ? @step.question.page_heading : @step.question.question_text), mode: @mode, error: @step.question&.errors&.any?)) %>
+<% set_page_title(form_title(form_name: @current_context.form.name, page_name: t('.title', page_title: (@step.question.page_heading.present? ? @step.question.page_heading : @step.question.question_text)), mode: @mode, error: @step.question&.errors&.any?)) %>
 
 <% content_for :back_link do %>
   <% if @back_link.present? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,7 +14,7 @@ en:
               blank: Enter an email address
               invalid_email: Enter an email address in the correct format, like name@example.com
             send_confirmation:
-              blank: Select ‘Yes’ if you want to get an email confirming your form has been submitted
+              blank: Select yes if you want to get an email confirming your form has been submitted
         question/address:
           attributes:
             address1:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
         add_another_answer_input:
           attributes:
             add_another_answer:
-              blank: You must select an option
+              blank: Select yes if you need to add another answer
               max_answers_reached: You cannot add another answer
         email_confirmation_input:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,6 +131,7 @@ en:
           zero: You have added no answers
         max_answers: You cannot add another answer to this question as you’ve entered the maximum of %{max_answers}
         radios_legend: Do you need to add another answer?
+        title: Add or remove answer to %{page_title}
     back: Back
     remove_answer:
       show:

--- a/spec/views/forms/add_another_answer/show.html.erb_spec.rb
+++ b/spec/views/forms/add_another_answer/show.html.erb_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "forms/add_another_answer/show.html.erb" do
   let(:form) { build :form, id: 1 }
   let(:mode) { OpenStruct.new(preview_draft?: false, preview_archived?: false, preview_live?: false) }
-  let(:step) { OpenStruct.new({ form_id: 1, form_slug: "form-1", page_slug: "1", mode:, questions:, question: OpenStruct.new({}), max_answers?: max_answers }) }
+  let(:step) { OpenStruct.new({ form_id: 1, form_slug: "form-1", page_slug: "1", mode:, questions:, question: OpenStruct.new({ question_text: "Question text" }), max_answers?: max_answers }) }
   let(:add_another_answer_input) { AddAnotherAnswerInput.new }
   let(:back_link) { "/back" }
   let(:questions) { [] }
@@ -27,6 +27,10 @@ describe "forms/add_another_answer/show.html.erb" do
     end
 
     render
+  end
+
+  it "has the correct page title" do
+    expect(view.content_for(:title)).to eq "Add or remove answer to Question text - #{form.name}"
   end
 
   it "has a back link" do


### PR DESCRIPTION
### Update the text for the title and error message of the add another page

Trello card: https://trello.com/c/CzswSAoa/1725-3-review-form-filler-content-for-single-repeatable-step

This PR updates the content for the add another page.


## Update
[Charlotte has said that the text should be "Select yes if you need to add another answer" and that other instances of this pattern should be updated to remove the capitalisation and quotes around yes](https://trello.com/c/CzswSAoa/1725-3-review-form-filler-content-for-single-repeatable-step#comment-66eaa040002be7b1a7af359e). I've changed the text for this error and the one which appears on the submission email form.

Updated screenshots of both:

![image](https://github.com/user-attachments/assets/f1d7233e-4dd8-4df5-b6ab-7e57f16b0271)


![image](https://github.com/user-attachments/assets/44db03ac-a080-4b0f-b9aa-9ac17eb2722a)

## Outdated - see above

**Note** the trello card gave the text as "Select yes if you need to add another answer". I've capitalised and add quotes around _yes_. This makes it match the error the form filler sees if they don't answer the question about confirmation emails before submitting the form.

It's easy to change it if thats not what we want.

![image](https://github.com/user-attachments/assets/2c3a3efe-ddaa-435b-ad75-c5207efa7a9d)


![image](https://github.com/user-attachments/assets/e4ec765a-f6d1-4d06-ab95-8c396929e521)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
