### PR TITLE
Add deprecation warnings for API endpoints that we think we don't use

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -19,4 +19,10 @@ class ErrorsController < ApplicationController
   def maintenance
     render "errors/maintenance", formats: :html
   end
+
+  def deprecated
+    form = Form.find params.require(:form_id)
+    page = Page.find params.require(:page_id), params: { form_id: params.require(:form_id) }
+    redirect_to form_page_path(form_id: form.id, form_slug: form.form_slug, page_slug: page.id, mode: :form)
+  end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -6,6 +6,17 @@ class Form < ActiveResource::Base
 
   has_many :pages
 
+  def self.deprecator
+    Rails.application.deprecators[:forms_api]
+  end
+
+  def self.find(scope, **options)
+    if options[:from].blank?
+      deprecator.warn "the /forms/:id endpoint will not return form documents in API v2"
+    end
+    super
+  end
+
   def self.find_with_mode(id:, mode:)
     raise ActiveResource::ResourceNotFound.new(404, "Not Found") unless id.to_s =~ /^[[:alnum:]]+$/
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -8,6 +8,15 @@ class Page < ActiveResource::Base
 
   belongs_to :form
 
+  def self.deprecator
+    Rails.application.deprecators[:forms_api]
+  end
+
+  def self.find(...)
+    deprecator.warn "the /forms/:id/pages endpoints are deprecated and will be removed in API v2"
+    super
+  end
+
   def form_id
     @prefix_options[:form_id]
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,7 +44,10 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation = :raise
 
   # Tell Active Support which deprecation messages to disallow.
