### PR TITLE
Use submission type on form

### DIFF
--- a/app/services/feature_service.rb
+++ b/app/services/feature_service.rb
@@ -1,26 +1,10 @@
-module FeatureService
-  class FormRequiredError < StandardError; end
+class FeatureService
+  class << self
+    def enabled?(feature_name)
+      return false if Settings.features.blank?
 
-  def self.enabled?(feature_name, form = nil)
-    return false if Settings.features.blank?
-
-    segments = feature_name.to_s.split(".")
-    feature = Settings.features.dig(*segments)
-
-    return feature unless feature.is_a? Config::Options
-
-    return true if feature.enabled
-
-    if feature.enabled_for_form_ids.present?
-      raise FormRequiredError, "Feature #{feature_name} requires form to be provided" if form.blank?
-
-      return feature.enabled_for_form_ids == form.id if feature.enabled_for_form_ids.is_a?(Integer)
-
-      form_ids = feature.enabled_for_form_ids.split(",").collect(&:strip)
-
-      return form_ids.include?(form.id.to_s)
+      segments = feature_name.to_s.split(".")
+      segments.reduce(Settings.features) { |config, segment| config[segment] }
     end
-
-    feature.enabled
   end
 end

--- a/app/services/feature_service.rb
+++ b/app/services/feature_service.rb
@@ -4,7 +4,7 @@ class FeatureService
       return false if Settings.features.blank?
 
       segments = feature_name.to_s.split(".")
-      segments.reduce(Settings.features) { |config, segment| config[segment] }
+      Settings.features.dig(*segments)
     end
   end
 end

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -41,7 +41,7 @@ private
     end
 
     unless @form.submission_email.blank? && @preview_mode
-      if FeatureService.enabled?("csv_submission", @form)
+      if @form.submission_type == "email_with_csv"
         deliver_submission_email_with_csv_attachment_with_fallback
       else
         deliver_submission_email

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,9 +1,4 @@
 features:
-  csv_submission:
-    enabled: false
-    # this list of form IDs should only be populated via Terraform in forms-deploy, to avoid mistakenly
-    # enabling CSV submissions for unrelated forms in different environments
-    enabled_for_form_ids: ""
   api_v2: false
 
 forms_admin:

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -21,14 +21,7 @@ describe "Settings" do
   describe ".features" do
     features = settings[:features]
 
-    it "csv_submission has a default value" do
-      expect(features["csv_submission"]).to eq(
-        {
-          "enabled" => false,
-          "enabled_for_form_ids" => "",
-        },
-      )
-    end
+    include_examples expected_value_test, :api_v2, features, false
   end
 
   describe ".forms_api" do

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -18,6 +18,8 @@ FactoryBot.define do
     declaration_text { nil }
     declaration_section_completed { false }
 
+    submission_type { :email }
+
     trait :new_form do
       submission_email { nil }
       privacy_policy_url { nil }

--- a/spec/services/feature_service_spec.rb
+++ b/spec/services/feature_service_spec.rb
@@ -1,160 +1,52 @@
 require "rails_helper"
 
 describe FeatureService do
-  describe "#enabled?" do
-    subject :feature_service do
-      described_class
-    end
-
-    let(:form) { build :form, id: 123 }
-
-    context "when the feature key has a boolean value" do
-      context "when feature key has value true" do
-        before do
-          Settings.features[:some_feature] = true
-        end
-
-        it "is enabled" do
-          expect(feature_service).to be_enabled(:some_feature, form)
-        end
+  describe ".enabled?" do
+    context "when feature is enabled" do
+      before do
+        Settings.features[:some_feature] = true
       end
 
-      context "when feature key has value false" do
-        before do
-          Settings.features[:some_feature] = false
-        end
+      it "returns true" do
+        response = described_class.enabled?(:some_feature)
 
-        it "is not enabled" do
-          expect(feature_service).not_to be_enabled(:some_feature, form)
-        end
-      end
-
-      context "when empty features" do
-        before do
-          allow(Settings).to receive(:features).and_return(nil)
-        end
-
-        it "is not enabled" do
-          expect(feature_service).not_to be_enabled(:some_feature, form)
-        end
-      end
-
-      context "when nested features" do
-        before do
-          Settings.features[:some] = OpenStruct.new(nested_feature: true)
-        end
-
-        it "is enabled" do
-          expect(feature_service).to be_enabled("some.nested_feature")
-        end
+        expect(response).to be_truthy
       end
     end
 
