### PR TITLE
Default to using v2 API in specs

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -11,7 +11,7 @@ class Form < ActiveResource::Base
   end
 
   def self.find(scope, **options)
-    if options[:from].blank?
+    if FeatureService.enabled?(:api_v2) || options[:from].blank?
       deprecator.warn "the /forms/:id endpoint will not return form documents in API v2"
     end
     super

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,3 +1,6 @@
+features:
+  api_v2: true
+
 forms_admin:
   # URL to form-admin
   base_url: http://localhost

--- a/lib/data_struct.rb
+++ b/lib/data_struct.rb
@@ -1,0 +1,9 @@
+# When an OpenStruct is converted to json, it inludes @table.
+# We inherit and overide as_json here to use to contain answer_settings, which
+# is a json hash converted into an object by ActiveResource. Using a plain hash
+# for answer_settings means there is no .access to attributes.
+class DataStruct < OpenStruct
+  def as_json(*args)
+    super.as_json["table"]
+  end
+end

--- a/spec/factories/models/pages.rb
+++ b/spec/factories/models/pages.rb
@@ -1,13 +1,3 @@
-# When an OpenStruct is converted to json, it inludes @table.
-# We inherit and overide as_json here to use to contain answer_settings, which
-# is a json hash converted into an object by ActiveResource. Using a plain hash
-# for answer_settings means there is no .access to attributes.
-class DataStruct < OpenStruct
-  def as_json(*args)
-    super.as_json["table"]
-  end
-end
-
 FactoryBot.define do
   factory :page, class: "Page" do
     id { Faker::Number.number(digits: 2) }