-  config.active_support.disallowed_deprecation_warnings = []
+  config.active_support.disallowed_deprecation_warnings = [
+    "/forms/:id endpoint",
+    "/forms/:id/pages endpoint",
+  ]
 
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,8 +72,13 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  # Don't log any deprecations.
-  config.active_support.report_deprecations = false
+  # Log disallowed deprecations.
+  config.active_support.report_deprecations = true
+  config.active_support.deprecation = :silence
+  config.active_support.disallowed_deprecation = :log
+  config.active_support.disallowed_deprecation_warnings = [
+    /API v2/,
+  ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,7 +50,10 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation = :raise
 
   # Tell Active Support which deprecation messages to disallow.
-  config.active_support.disallowed_deprecation_warnings = []
+  config.active_support.disallowed_deprecation_warnings = [
+    "/forms/:id endpoint",
+    "/forms/:id/pages endpoint",
+  ]
 
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true

--- a/config/initializers/forms_api_deprecations.rb
+++ b/config/initializers/forms_api_deprecations.rb
@@ -1,0 +1,1 @@
+Rails.application.deprecators[:forms_api] ||= ActiveSupport::Deprecation.new("v2", "GOV.UK Forms API")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,5 +65,6 @@ Rails.application.routes.draw do
   get "/maintenance" => "errors#maintenance", as: :maintenance_page
   get "/404", to: "errors#not_found", as: :error_404, via: :all
   get "/500", to: "errors#internal_server_error", as: :error_500, via: :all
+  get "/deprecated", to: "errors#deprecated"
   match "*path", to: "errors#not_found", via: :all
 end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -10,8 +10,6 @@ end
 
 FactoryBot.define do
   factory :page, class: "Page" do
-    initialize_with { new(**attributes) }
-
     id { Faker::Number.number(digits: 2) }
     question_text { Faker::Lorem.question }
     answer_type { "number" }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -25,76 +25,38 @@ RSpec.describe Form, type: :model do
     end
   end
 
-  it "returns a simple form" do
-    expect(form).to have_attributes(id: 1, name: "form name", submission_email: "user@example.com")
-  end
-
-  describe "Getting the pages for a form" do
-    it "returns the pages for a form" do
-      pages = form.pages
-      expect(pages.length).to eq(2)
-      expect(pages[0]).to have_attributes(id: 9, next_page: 10, answer_type: "date", question_text: "Question one")
-      expect(pages[1]).to have_attributes(id: 10, answer_type: "address", question_text: "Question two")
+  shared_examples "form snapshot" do
+    it "returns a simple form" do
+      expect(form).to have_attributes(id: 1, name: "form name", submission_email: "user@example.com")
     end
-  end
 
-  describe "#live?" do
-    let(:response_data) { { id: 1, name: "form name", live_at: }.compact }
-    let(:live_at) { "2022-08-18 09:16:50Z" }
-
-    context "when live_at is not set" do
-      let(:live_at) { nil }
-
-      it "raises an error" do
-        expect { form.live? }.to raise_error(Date::Error)
+    describe "#pages" do
+      it "returns the pages for the form" do
+        pages = form.pages
+        expect(pages.length).to eq(2)
+        expect(pages[0]).to have_attributes(id: 9, next_page: 10, answer_type: "date", question_text: "Question one")
+        expect(pages[1]).to have_attributes(id: 10, answer_type: "address", question_text: "Question two")
       end
     end
 
-    context "when live_at is set to empty string" do
-      let(:live_at) { "" }
+    describe "#payment_url_with_reference" do
+      let(:response_data) { { id: 1, name: "form name", payment_url:, start_page: 1 } }
+      let(:reference) { SecureRandom.base58(8).upcase }
 
-      it "returns false" do
-        expect(form.live?).to be false
+      context "when there is a payment_url" do
+        let(:payment_url) { "https://www.gov.uk/payments/test-service/pay-for-licence" }
+
+        it "returns a full payment link" do
+          expect(form.payment_url_with_reference(reference)).to eq("#{payment_url}?reference=#{reference}")
+        end
       end
-    end
 
-    context "when live_at is a string which isn't a valid date" do
-      let(:live_at) { "not a date!" }
+      context "when there is no payment_url" do
+        let(:payment_url) { nil }
 
-      it "raises an error" do
-        expect { form.live? }.to raise_error(Date::Error)
-      end
-    end
-
-    context "when live_at is not a string" do
-      let(:live_at) { 1 }
-
-      it "raises an error" do
-        expect { form.live? }.to raise_error(Date::Error)
-      end
-    end
-
-    context "when live_at is a date in the future" do
-      let(:live_at) { "2022-08-18 09:16:50Z" }
-
-      it "returns false" do
-        expect(form.live?("2022-01-01 10:00:00Z")).to be false
-      end
-    end
-
-    context "when live_at is a date in the past" do
-      let(:live_at) { "2022-08-18 09:16:50Z" }
-
-      it "returns true" do
-        expect(form.live?("2023-01-01 10:00:00Z")).to be true
-      end
-    end
-
-    context "when dates are the same" do
-      let(:live_at) { "2022-08-18 09:16:50Z" }
-
-      it "returns false" do
-        expect(form.live?("2022-08-18 09:16:50Z")).to be false
+        it "returns nil" do
+          expect(form.payment_url_with_reference(reference)).to be_nil
+        end
       end
     end
   end
@@ -102,7 +64,7 @@ RSpec.describe Form, type: :model do
   describe "#find_with_mode" do
     context "when mode is live" do
       let(:form) { described_class.find_with_mode(id: 1, mode: Mode.new("live")) }
-      let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z" } }
+      let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", live_at: "2022-08-18 09:16:50Z", pages: } }
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
@@ -110,21 +72,86 @@ RSpec.describe Form, type: :model do
         end
       end
 
+      it_behaves_like "form snapshot"
+
       it "returns a live form" do
         expect(form).to have_attributes(id: 1, name: "form name")
         expect(form.live?).to be(true)
+      end
+
+      describe "#live?" do
+        let(:response_data) { { id: 1, name: "form name", live_at: }.compact }
+        let(:live_at) { "2022-08-18 09:16:50Z" }
+
+        context "when live_at is not set" do
+          let(:live_at) { nil }
+
+          it "raises an error" do
+            expect { form.live? }.to raise_error(Date::Error)
+          end
+        end
+
+        context "when live_at is set to empty string" do
+          let(:live_at) { "" }
+
+          it "returns false" do
+            expect(form.live?).to be false
+          end
+        end
+
+        context "when live_at is a string which isn't a valid date" do
+          let(:live_at) { "not a date!" }
+
+          it "raises an error" do
+            expect { form.live? }.to raise_error(Date::Error)
+          end
+        end
+
+        context "when live_at is not a string" do
+          let(:live_at) { 1 }
+
+          it "raises an error" do
+            expect { form.live? }.to raise_error(Date::Error)
+          end
+        end
+
+        context "when live_at is a date in the future" do
+          let(:live_at) { "2022-08-18 09:16:50Z" }
+
+          it "returns false" do
+            expect(form.live?("2022-01-01 10:00:00Z")).to be false
+          end
+        end
+
+        context "when live_at is a date in the past" do
+          let(:live_at) { "2022-08-18 09:16:50Z" }
+
+          it "returns true" do
+            expect(form.live?("2023-01-01 10:00:00Z")).to be true
+          end
+        end
+
+        context "when dates are the same" do
+          let(:live_at) { "2022-08-18 09:16:50Z" }
+
+          it "returns false" do
+            expect(form.live?("2022-08-18 09:16:50Z")).to be false
+          end
+        end
       end
     end
 
     context "when mode is draft" do
       let(:form) { described_class.find_with_mode(id: 1, mode: Mode.new("preview-draft")) }
-      let(:response_data) { { id: 1, name: "form name", live_at: nil } }
+      let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", live_at: nil, pages: } }
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
           mock.get "/api/v1/forms/1/draft", req_headers, response_data.to_json, 200
         end
       end
+
+      it_behaves_like "form snapshot"
 
       it "returns a draft form" do
         expect(form).to have_attributes(id: 1, name: "form name")
@@ -158,27 +185,6 @@ RSpec.describe Form, type: :model do
 
         expect(form).to have_attributes(id: "Alpha123", name: "form name")
         expect(form.live?).to be(false)
-      end
-    end
-  end
-
-  describe "#payment_url_with_reference" do
-    let(:response_data) { { id: 1, name: "form name", payment_url:, start_page: 1 } }
-    let(:reference) { SecureRandom.base58(8).upcase }
-
-    context "when there is a payment_url" do
-      let(:payment_url) { "https://www.gov.uk/payments/test-service/pay-for-licence" }
-
-      it "returns a full payment link" do
-        expect(form.payment_url_with_reference(reference)).to eq("#{payment_url}?reference=#{reference}")
-      end
-    end
-
-    context "when there is no payment_url" do
-      let(:payment_url) { nil }
-
-      it "returns nil" do
-        expect(form.payment_url_with_reference(reference)).to be_nil
       end
     end
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "getting a form without a mode" do
+    it "raises a deprecation warning" do
+      expect {
+        form
+      }.to raise_error(ActiveSupport::DeprecationException)
+    end
+  end
+
   shared_examples "form snapshot" do
     it "returns a simple form" do
       expect(form).to have_attributes(id: 1, name: "form name", submission_email: "user@example.com")

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,13 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Form, type: :model do
-  let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", start_page: 1 }.to_json }
+  let(:form) { described_class.find(1) }
+  let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", start_page: 1 } }
 
-  let(:pages_data) do
+  let(:pages) do
     [
       { id: 9, next_page: 10, answer_type: "date", question_text: "Question one" },
       { id: 10, answer_type: "address", question_text: "Question two" },
-    ].to_json
+    ]
   end
 
   let(:req_headers) do