-    context "when the feature key has an object value" do
-      context "when the enabled key exists and is set to true" do
-        before do
-          Settings.features[:some_feature] = Config::Options.new(enabled: true)
-        end
-
-        it "is enabled" do
-          expect(feature_service).to be_enabled(:some_feature, form)
-        end
-
-        context "and the feature is enabled for a specific form" do
-          before do
-            Settings.features[:some_feature] = Config::Options.new(enabled: true, enabled_for_form_ids: "123")
-          end
-
-          it "is enabled for the specific form" do
-            expect(feature_service).to be_enabled(:some_feature, form)
-          end
-
-          it "is enabled for other forms" do
-            other_form = build :form, id: 1234
-
-            expect(feature_service).to be_enabled(:some_feature, other_form)
-          end
-        end
+    context "when feature is disabled" do
+      before do
+        Settings.features[:some_feature] = false
       end
 
-      context "when the enabled key exists and is set to false" do
-        before do
-          Settings.features[:some_feature] = Config::Options.new(enabled: false)
-        end
+      it "returns false" do
+        response = described_class.enabled?(:some_feature)
 
-        it "is not enabled" do
-          expect(feature_service).not_to be_enabled(:some_feature, form)
-        end
+        expect(response).to be_falsey
+      end
+    end
 
-        context "and the feature is enabled for this specific form" do
-          before do
-            Settings.features[:some_feature] = Config::Options.new(enabled: false, enabled_for_form_ids: 123)
-          end
-
-          it "is enabled" do
-            expect(feature_service).to be_enabled(:some_feature, form)
-          end
-
-          context "but the form has not been provided to the service" do
-            it "raises an error" do
-              expect { feature_service.enabled?(:some_feature) }.to raise_error described_class::FormRequiredError
-            end
-          end
-        end
-
-        context "and the feature is enabled for a different form" do
-          before do
-            Settings.features[:some_feature] = Config::Options.new(enabled: false, enabled_for_form_ids: 122)
-          end
-
-          it "returns the value of the enabled flag" do
-            expect(feature_service).not_to be_enabled(:some_feature, form)
-          end
-        end
-
-        context "and the feature is enabled for multiple forms" do
-          before do
-            Settings.features[:some_feature] = Config::Options.new(enabled: false, enabled_for_form_ids: "122, 123")
-          end
-
-          it "returns the value of the enabled flag" do
-            other_form = build :form, id: 122
-
-            expect(feature_service).to be_enabled(:some_feature, other_form)
-            expect(feature_service).to be_enabled(:some_feature, form)
-          end
-        end
+    context "when empty features" do
+      before do
+        allow(Settings).to receive(:features).and_return(nil)
       end
 
-      context "when the enabled key does not exist" do
-        before do
-          Settings.features[:some_feature] = Config::Options.new
-        end
+      it "returns false" do
+        response = described_class.enabled?(:some_feature)
 
-        it "is not enabled" do
-          expect(feature_service).not_to be_enabled(:some_feature, form)
-        end
+        expect(response).to be_falsey
+      end
+    end
+
+    context "when nested features" do
+      before do
+        Settings.features[:some] = OpenStruct.new(nested_feature: true)
       end
 
-      context "when the enabled_for_form_ids array is empty" do
-        before do
-          Settings.features[:some_feature] = Config::Options.new(enabled: true, enabled_for_form_ids: "")
-        end
+      it "returns true" do
+        response = described_class.enabled?("some.nested_feature")
 
-        it "returns the value of the enabled flag" do
-          expect(feature_service).to be_enabled(:some_feature, form)
-        end
-      end
-
-      context "when the form does not have a form id set" do
-        before do
-          form.id = nil
-          Settings.features[:some_feature] = Config::Options.new(enabled: false, enabled_for_form_ids: "123")
-        end
-
-        it "returns the value of the enabled flag" do
-          expect(feature_service).not_to be_enabled(:some_feature, form)
-        end
+        expect(response).to be_truthy
       end
     end
   end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -65,7 +65,11 @@ RSpec.describe FormSubmissionService do
     end
 
     describe "sending the submission email" do
-      context "when send CSV feature is disabled", feature_csv_submission: false do
+      context "when the submission type is email" do
+        before do
+          form.submission_type = "email"
+        end
+
         it "calls FormSubmissionMailer" do
           freeze_time do
             allow(FormSubmissionMailer).to receive(:email_confirmation_input).and_call_original
@@ -101,7 +105,11 @@ RSpec.describe FormSubmissionService do
         end
       end
 
-      context "when send CSV feature is enabled", :feature_csv_submission do
+      context "when the submission type is email_with_csv" do
+        before do
+          form.submission_type = "email_with_csv"
+        end
+
         it "writes a CSV file" do
           service.submit
           expect(submission_csv_service_spy).to have_received(:write)


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/DQCipW8q

This PR refactors the form submission service to use the `submission_type` stored on the Form model instead of the per form CSV submission feature flag. Since the per form feature flagging is no longer needed and we recommend not using it in future, we've removed it from the feature service.

We'll remove associated terraform from forms-deploy in a subsequent PR.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