--- a/spec/factories/v2_form_document.rb
+++ b/spec/factories/v2_form_document.rb
@@ -1,0 +1,63 @@
+FactoryBot.define do
+  factory :v2_form_document, class: DataStruct do
+    form_id { Faker::Alphanumeric.alphanumeric(number: 8) }
+
+    sequence(:name) { |n| "Form #{n}" }
+    form_slug { name ? name.parameterize : nil }
+
+    steps { [] }
+
+    declaration_text { nil }
+    declaration_section_completed { false }
+    payment_url { nil }
+    privacy_policy_url { nil }
+    submission_email { nil }
+    submission_type { nil }
+    support_email { nil }
+    support_phone { nil }
+    support_url { nil }
+    support_url_text { nil }
+    question_section_completed { false }
+    what_happens_next_markdown { nil }
+
+    trait :with_steps do
+      transient do
+        steps_count { 5 }
+      end
+
+      steps do
+        Array.new(steps_count) { attributes_for(:v2_step) }
+      end
+
+      question_section_completed { true }
+    end
+
+    trait :with_privacy_policy_url do
+      privacy_policy_url { Faker::Internet.url host: "gov.uk" }
+    end
+
+    trait :with_submission_email do
+      submission_email { Faker::Internet.email domain: "example.gov.uk" }
+    end
+
+    trait :with_support do
+      support_email { Faker::Internet.email(domain: "example.gov.uk") }
+      support_phone { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
+      support_url { Faker::Internet.url(host: "gov.uk") }
+      support_url_text { Faker::Lorem.sentence(word_count: 1, random_words_to_add: 4) }
+    end
+
+    trait :ready_for_live do
+      with_steps
+      with_privacy_policy_url
+      with_submission_email
+      support_email { Faker::Internet.email(domain: "example.gov.uk") }
+      what_happens_next_markdown { "We usually respond to applications within 10 working days." }
+    end
+
+    trait :live? do
+      ready_for_live
+      live_at { Time.zone.now }
+    end
+  end
+end

--- a/spec/factories/v2_step.rb
+++ b/spec/factories/v2_step.rb
@@ -1,0 +1,72 @@
+FactoryBot.define do
+  factory :v2_step, class: DataStruct do
+    id { Faker::Number.number(digits: 2) }
+
+    sequence(:position) { |n| n }
+    next_step_id { nil }
+
+    routing_conditions { [] }
+
+    type { nil }
+    data { nil }
+
+    factory :v2_question_page_step do
+      type { "question_page" }
+
+      transient do
+        answer_type { "number" }
+        answer_settings { nil }
+
+        question_text { Faker::Lorem.question }
+
+        hint_text { nil }
+
+        guidance_markdown { nil }
+        page_heading { nil }
+
+        is_optional { false }
+        is_repeatable { false }
+      end
+
+      data do
+        DataStruct.new(
+          answer_settings:,
+          answer_type:,
+          guidance_markdown:,
+          hint_text:,
+          is_optional:,
+          is_repeatable:,
+          page_heading:,
+          question_text:,
+        )
+      end
+
+      trait :with_selections_settings do
+        transient do
+          only_one_option { "true" }
+          selection_options { [{ name: "Option 1" }, { name: "Option 2" }] }
+        end
+
+        answer_type { "selection" }
+        answer_settings { DataStruct.new(only_one_option:, selection_options:) }
+      end
+
+      trait :with_text_settings do
+        transient do
+          input_type { %w[single_line long_text].sample }
+        end
+
+        answer_type { "text" }
+        answer_settings do
+          DataStruct.new(
+            input_type:,
+          )
+        end
+      end
+
+      trait :with_repeatable do
+        is_repeatable { true }
+      end
+    end
+  end
+end

--- a/spec/features/email_confirmation_spec.rb
+++ b/spec/features/email_confirmation_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 feature "Email confirmation", type: :feature do
-  let(:pages) { [(build :page, :with_text_settings, id: 1, form_id: 1, routing_conditions: [], question_text:)] }
-  let(:form) { build :form, :live?, id: 1, name: "Apply for a juggling license", pages:, start_page: 1 }
+  let(:steps) { [build(:v2_question_page_step, :with_text_settings, id: 1, routing_conditions: [], question_text:)] }
+  let(:form) { build :v2_form_document, :live?, id: 1, name: "Apply for a juggling license", steps:, start_page: 1 }
   let(:question_text) { Faker::Lorem.question }
   let(:text_answer) { Faker::Lorem.sentence }
 
@@ -21,8 +21,7 @@ feature "Email confirmation", type: :feature do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
-      mock.get "/api/v1/forms/1/live", req_headers, form.to_json(include: [:pages]), 200
+      mock.get "/api/v2/forms/1/live", req_headers, form.to_json, 200
     end
   end
 

--- a/spec/features/email_confirmation_spec.rb
+++ b/spec/features/email_confirmation_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 feature "Email confirmation", type: :feature do
-  let(:pages) { [(build :page, :with_text_settings, id: 1, form_id: 1, routing_conditions: [])] }
+  let(:pages) { [(build :page, :with_text_settings, id: 1, form_id: 1, routing_conditions: [], question_text:)] }
   let(:form) { build :form, :live?, id: 1, name: "Apply for a juggling license", pages:, start_page: 1 }
+  let(:question_text) { Faker::Lorem.question }
   let(:text_answer) { Faker::Lorem.sentence }
 
   let(:req_headers) do
@@ -44,13 +45,13 @@ feature "Email confirmation", type: :feature do
 
   def fill_in_form
     visit form_path(mode: "form", form_id: 1, form_slug: "apply-for-a-juggling-licence")
-    expect(page.find("h1")).to have_text pages[0].question_text
+    expect(page.find("h1")).to have_text question_text
     expect_page_to_have_no_axe_errors(page)
 
-    fill_in pages[0].question_text, with: text_answer
+    fill_in question_text, with: text_answer
     click_button "Continue"
     expect(page.find("h1")).to have_text I18n.t("form.check_your_answers.title")
-    expect(page).to have_text pages[0].question_text
+    expect(page).to have_text question_text
     expect(page).to have_text text_answer
   end
 end

--- a/spec/features/fill_in_and_submit_form_spec.rb
+++ b/spec/features/fill_in_and_submit_form_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 feature "Fill in and submit a form", type: :feature do
-  let(:pages) { [(build :page, :with_text_settings, id: 1, form_id: 1, routing_conditions: [], question_text:)] }
-  let(:form) { build :form, :live?, id: 1, name: "Fill in this form", pages:, start_page: 1 }
+  let(:steps) { [(build :v2_question_page_step, :with_text_settings, id: 1, routing_conditions: [], question_text:)] }
+  let(:form) { build :v2_form_document, :live?, id: 1, name: "Fill in this form", steps:, start_page: 1 }
   let(:question_text) { Faker::Lorem.question }
   let(:answer_text) { "Answer text" }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
@@ -23,8 +23,7 @@ feature "Fill in and submit a form", type: :feature do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/1", req_headers, form.to_json, 200
-      mock.get "/api/v1/forms/1/live", req_headers, form.to_json(include: [:pages]), 200
+      mock.get "/api/v2/forms/1/live", req_headers, form.to_json, 200
     end
 
     allow(ReferenceNumberService).to receive(:generate).and_return(reference)

--- a/spec/features/fill_in_and_submit_form_spec.rb
+++ b/spec/features/fill_in_and_submit_form_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 feature "Fill in and submit a form", type: :feature do
-  let(:pages) { [(build :page, :with_text_settings, id: 1, form_id: 1, routing_conditions: [])] }
+  let(:pages) { [(build :page, :with_text_settings, id: 1, form_id: 1, routing_conditions: [], question_text:)] }
   let(:form) { build :form, :live?, id: 1, name: "Fill in this form", pages:, start_page: 1 }
-  let(:question_text) { pages[0].question_text }
+  let(:question_text) { Faker::Lorem.question }
   let(:answer_text) { "Answer text" }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 

--- a/spec/features/fill_in_single_repeatable_form_spec.rb
+++ b/spec/features/fill_in_single_repeatable_form_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 feature "Fill in and submit a form with a single repeatable question", type: :feature do
-  let(:pages) { [(build :page, :with_repeatable, answer_type: "number")] }
+  let(:pages) { [(build :page, :with_repeatable, answer_type: "number", question_text:)] }
   let(:form) { build :form, :live?, id: 42, name: "Form with repeating question", pages:, start_page: pages.first.id }
 
-  let(:question_text) { pages[0].question_text }
+  let(:question_text) { Faker::Lorem.question }
   let(:first_answer_text) { "99" }
   let(:second_answer_text) { "7" }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }

--- a/spec/features/fill_in_single_repeatable_form_spec.rb
+++ b/spec/features/fill_in_single_repeatable_form_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 feature "Fill in and submit a form with a single repeatable question", type: :feature do
-  let(:pages) { [(build :page, :with_repeatable, answer_type: "number", question_text:)] }
-  let(:form) { build :form, :live?, id: 42, name: "Form with repeating question", pages:, start_page: pages.first.id }
+  let(:steps) { [(build :v2_question_page_step, :with_repeatable, answer_type: "number", question_text:)] }
+  let(:form) { build :v2_form_document, :live?, id: 42, name: "Form with repeating question", steps:, start_page: steps.first.id }
 
   let(:question_text) { Faker::Lorem.question }
   let(:first_answer_text) { "99" }
@@ -25,8 +25,7 @@ feature "Fill in and submit a form with a single repeatable question", type: :fe
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/42", req_headers, form.to_json, 200
-      mock.get "/api/v1/forms/42/live", req_headers, form.to_json(include: [:pages]), 200
+      mock.get "/api/v2/forms/42/live", req_headers, form.to_json, 200
     end
 
     allow(ReferenceNumberService).to receive(:generate).and_return(reference)

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Form, type: :model do
+RSpec.describe Form, feature_api_v2: false, type: :model do
   let(:form) { described_class.find(1) }
   let(:response_data) { { id: 1, name: "form name", submission_email: "user@example.com", start_page: 1 } }
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Page, type: :model do
+RSpec.describe Page, feature_api_v2: false, type: :model do
   it "has a valid factory" do
     page = build :page
     expect(page).to be_valid

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ErrorsController, type: :request do
   describe "Submission error" do
     let(:form_data) do
       build(
-        :form,
+        :v2_form_document,
         :with_support,
         id: 2,
         name: "Form name",
@@ -45,8 +45,8 @@ RSpec.describe ErrorsController, type: :request do
         live_at: "2022-08-18 09:16:50 +0100",
         submission_email: "submission@email.com",
         start_page: 1,
-        pages: [
-          (build :page, id: 1, answer_type: "text", answer_settings: { input_type: "single_line" }),
+        steps: [
+          (build :v2_question_page_step, id: 1, answer_type: "text", answer_settings: { input_type: "single_line" }),
         ],
       )
     end
@@ -60,7 +60,7 @@ RSpec.describe ErrorsController, type: :request do
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/2/live", req_headers, form_data.to_json, 200
+        mock.get "/api/v2/forms/2/live", req_headers, form_data.to_json, 200
       end
 
       # setup the context in the session

--- a/spec/requests/forms/add_another_answer_controller_spec.rb
+++ b/spec/requests/forms/add_another_answer_controller_spec.rb
@@ -2,22 +2,22 @@ require "rails_helper"
 
 RSpec.describe Forms::AddAnotherAnswerController, type: :request do
   let(:form) do
-    build(:form, :with_support, id: 2, start_page: 1, pages:)
+    build(:v2_form_document, :with_support, id: 2, start_page: 1, steps:)
   end
 
-  let(:pages) { [first_page_in_form, second_page_in_form] }
+  let(:steps) { [first_step_in_form, second_step_in_form] }
 
-  let(:first_page_in_form) do
-    build :page,
+  let(:first_step_in_form) do
+    build :v2_question_page_step,
           :with_text_settings,
-          :with_repeatable,
           id: 1,
-          next_page: 2,
-          is_optional: false
+          next_step_id: 2,
+          is_optional: false,
+          is_repeatable: true
   end
 
-  let(:second_page_in_form) do
-    build :page, :with_text_settings, id: 2
+  let(:second_step_in_form) do
+    build :v2_question_page_step, :with_text_settings, id: 2
   end
 
   let(:req_headers) do
@@ -35,7 +35,7 @@ RSpec.describe Forms::AddAnotherAnswerController, type: :request do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/#{form.id}#{api_url_suffix}", req_headers, form.to_json, 200
+      mock.get "/api/v2/forms/#{form.id}#{api_url_suffix}", req_headers, form.to_json, 200
     end
 
     form_context = instance_double(Flow::FormContext)
@@ -46,24 +46,24 @@ RSpec.describe Forms::AddAnotherAnswerController, type: :request do
 
   describe "GET #show" do
     it "renders the show template" do
-      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer"
+      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/add-another-answer"
       expect(response).to render_template(:show)
     end
 
     it "assigns @rows" do
-      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer"
+      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/add-another-answer"
       expect(assigns(:rows).count).to eq 2
     end
 
     it "adds the change and remove links to each row" do
-      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer"
+      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/add-another-answer"
       expect(assigns(:rows).first[:actions].first[:text]).to eq("Change")
       expect(assigns(:rows).first[:actions].second[:text]).to eq("Remove")
-      expect(response.body).to include(form_remove_answer_path(form.id, form.form_slug, first_page_in_form.id, answer_index: 1, changing_existing_answer: nil))
+      expect(response.body).to include(form_remove_answer_path(form.id, form.form_slug, first_step_in_form.id, answer_index: 1, changing_existing_answer: nil))
     end
 
     it "initializes @add_another_answer_input" do
-      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer"
+      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/add-another-answer"
       expect(assigns(:add_another_answer_input)).to be_a(AddAnotherAnswerInput)
     end
   end
@@ -72,27 +72,27 @@ RSpec.describe Forms::AddAnotherAnswerController, type: :request do
     context "with valid params" do
       context "when adding another answer" do
         it "redirects to first page to add another" do
-          post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "yes" } }
-          expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/3")
+          post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "yes" } }
+          expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/3")
         end
       end
 
       context "when not adding another answer" do
         it "redirects to next page" do