@@ -19,18 +20,18 @@ RSpec.describe Form, type: :model do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1", req_headers, response_data, 200
-      mock.get "/api/v1/forms/1/pages", req_headers, pages_data, 200
+      mock.get "/api/v1/forms/1", req_headers, response_data.to_json, 200
+      mock.get "/api/v1/forms/1/pages", req_headers, pages.to_json, 200
     end
   end
 
   it "returns a simple form" do
-    expect(described_class.find(1)).to have_attributes(id: 1, name: "form name", submission_email: "user@example.com")
+    expect(form).to have_attributes(id: 1, name: "form name", submission_email: "user@example.com")
   end
 
   describe "Getting the pages for a form" do
     it "returns the pages for a form" do
-      pages = described_class.find(1).pages
+      pages = form.pages
       expect(pages.length).to eq(2)
       expect(pages[0]).to have_attributes(id: 9, next_page: 10, answer_type: "date", question_text: "Question one")
       expect(pages[1]).to have_attributes(id: 10, answer_type: "address", question_text: "Question two")
@@ -38,104 +39,105 @@ RSpec.describe Form, type: :model do
   end
 
   describe "#live?" do
+    let(:response_data) { { id: 1, name: "form name", live_at: }.compact }
+    let(:live_at) { "2022-08-18 09:16:50Z" }
+
     context "when live_at is not set" do
-      let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", start_page: 1 }.to_json }
+      let(:live_at) { nil }
 
       it "raises an error" do
-        expect { described_class.find(1).live? }.to raise_error(Date::Error)
+        expect { form.live? }.to raise_error(Date::Error)
       end
     end
 
