### PR TITLE
Display optional questions in CSV

### DIFF
--- a/app/models/question/name.rb
+++ b/app/models/question/name.rb
@@ -54,7 +54,22 @@ module Question
     end
 
     def show_answer_in_csv
-      attributes_with_values.to_h { |attribute| ["#{question_text} - #{friendly_name_for_attribute(attribute)}", send(attribute)] }
+      header_values_hash = {}
+      if needs_title?
+        add_attribute_to_hash(:title, header_values_hash)
+      end
+
+      if is_full_name?
+        add_attribute_to_hash(:full_name, header_values_hash)
+      else
+        add_attribute_to_hash(:first_name, header_values_hash)
+        if include_middle_name?
+          add_attribute_to_hash(:middle_names, header_values_hash)
+        end
+        add_attribute_to_hash(:last_name, header_values_hash)
+      end
+
+      header_values_hash
     end
 
     def has_blank_values?(attribute)
@@ -73,6 +88,14 @@ module Question
 
     def attributes_with_values
       attribute_names.reject { |attribute| has_blank_values?(attribute) }
+    end
+
+    def add_attribute_to_hash(attribute, hash)
+      hash[csv_header_name_for_attribute(attribute)] = send(attribute).to_s
+    end
+
+    def csv_header_name_for_attribute(attribute)
+      "#{question_text} - #{friendly_name_for_attribute(attribute)}"
     end
   end
 end

--- a/app/models/question/phone_number.rb
+++ b/app/models/question/phone_number.rb
@@ -14,7 +14,7 @@ module Question
     validate :phone_number, :too_many_digits?
 
     def show_answer_in_csv
-      return {} if phone_number.blank?
+      return { question_text => "" } if phone_number.blank?
       # numbers containing non-numeric characters, or starting with a non-0 digit, shouldn't need additional processing
       return { question_text => phone_number } unless phone_number.match(/^0\d*$/)
 

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -30,8 +30,6 @@ module Question
     end
 
     def show_answer_in_csv
-      return {} if show_answer.blank?
-
       Hash[question_text, show_answer]
     end
 

--- a/spec/models/question/address_spec.rb
+++ b/spec/models/question/address_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Question::Address, type: :model do
         expect(question.show_answer).to eq ""
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash with an blank value for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
       end
     end
 
@@ -104,8 +104,8 @@ RSpec.describe Question::Address, type: :model do
           expect(question.show_answer).to eq ""
         end
 
-        it "returns an empty hash for show_answer_in_csv" do
-          expect(question.show_answer_in_csv).to eq({})
+        it "returns a hash with an blank value for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
         end
       end
 
@@ -163,8 +163,8 @@ RSpec.describe Question::Address, type: :model do
         expect(question.show_answer).to eq ""
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash with an blank value for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
       end
     end
 
@@ -214,8 +214,8 @@ RSpec.describe Question::Address, type: :model do
           expect(question.show_answer).to eq ""
         end
 
-        it "returns an empty hash for show_answer_in_csv" do
-          expect(question.show_answer_in_csv).to eq({})
+        it "returns a hash with an blank value for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
         end
       end
 

--- a/spec/models/question/date_spec.rb
+++ b/spec/models/question/date_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Question::Date, type: :model do
       expect(question.show_answer).to eq ""
     end
 
-    it "returns an empty hash for show_answer_in_csv" do
-      expect(question.show_answer_in_csv).to eq({})
+    it "returns a hash with an blank value for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
     end
   end
 
@@ -75,8 +75,8 @@ RSpec.describe Question::Date, type: :model do
       expect(question.errors[:date]).to include(I18n.t("activemodel.errors.models.question/date.attributes.date.invalid_date"))
     end
 
-    it "returns an empty hash for show_answer_in_csv" do
-      expect(question.show_answer_in_csv).to eq({})
+    it "returns a hash with an blank value for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
     end
   end
 

--- a/spec/models/question/email_spec.rb
+++ b/spec/models/question/email_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Question::Email, type: :model do
       expect(question.show_answer).to eq ""
     end
 
-    it "returns an empty hash for show_answer_in_csv" do
-      expect(question.show_answer_in_csv).to eq({})
+    it "returns a hash with an blank value for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
     end
   end
 
@@ -77,8 +77,8 @@ RSpec.describe Question::Email, type: :model do
       expect(question.show_answer).to eq ""
     end
 
-    it "returns an empty hash for show_answer_in_csv" do
-      expect(question.show_answer_in_csv).to eq({})
+    it "returns a hash with an blank value for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
     end
 
     context "when given a string with an @ symbol in" do