-          post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "no" } }
-          expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{second_page_in_form.id}")
+          post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "no" } }
+          expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{second_step_in_form.id}")
         end
       end
     end
 
     context "with invalid params" do
       it "renders the show template" do
-        post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "" } }
+        post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "" } }
         expect(response).to render_template(:show)
       end
 
       it "assigns @rows" do
-        post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "" } }
+        post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "" } }
         expect(assigns(:rows).count).to be_present
       end
     end
@@ -101,7 +101,7 @@ RSpec.describe Forms::AddAnotherAnswerController, type: :request do
       let(:stored_answers) { Array.new(RepeatableStep::MAX_ANSWERS) { |i| { text: i.to_s } } }
 
       it "renders the show template with an error" do
-        post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "yes" } }
+        post "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/add-another-answer", params: { add_another_answer_input: { add_another_answer: "yes" } }
         expect(response).to render_template(:show)
         expect(response.body).to include("You cannot add another answer")
       end
@@ -111,13 +111,13 @@ RSpec.describe Forms::AddAnotherAnswerController, type: :request do
   describe "redirect_if_not_repeating" do
     context "when step is not RepeatableStep" do
       it "redirects to form_page when not changing existing answer" do
-        get "/preview-draft/#{form.id}/#{form.form_slug}/#{second_page_in_form.id}/add-another-answer"
-        expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{second_page_in_form.id}")
+        get "/preview-draft/#{form.id}/#{form.form_slug}/#{second_step_in_form.id}/add-another-answer"
+        expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{second_step_in_form.id}")
       end
 
       it "redirects to form_change_answer_path when changing existing answer" do