-    context "when no live_at is set to empty string" do
-      let(:response_data) { { id: 1, name: "form name", live_at: "", submission_email: "user@example.com", start_page: 1 }.to_json }
+    context "when live_at is set to empty string" do
+      let(:live_at) { "" }
 
       it "returns false" do
-        expect(described_class.find(1).live?).to be false
+        expect(form.live?).to be false
       end
     end
 
     context "when live_at is a string which isn't a valid date" do
-      let(:response_data) { { id: 1, name: "form name", live_at: "not a date!", submission_email: "user@example.com", start_page: 1 }.to_json }
+      let(:live_at) { "not a date!" }
 
       it "raises an error" do
-        expect { described_class.find(1).live? }.to raise_error(Date::Error)
+        expect { form.live? }.to raise_error(Date::Error)
       end
     end
 
     context "when live_at is not a string" do
-      let(:response_data) { { id: 1, name: "form name", live_at: 1, submission_email: "user@example.com", start_page: 1 }.to_json }
+      let(:live_at) { 1 }
 
       it "raises an error" do
-        expect { described_class.find(1).live? }.to raise_error(Date::Error)
+        expect { form.live? }.to raise_error(Date::Error)
       end
     end
 
     context "when live_at is a date in the future" do
-      let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z", submission_email: "user@example.com", start_page: 1 }.to_json }
+      let(:live_at) { "2022-08-18 09:16:50Z" }
 
       it "returns false" do
-        expect(described_class.find(1).live?("2022-01-01 10:00:00Z")).to be false
+        expect(form.live?("2022-01-01 10:00:00Z")).to be false
       end
     end
 
     context "when live_at is a date in the past" do
-      let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z", submission_email: "user@example.com", start_page: 1 }.to_json }
+      let(:live_at) { "2022-08-18 09:16:50Z" }
 
       it "returns true" do
-        expect(described_class.find(1).live?("2023-01-01 10:00:00Z")).to be true
+        expect(form.live?("2023-01-01 10:00:00Z")).to be true
       end
     end
 
     context "when dates are the same" do
-      let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z", submission_email: "user@example.com", start_page: 1 }.to_json }
+      let(:live_at) { "2022-08-18 09:16:50Z" }
 
       it "returns false" do
-        expect(described_class.find(1).live?("2022-08-18 09:16:50Z")).to be false
+        expect(form.live?("2022-08-18 09:16:50Z")).to be false
       end
     end
   end
 
   describe "#find_with_mode" do
     context "when mode is live" do
-      let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z" }.to_json }
+      let(:form) { described_class.find_with_mode(id: 1, mode: Mode.new("live")) }
+      let(:response_data) { { id: 1, name: "form name", live_at: "2022-08-18 09:16:50Z" } }
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/1/live", req_headers, response_data, 200
+          mock.get "/api/v1/forms/1/live", req_headers, response_data.to_json, 200
         end
       end
 
       it "returns a live form" do
-        form = described_class.find_with_mode(id: 1, mode: Mode.new("live"))
-
         expect(form).to have_attributes(id: 1, name: "form name")
         expect(form.live?).to be(true)
       end
     end
 
     context "when mode is draft" do
-      let(:response_data) { { id: 1, name: "form name", live_at: nil }.to_json }
+      let(:form) { described_class.find_with_mode(id: 1, mode: Mode.new("preview-draft")) }
+      let(:response_data) { { id: 1, name: "form name", live_at: nil } }
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/1/draft", req_headers, response_data, 200
+          mock.get "/api/v1/forms/1/draft", req_headers, response_data.to_json, 200
         end
       end
 
       it "returns a draft form" do
-        form = described_class.find_with_mode(id: 1, mode: Mode.new("preview-draft"))
-
         expect(form).to have_attributes(id: 1, name: "form name")
         expect(form.live?).to be(false)
       end
     end
 
     context "when validating the provided form id" do
-      let(:response_data) { { id: "Alpha123", name: "form name", live_at: nil }.to_json }
+      let(:response_data) { { id: "Alpha123", name: "form name", live_at: nil } }
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
-          mock.get "/api/v1/forms/Alpha123/draft", req_headers, response_data, 200
+          mock.get "/api/v1/forms/Alpha123/draft", req_headers, response_data.to_json, 200
         end
       end
 
