### PR TITLE
Change max number answers for repeatable_step

### DIFF
--- a/app/models/repeatable_step.rb
+++ b/app/models/repeatable_step.rb
@@ -5,7 +5,7 @@ class RepeatableStep < Step
 
   class AnswerIndexError < IndexError; end
 
-  MAX_ANSWERS = 10
+  MAX_ANSWERS = 50
 
   attr_accessor :answer_index, :questions
 

--- a/spec/models/repeatable_step_spec.rb
+++ b/spec/models/repeatable_step_spec.rb
@@ -106,16 +106,16 @@ RSpec.describe RepeatableStep, type: :model do
   describe "#max_answers?" do
     before { repeatable_step.questions = questions }
 
-    context "with 9 or fewer questions" do
-      let(:questions) { [1, 2, 3, 4, 5, 6, 7, 8, 9] }
+    context "with 49 or fewer questions" do
+      let(:questions) { Array.new(49, :a_default_value) }
 
       it "returns false" do
         expect(repeatable_step.max_answers?).to be(false)
       end
     end
 
-    context "with 10 questions" do
-      let(:questions) { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] }
+    context "with 50 questions" do
+      let(:questions) { Array.new(50, :a_default_value) }
 
       it "returns true" do
         expect(repeatable_step.max_answers?).to be(true)

--- a/spec/views/forms/add_another_answer/show.html.erb_spec.rb
+++ b/spec/views/forms/add_another_answer/show.html.erb_spec.rb
@@ -65,7 +65,7 @@ describe "forms/add_another_answer/show.html.erb" do
     let(:max_answers) { true }
 
     it "renders the max answers text" do
-      expect(rendered).to have_content("You cannot add another answer to this question as you’ve entered the maximum of 10")
+      expect(rendered).to have_content("You cannot add another answer to this question as you’ve entered the maximum of 50")
     end
   end
 end


### PR DESCRIPTION
# Increase the number of answers which can be given to a singe repeatable question

The current limit of ten answers for a single repeatable question is
being increased from 10 to 50.

This figure has been chosen to cover most use cases for form creators.

This commit changes the MAX_ANSWERS constant from 10 to 50 and fixes the
tests which also need to change.

The tests could be changed to not break when changing this constant.

We are unlikely to change this number often. The tests have been kept as
explicitly checking the text and value.

There will be another ticket to update the text used in the admin to tell form creators about the limit.

Trello card: https://trello.com/c/7unK4mxB/1775-53dev-iterate-designs-for-single-repeatable-question-mvp-following-ur

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