-        get "/preview-draft/#{form.id}/#{form.form_slug}/#{second_page_in_form.id}/add-another-answer/change"
-        expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{second_page_in_form.id}/change")
+        get "/preview-draft/#{form.id}/#{form.form_slug}/#{second_step_in_form.id}/add-another-answer/change"
+        expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{second_step_in_form.id}/change")
       end
     end
   end

--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -4,14 +4,17 @@ RSpec.describe Forms::BaseController, type: :request do
   let(:timestamp_of_request) { Time.utc(2022, 12, 14, 10, 0o0, 0o0) }
 
   let(:form_response_data) do
-    build(:form, :with_support,
-          id: 2,
-          live_at:,
-          start_page:,
-          privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
-          what_happens_next_markdown: "Good things come to those that wait",
-          declaration_text: "agree to the declaration",
-          pages: pages_data)
+    build(
+      :v2_form_document,
+      :with_support,
+      id: 2,
+      live_at:,
+      start_page:,
+      privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+      what_happens_next_markdown: "Good things come to those that wait",
+      declaration_text: "agree to the declaration",
+      steps: steps_data,
+    )
   end
   let(:start_page) { 1 }
   let(:live_at) { "2022-08-18 09:16:50 +0100" }
@@ -22,18 +25,18 @@ RSpec.describe Forms::BaseController, type: :request do
     }
   end
 
-  let(:pages_data) do
+  let(:steps_data) do
     [
-      (build :page,
-             id: 1,
-             next_page: 2,
-             answer_type: "text",
-             answer_settings: { input_type: "single_line" }
+      (attributes_for :v2_question_page_step,
+                      id: 1,
+                      next_page: 2,
+                      answer_type: "text",
+                      answer_settings: { input_type: "single_line" }
       ),
-      (build :page,
-             id: 2,
-             answer_type: "text",
-             answer_settings: { input_type: "single_line" }
+      (attributes_for :v2_question_page_step,
+                      id: 2,
+                      answer_type: "text",
+                      answer_settings: { input_type: "single_line" }
       ),
     ]
   end
@@ -56,8 +59,8 @@ RSpec.describe Forms::BaseController, type: :request do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2#{api_url_suffix}", req_headers, form_response_data.to_json, 200
-      mock.get "/api/v1/forms/9999#{api_url_suffix}", req_headers, no_data_found_response, 404
+      mock.get "/api/v2/forms/2#{api_url_suffix}", req_headers, form_response_data.to_json, 200
+      mock.get "/api/v2/forms/9999#{api_url_suffix}", req_headers, no_data_found_response, 404
     end
   end
 
@@ -122,7 +125,7 @@ RSpec.describe Forms::BaseController, type: :request do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
         allow(LogEventService).to receive(:log_form_start).at_least(:once)
-        mock.get "/api/v1/forms/2/live", req_headers, form_response_data.to_json, 200
+        mock.get "/api/v2/forms/2/live", req_headers, form_response_data.to_json, 200
       end
 
       get error_repeat_submission_path(mode: "form", form_id: 2, form_slug: form_response_data.form_slug)

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Good things come to those that wait",
           declaration_text: "agree to the declaration",
-          pages: pages_data)
+          pages: pages_data,
+          submission_email:)
   end
 
   let(:email_confirmation_input) do