@@ -161,14 +163,14 @@ RSpec.describe Form, type: :model do
   end
 
   describe "#payment_url_with_reference" do
-    let(:response_data) { { id: 1, name: "form name", payment_url:, start_page: 1 }.to_json }
+    let(:response_data) { { id: 1, name: "form name", payment_url:, start_page: 1 } }
     let(:reference) { SecureRandom.base58(8).upcase }
 
     context "when there is a payment_url" do
       let(:payment_url) { "https://www.gov.uk/payments/test-service/pay-for-licence" }
 
       it "returns a full payment link" do
-        expect(described_class.find(1).payment_url_with_reference(reference)).to eq("#{payment_url}?reference=#{reference}")
+        expect(form.payment_url_with_reference(reference)).to eq("#{payment_url}?reference=#{reference}")
       end
     end
 
@@ -176,7 +178,7 @@ RSpec.describe Form, type: :model do
       let(:payment_url) { nil }
 
       it "returns nil" do
-        expect(described_class.find(1).payment_url_with_reference(reference)).to be_nil
+        expect(form.payment_url_with_reference(reference)).to be_nil
       end
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -8,29 +8,29 @@ RSpec.describe Page, type: :model do
 
   describe "#answer_settings" do
     it "returns an empty object for answer_settings when it's not present" do
-      page = build :page
+      page = described_class.new
       expect(page).to have_attributes(answer_settings: {})
     end
 
     it "returns an answer settings object for answer_settings when present" do
-      page = build :page, answer_settings: { only_one_option: "true" }
+      page = described_class.new(answer_settings: { only_one_option: "true" })
       expect(page.answer_settings.attributes).to eq({ "only_one_option" => "true" })
     end
   end
 
   describe "#repeatable?" do
     it "returns false when attribute does not exist" do
-      page = build :page
+      page = described_class.new
       expect(page.repeatable?).to be false
     end
 
     it "returns false when attribute is false" do
-      page = build :page, is_repeatable: false
+      page = described_class.new is_repeatable: false
       expect(page.repeatable?).to be false
     end
 
     it "returns true when attribute is true" do
-      page = build :page, is_repeatable: true
+      page = described_class.new is_repeatable: true
       expect(page.repeatable?).to be true
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -36,12 +36,19 @@ RSpec.describe Page, type: :model do
   end
 
   describe "API call" do
-    let(:response_data) do
+    let(:form_snapshot) do
+      {
+        id: 2,
+        pages: [page],
+      }
+    end
+
+    let(:page) do
       {
         id: 1,
         question_text: "Question text",
         answer_type: "date",
-      }.to_json
+      }
     end
 
     let(:req_headers) do
@@ -53,12 +60,21 @@ RSpec.describe Page, type: :model do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/2/pages/1", req_headers, response_data, 200
+        mock.get "/api/v1/forms/2/draft", req_headers, form_snapshot.to_json, 200
+        mock.get "/api/v1/forms/2/pages/1", req_headers, page.to_json, 200
       end
     end
 
-    it "returns the page for a form" do
-      expect(described_class.find(1, params: { form_id: 2 })).to have_attributes(id: 1, question_text: "Question text", answer_type: "date")
+    it "models the pages of a form as page records" do
+      expect(Form.find_draft(2).pages.first).to have_attributes(
+        id: 1, question_text: "Question text", answer_type: "date",
+      )
+    end
+
+    it "raises a deprecation warning if a page is requested" do
+      expect {
+        described_class.find(1, params: { form_id: 2 })
+      }.to raise_error(ActiveSupport::DeprecationException)
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/7unK4mxB/1775-53dev-iterate-designs-for-single-repeatable-question-mvp-following-ur <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to be certain that forms-runner is not using any of the `/forms/:id`, `/forms/:id/pages`, or `/forms/:form_id/pages/:id` API endpoints.

This is because we plan to deprecate those endpoints as part of moving to version 2 of the API (see [ADR 034]).

This PR adds a deprecation warning to the `.find` methods for the `Page` and `Form` class.

Note that this also causes a warning when `Form.find#pages` is used if the form response doesn't include the pages; however apart from one explicit test I don't think we call API endpoints that don't include the pages (but we'll find out when we release this change!).

[ADR 034]: https://github.com/alphagov/forms/blob/5469de94bbd7e657a0b888608e4549c9ba30087a/ADR/ADR034-api-v2-for-forms.md

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?