### PR TITLE
Support repeated answers in submission CSV

### DIFF
--- a/app/models/repeatable_step.rb
+++ b/app/models/repeatable_step.rb
@@ -85,6 +85,18 @@ class RepeatableStep < Step
     end
   end
 
+  def show_answer_in_csv
+    if questions.present?
+      header_values_hash = {}
+      questions.each.with_index(1) do |question, index|
+        question.show_answer_in_csv.each do |header, value|
+          header_values_hash["#{header} - Answer #{index}"] = value
+        end
+      end
+      header_values_hash
+    end
+  end
+
   def remove_answer(answer_index)
     questions.delete_at(answer_index - 1)
     if questions.empty?

--- a/spec/factories/models/question/text.rb
+++ b/spec/factories/models/question/text.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :text, class: "Question::Text" do
+    question_text { Faker::Lorem.question }
+    hint_text { nil }
+    is_optional { false }
+    page_heading { nil }
+    guidance_markdown { nil }
+    text { nil }
+
+    trait :with_answer do
+      text { Faker::Lorem.sentence }
+    end
+  end
+end

--- a/spec/factories/models/repeatable_steps.rb
+++ b/spec/factories/models/repeatable_steps.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :repeatable_step, class: "RepeatableStep" do
+    page { association :page }
+    sequence(:page_slug) { |n| "page-#{n}" }
+    sequence(:form_slug) { |n| "form-#{n}" }
+    form_id { 1 }
+    question { build(:full_name_question) }
+    next_page_slug { nil }
+
+    initialize_with { new(question:, page:, form_id:, form_slug:, next_page_slug:, page_slug:) }
+  end
+end

--- a/spec/factories/models/steps.rb
+++ b/spec/factories/models/steps.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :step, class: "Step" do
+    page { association :page }
+    sequence(:page_slug) { |n| "page-#{n}" }
+    sequence(:form_slug) { |n| "form-#{n}" }
+    form_id { 1 }
+    question { build(:full_name_question) }
+    next_page_slug { nil }
+
+    initialize_with { new(question:, page:, form_id:, form_slug:, next_page_slug:, page_slug:) }
+  end
+end

--- a/spec/models/repeatable_step_spec.rb
+++ b/spec/models/repeatable_step_spec.rb
@@ -155,6 +155,44 @@ RSpec.describe RepeatableStep, type: :model do
     end
   end
 
+  describe "#show_answer_in_csv" do
+    let(:first_question) { build :first_middle_last_name_question, question_text: "What is your name?" }
+    let(:second_question) { build :first_middle_last_name_question, question_text: "What is your name?" }
+
+    context "when the question has multiple attributes" do
+      before do
+        repeatable_step.questions = [first_question, second_question]
+      end
+
+      it "returns a hash of all answers with keys containing the answer numbers" do
+        # we convert to an array to test the ordering of the hash
+        expect(repeatable_step.show_answer_in_csv.to_a).to eq({
+          "What is your name? - First name - Answer 1" => first_question.first_name,
+          "What is your name? - Last name - Answer 1" => first_question.last_name,
+          "What is your name? - First name - Answer 2" => second_question.first_name,
+          "What is your name? - Last name - Answer 2" => second_question.last_name,
+        }.to_a)
+      end
+    end
+
+    context "when the question has a single attribute" do
+      let(:first_question) { build :text, :with_answer, question_text: "What is the meaning of life?" }
+      let(:second_question) { build :text, :with_answer, question_text: "What is the meaning of life?" }
+
+      before do
+        repeatable_step.questions = [first_question, second_question]
+      end
+
+      it "returns a hash of all answers with keys containing the answer numbers" do
+        # we convert to an array to test the ordering of the hash
+        expect(repeatable_step.show_answer_in_csv.to_a).to eq({
+          "What is the meaning of life? - Answer 1" => first_question.text,
+          "What is the meaning of life? - Answer 2" => second_question.text,
+        }.to_a)
+      end
+    end
+  end
+
   describe "#remove_answer" do
     let(:questions) { [first_question, second_question] }
     let(:first_question) { OpenStruct.new({ show_answer_in_email: "first answer" }) }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/n6Jpj46Q/1822-support-add-another-single-answer-into-csv-processor

When there is a repeated step in the completed form - i.e. when a question that allows multiple answers has been answered multiple times, include a column in the submission CSV for each repeated answer. The column header is suffixed by the answer index, like ' - Answer 1'.

For example,

'What is the meaning of life - Answer 1, What is the meaning of life - Answer 2'

When the question has separate attributes for different parts of the answer, like a name type question can, the suffix comes after the suffix for the attribute name.

For example,

'What is your name - First name - Answer 1, What is your name - Last name - Answer 1'

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