--- a/spec/models/question/name_spec.rb
+++ b/spec/models/question/name_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Question::Name, type: :model do
         expect(question.show_answer).to eq ""
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash containing a blank value for the full name field" do
+        expect(question.show_answer_in_csv).to eq({ "What is your name? - Full name" => "" })
       end
     end
 
@@ -82,8 +82,11 @@ RSpec.describe Question::Name, type: :model do
         expect(question.show_answer).to eq ""
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash containing a blank value for the first and last name fields" do
+        expect(question.show_answer_in_csv).to eq({
+          "What is your name? - First name" => "",
+          "What is your name? - Last name" => "",
+        })
       end
     end
 
@@ -105,8 +108,11 @@ RSpec.describe Question::Name, type: :model do
         expect(question.errors[:last_name]).to include(I18n.t("activemodel.errors.models.question/name.attributes.last_name.blank"))
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash with blank fields for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq({
+          "What is your name? - First name" => "",
+          "What is your name? - Last name" => "",
+        })
       end
     end
 
@@ -165,8 +171,12 @@ RSpec.describe Question::Name, type: :model do
         expect(question.show_answer).to eq ""
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash containing a blank value for the first, middle and last name fields" do
+        expect(question.show_answer_in_csv).to eq({
+          "What is your name? - First name" => "",
+          "What is your name? - Middle names" => "",
+          "What is your name? - Last name" => "",
+        })
       end
     end
 
@@ -231,8 +241,11 @@ RSpec.describe Question::Name, type: :model do
           expect(question.show_answer_in_email).to eq("Full name: #{name}")
         end
 
-        it "returns a hash with the full name for show_answer_in_csv" do
-          expect(question.show_answer_in_csv).to eq({ "#{question_text} - Full name" => name })
+        it "returns a hash with a blank value for the title and the full name for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq({
+            "#{question_text} - Title" => "",
+            "#{question_text} - Full name" => name,
+          })
         end
       end
 
@@ -289,6 +302,7 @@ RSpec.describe Question::Name, type: :model do
 
         it "returns a hash with the first and last name for show_answer_in_csv" do
           expect(question.show_answer_in_csv).to eq({
+            "#{question_text} - Title" => "",
             "#{question_text} - First name" => first_name,
             "#{question_text} - Last name" => last_name,
           })
@@ -323,7 +337,7 @@ RSpec.describe Question::Name, type: :model do
     end
 
     context "when the name question is in first, middle and last name format" do
-      let(:input_type) { "first_and_last_name" }
+      let(:input_type) { "first_middle_and_last_name" }
       let(:first_name) { Faker::Name.first_name }
       let(:middle_name) { "#{Faker::Name.middle_name} #{Faker::Name.middle_name}" }
       let(:last_name) { Faker::Name.last_name }