@@ -20,6 +21,8 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       confirmation_email_reference:,
       submission_email_reference: }
   end
+
+  let(:submission_email) { Faker::Internet.email(domain: "example.gov.uk") }
 
   let(:store) do
     {
@@ -393,7 +396,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(deliveries.length).to eq 2
 
         mail = deliveries[0]
-        expect(mail.to).to eq [form_data.submission_email]
+        expect(mail.to).to eq [submission_email]
 
         expected_personalisation = {
           title: form_data.name,
@@ -441,7 +444,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         expect(deliveries.length).to eq 2
 
         mail = deliveries[0]
-        expect(mail.to).to eq [form_data.submission_email]
+        expect(mail.to).to eq [submission_email]
 
         expected_personalisation = {
           title: form_data.name,

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
   let(:timestamp_of_request) { Time.utc(2022, 12, 14, 10, 0o0, 0o0) }
 
   let(:form_data) do
-    build(:form, :with_support,
+    build(:v2_form_document, :with_support,
           id: 2,
           live_at:,
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Good things come to those that wait",
           declaration_text: "agree to the declaration",
-          pages: pages_data,
+          steps: steps_data,
           submission_email:)
   end
 
@@ -45,22 +45,28 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
   let(:live_at) { "2022-08-18 09:16:50 +0100" }
 
-  let(:pages_data) do
+  let(:steps_data) do
     [
       {
         id: 1,
         position: 1,
-        question_text: "Question one",
-        answer_type: "date",
-        next_page: 2,
-        is_optional: nil,
+        next_step_id: 2,
+        type: "question_page",
+        data: {
+          answer_type: "date",
+          is_optional: nil,
+          question_text: "Question one",
+        },
       },
       {
         id: 2,
         position: 2,
-        question_text: "Question two",
-        answer_type: "date",
-        is_optional: nil,
+        type: "question_page",
+        data: {
+          answer_type: "date",
+          is_optional: nil,
+          question_text: "Question two",
+        },
       },
     ]
   end
@@ -93,7 +99,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     allow(Lograge).to receive(:logger).and_return(logger)
 
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/2#{api_url_suffix}", req_headers, form_data.to_json, 200
+      mock.get "/api/v2/forms/2#{api_url_suffix}", req_headers, form_data.to_json, 200
     end
 
     allow(Flow::Context).to receive(:new).and_wrap_original do |original_method, *args|
@@ -159,31 +165,40 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       end
 
       context "when the form has a question that can be answered more than once" do
-        let(:pages_data) do
+        let(:steps_data) do
           [
             {
               id: 1,
               position: 1,
-              question_text: "Question one",
-              answer_type: "date",
-              next_page: 2,
-              is_optional: nil,
+              next_step_id: 2,
+              type: "question_page",
+              data: {
+                answer_type: "date",
+                is_optional: nil,
+                question_text: "Question one",
+              },
             },
             {
               id: 2,
               position: 2,
-              question_text: "Question two",
-              answer_type: "date",
-              next_page: 3,
-              is_optional: nil,
+              next_step_id: 3,
+              type: "question_page",
+              data: {
+                answer_type: "date",
+                is_optional: nil,
+                question_text: "Question two",
+              },
             },
             {
               id: 3,
               position: 3,
-              question_text: "Question three",
-              answer_type: "date",
-              is_optional: nil,
-              is_repeatable: true,
+              type: "question_page",
+              data: {
+                answer_type: "date",
+                is_optional: nil,
+                is_repeatable: true,
+                question_text: "Question three",
+              },
             },
           ]
         end
@@ -220,31 +235,40 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         end
 
         context "and that question is optional and has been skipped" do
-          let(:pages_data) do
+          let(:steps_data) do
             [
               {
                 id: 1,
                 position: 1,
-                question_text: "Question one",
-                answer_type: "date",
-                next_page: 2,
-                is_optional: nil,
+                next_step_id: 2,
+                type: "question_page",
+                data: {
+                  answer_type: "date",
+                  is_optional: nil,
+                  question_text: "Question one",
+                },
               },
               {
                 id: 2,
                 position: 2,
-                question_text: "Question two",
-                answer_type: "date",
-                next_page: 3,
-                is_optional: nil,
+                next_step_id: 3,
+                type: "question_page",
+                data: {
+                  answer_type: "date",
+                  is_optional: nil,
+                  question_text: "Question two",
+                },
               },
               {
                 id: 3,
                 position: 3,
-                question_text: "Question three",
-                answer_type: "date",
-                is_optional: true,
-                is_repeatable: true,
+                type: "question_page",
+                data: {
+                  answer_type: "date",
+                  is_optional: true,
+                  is_repeatable: true,
+                  question_text: "Question three",
+                },
               },
             ]
           end

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -235,12 +235,12 @@ RSpec.describe Forms::PageController, type: :request do
       let(:mode) { "preview-live" }
 
       let(:first_page_in_form) do
-        page_without_routing_condition = build(:page, :with_text_settings,
-                                               id: 1,
-                                               next_page: 2,
-                                               is_optional: false)
+        page_without_routing_conditions = attributes_for(:page, :with_text_settings,
+                                                         id: 1,
+                                                         next_page: 2,
+                                                         is_optional: false).except(:routing_conditions)
 
-        Page.new(page_without_routing_condition.attributes.except(:routing_conditions))
+        DataStruct.new(page_without_routing_conditions)
       end
 
       it "Returns a 200" do

--- a/spec/requests/forms/privacy_page_controller_spec.rb
+++ b/spec/requests/forms/privacy_page_controller_spec.rb
@@ -2,31 +2,37 @@ require "rails_helper"
 
 RSpec.describe Forms::PrivacyPageController, type: :request do
   let(:form_data) do
-    build(:form, :with_support,
+    build(:v2_form_document, :with_support,
           id: 2,
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Good things come to those that wait",
           declaration_text: "agree to the declaration",
-          pages: pages_data)
+          steps: steps_data)
   end
 
-  let(:pages_data) do
+  let(:steps_data) do
     [
       {
         id: 1,
         position: 1,
-        question_text: "Question one",
-        answer_type: "date",
-        next_page: 2,
-        is_optional: nil,
+        next_step_id: 2,
+        type: "question_page",
+        data: {
+          answer_type: "date",
+          is_optional: nil,
+          question_text: "Question one",
+        },
       },
       {
         id: 2,
         position: 2,
-        question_text: "Question two",
-        answer_type: "date",
-        is_optional: nil,
+        type: "question_page",
+        data: {
+          answer_type: "date",
+          is_optional: nil,
+          question_text: "Question two",
+        },
       },
     ]
   end
@@ -41,7 +47,7 @@ RSpec.describe Forms::PrivacyPageController, type: :request do
   describe "#show" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/2/draft", req_headers, form_data.to_json, 200
+        mock.get "/api/v2/forms/2/draft", req_headers, form_data.to_json, 200
       end
 
       get form_privacy_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug)

--- a/spec/requests/forms/remove_answer_controller_spec.rb
+++ b/spec/requests/forms/remove_answer_controller_spec.rb
@@ -2,24 +2,24 @@ require "rails_helper"
 
 RSpec.describe Forms::RemoveAnswerController, type: :request do
   let(:form) do
-    build(:form, :with_support, id: 2, start_page: 1, pages:)
+    build(:v2_form_document, :with_support, id: 2, start_page: 1, steps:)
   end
 
-  let(:pages) { [first_page_in_form, second_page_in_form] }
+  let(:steps) { [first_step_in_form, second_step_in_form] }
   let(:is_optional) { false }
   let(:remove_answer) { "yes" }
 
-  let(:first_page_in_form) do
-    build :page,
+  let(:first_step_in_form) do
+    build :v2_question_page_step,
           :with_text_settings,
           :with_repeatable,
           id: 1,
-          next_page: 2,
+          next_step_id: 2,
           is_optional:
   end
 
-  let(:second_page_in_form) do
-    build :page, :with_text_settings, id: 2
+  let(:second_step_in_form) do
+    build :v2_question_page_step, :with_text_settings, id: 2
   end
 
   let(:req_headers) do
@@ -37,7 +37,7 @@ RSpec.describe Forms::RemoveAnswerController, type: :request do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v1/forms/#{form.id}#{api_url_suffix}", req_headers, form.to_json, 200
+      mock.get "/api/v2/forms/#{form.id}#{api_url_suffix}", req_headers, form.to_json, 200
     end
 
     form_context = instance_double(Flow::FormContext)
@@ -49,12 +49,12 @@ RSpec.describe Forms::RemoveAnswerController, type: :request do
 
   describe "GET #show" do
     it "renders the show template" do
-      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/1/remove"
+      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/1/remove"
       expect(response).to render_template(:show)
     end
 
     it "initializes @remove_answer_input" do
-      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/1/remove"
+      get "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/1/remove"
       expect(assigns(:remove_answer_input)).to be_a(RemoveAnswerInput)
     end
   end
@@ -62,16 +62,16 @@ RSpec.describe Forms::RemoveAnswerController, type: :request do
   describe "DELETE #delete" do
     context "with valid params" do
       it "redirects to add another answer" do
-        delete "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/1/remove", params: { remove_answer_input: { remove_answer: } }
-        expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer")
+        delete "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/1/remove", params: { remove_answer_input: { remove_answer: } }
+        expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/add-another-answer")
       end
 
       context "when not removing answer" do
         let(:remove_answer) { "no" }
 
         it "redirects to add another answer" do
-          delete "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/1/remove", params: { remove_answer_input: { remove_answer: } }
-          expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/add-another-answer")
+          delete "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/1/remove", params: { remove_answer_input: { remove_answer: } }
+          expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/add-another-answer")
         end
       end
     end
@@ -80,7 +80,7 @@ RSpec.describe Forms::RemoveAnswerController, type: :request do
       let(:remove_answer) { "invalid" }
 
       it "renders the show template" do
-        delete "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/1/remove", params: { remove_answer_input: { remove_answer: } }
+        delete "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/1/remove", params: { remove_answer_input: { remove_answer: } }
         expect(response).to render_template(:show)
         expect(response).to have_http_status(:unprocessable_entity)
       end
@@ -91,8 +91,8 @@ RSpec.describe Forms::RemoveAnswerController, type: :request do
       let(:is_optional) { true }
 
       it "redirects to the next question page" do
-        delete "/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}/1/remove", params: { remove_answer_input: { remove_answer: } }
-        expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{first_page_in_form.id}")
+        delete "/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}/1/remove", params: { remove_answer_input: { remove_answer: } }
+        expect(response).to redirect_to("/preview-draft/#{form.id}/#{form.form_slug}/#{first_step_in_form.id}")
       end
     end
   end

--- a/spec/requests/forms/submitted_controller_spec.rb
+++ b/spec/requests/forms/submitted_controller_spec.rb
@@ -2,25 +2,25 @@ require "rails_helper"
 
 RSpec.describe Forms::SubmittedController, type: :request do
   let(:form_data) do
-    build(:form, :with_support,
+    build(:v2_form_document, :with_support,
           id: 2,
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Your application will be processed within a few days.\n\nContact us if you need to:\n\n-change the details of your application\n-cancel your application",
           declaration_text: "agree to the declaration",
-          pages: pages_data)
+          steps: steps_data)
   end
 
-  let(:pages_data) do
+  let(:steps_data) do
     [
-      build(:page,
+      build(:v2_question_page_step,
             id: 1,
             position: 1,
             question_text: "Question one",
             answer_type: "date",
-            next_page: 2,
+            next_step_id: 2,
             is_optional: nil),
-      build(:page,
+      build(:v2_question_page_step,
             id: 2,
             position: 2,
             question_text: "Question two",
@@ -58,7 +58,7 @@ RSpec.describe Forms::SubmittedController, type: :request do
   describe "#submitted" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v1/forms/2/draft", req_headers, form_data.to_json, 200
+        mock.get "/api/v2/forms/2/draft", req_headers, form_data.to_json, 200
       end
 
       post save_form_page_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: store[:answers]["2"]["1"] }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/OOYCWoTa/1779-8-change-forms-runner-to-use-v2-api <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Update our specs to use the v2 API where appropriate.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?