@@ -352,6 +366,7 @@ RSpec.describe Question::Name, type: :model do
 
         it "returns a hash with the first, middle and last name for show_answer_in_csv" do
           expect(question.show_answer_in_csv).to eq({
+            "#{question_text} - Title" => "",
             "#{question_text} - First name" => first_name,
             "#{question_text} - Middle names" => middle_name,
             "#{question_text} - Last name" => last_name,

--- a/spec/models/question/national_insurance_number_spec.rb
+++ b/spec/models/question/national_insurance_number_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Question::NationalInsuranceNumber, type: :model do
       expect(question.show_answer).to eq ""
     end
 
-    it "returns an empty hash for show_answer_in_csv" do
-      expect(question.show_answer_in_csv).to eq({})
+    it "returns a hash with an blank value for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
     end
   end
 
@@ -85,8 +85,8 @@ RSpec.describe Question::NationalInsuranceNumber, type: :model do
         expect(question.show_answer).to eq ""
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash with an blank value for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
       end
     end
 

--- a/spec/models/question/number_spec.rb
+++ b/spec/models/question/number_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Question::Number, type: :model do
       expect(question.show_answer).to eq ""
     end
 
-    it "returns an empty hash for show_answer_in_csv" do
-      expect(question.show_answer_in_csv).to eq({})
+    it "returns a hash with an blank value for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
     end
   end
 
@@ -102,8 +102,8 @@ RSpec.describe Question::Number, type: :model do
         expect(question.show_answer).to eq ""
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash with an blank value for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
       end
     end
 

--- a/spec/models/question/organisation_name_spec.rb
+++ b/spec/models/question/organisation_name_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Question::OrganisationName, type: :model do
       expect(question.show_answer).to eq ""
     end
 
-    it "returns an empty hash for show_answer_in_csv" do
-      expect(question.show_answer_in_csv).to eq({})
+    it "returns a hash with an blank value for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
     end
   end
 
@@ -77,8 +77,8 @@ RSpec.describe Question::OrganisationName, type: :model do
         expect(question.show_answer).to eq ""
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash with an blank value for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
       end
     end
 

--- a/spec/models/question/phone_number_spec.rb
+++ b/spec/models/question/phone_number_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe Question::PhoneNumber, type: :model do
       expect(question.show_answer).to eq ""
     end
 
-    it "returns an empty hash for show_answer_in_csv" do
-      expect(question.show_answer_in_csv).to eq({})
+    it "returns a hash with an blank value for show_answer_in_csv" do
+      expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
     end
   end
 
@@ -154,8 +154,8 @@ RSpec.describe Question::PhoneNumber, type: :model do
         expect(question.show_answer).to eq ""
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash with an blank value for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
       end
     end
 

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Question::Selection, type: :model do
         expect(question.show_answer).to eq ""
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash with an blank value for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
       end
     end
 
@@ -97,8 +97,8 @@ RSpec.describe Question::Selection, type: :model do
           expect(question.show_answer).to eq ""
         end
 
-        it "returns an empty hash for show_answer_in_csv" do
-          expect(question.show_answer_in_csv).to eq({})
+        it "returns a hash with an blank value for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
         end
       end
 
@@ -158,8 +158,8 @@ RSpec.describe Question::Selection, type: :model do
         expect(question.show_answer).to eq ""
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash with an blank value for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
       end
     end
 
@@ -216,8 +216,8 @@ RSpec.describe Question::Selection, type: :model do
           expect(question.show_answer).to eq ""
         end
 
-        it "returns an empty hash for show_answer_in_csv" do
-          expect(question.show_answer_in_csv).to eq({})
+        it "returns a hash with an blank value for show_answer_in_csv" do
+          expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
         end
       end
 

--- a/spec/models/question/text_spec.rb
+++ b/spec/models/question/text_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Question::Text, type: :model do
         expect(question.show_answer).to eq ""
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash with an blank value for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
       end
     end
 
@@ -83,8 +83,8 @@ RSpec.describe Question::Text, type: :model do
         expect(question.show_answer).to eq ""
       end
 
-      it "returns an empty hash for show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq({})
+      it "returns a hash with an blank value for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
       end
     end
 

--- a/spec/models/repeatable_step_spec.rb
+++ b/spec/models/repeatable_step_spec.rb
@@ -191,6 +191,16 @@ RSpec.describe RepeatableStep, type: :model do
         }.to_a)
       end
     end
+
+    context "when the question is optional and has no answers" do
+      let(:question) { build :text, is_optional: false }
+
+      it "returns a hash containing a key for the first answer with a blank value" do
+        expect(repeatable_step.show_answer_in_csv).to eq({
+          "#{question.question_text} - Answer 1" => "",
+        })
+      end
+    end
   end
 
   describe "#remove_answer" do

--- a/spec/services/submission_csv_service_spec.rb
+++ b/spec/services/submission_csv_service_spec.rb
@@ -35,6 +35,19 @@ RSpec.describe SubmissionCsvService do
       )
     end
 
+    context "when a question is optional and answer is not provided" do
+      let(:text_question) { build :text, question_text: "What is the meaning of life?", is_optional: true, text: nil }
+
+      it "writes submission to CSV file including blank column for unanswered optional question" do
+        expect(CSV.open(test_file.path).readlines).to eq(
+          [
+            ["Reference", "Submitted at", "What is the meaning of life?", "What is your name? - First name", "What is your name? - Last name"],
+            [submission_reference, "2022-09-14T08:00:00+01:00", "", name_question.first_name, name_question.last_name],
+          ],
+        )
+      end
+    end
+
     context "when there are repeated steps" do
       let(:name_question_repeated) { build :first_middle_last_name_question, question_text: "What is your name?" }
       let(:second_step) { build :repeatable_step, questions: [name_question, name_question_repeated] }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/n6Jpj46Q

This PR makes it so that we always include columns for optional questions in the submission CSV, with a blank value if they are unanswered.

For optional questions that can have multiple answers, if no answer is given, we want to include columns for the first answer, with the suffix " - Answer 1" and with blank value, to mirror what we do in the email.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
