### PR TITLE
Refactor Journey class to be easier to understand and extend

### DIFF
--- a/app/lib/flow/journey.rb
+++ b/app/lib/flow/journey.rb
@@ -1,4 +1,21 @@
 module Flow
+  ##
+  # This class represents the journey taken by a form filler through a form.
+  #
+  # For a simple form (with no routing) there is only one possible set of
+  # steps that a form filler can take, but for a form with routing there
+  # may be some pages that the form filler never sees.
+  #
+  # Journey#completed_steps is an array of the steps that the form filler has
+  # visited so far in the form, in the order defined by the form. If their
+  # answer to a question page step causes a routing rule to be applied, for
+  # instance by skipping over the next two questions, only the questions in the
+  # resulting route are included.
+  #
+  # Note: the completed_steps array is ordered, from start to last step
+  # answered; if the form filler has not yet visited the forms first page the
+  # array will be empty.
+
   class Journey
     include Enumerable
 
@@ -12,8 +29,11 @@ module Flow
 
   private
 
-    def find_existing_step(page_slug)
+    def find_completed_step(page_slug)
       step = @step_factory.create_step(page_slug)
+
+      # A step has been completed if it is a question page that has been answered.
+      # We also need to load the answer into the step for next_page_with_routing to give the correct result.
       step.load_from_context(@form_context) unless @form_context.get_stored_answer(step).nil?
     rescue ActiveModel::UnknownAttributeError, ArgumentError
       @form_context.clear_stored_answer(step)
@@ -22,7 +42,7 @@ module Flow
 
     def generate_completed_steps
       @completed_steps = []
-      current_step = find_existing_step(:_start)
+      current_step = find_completed_step(:_start)
 
       while current_step
         next_page_slug = current_step.next_page_slug_after_routing
@@ -34,7 +54,7 @@ module Flow
 
         break if next_page_slug.nil?
 
-        current_step = find_existing_step(next_page_slug)
+        current_step = find_completed_step(next_page_slug)
       end
     end
   end

--- a/app/lib/flow/journey.rb
+++ b/app/lib/flow/journey.rb
@@ -22,37 +22,58 @@ module Flow
     def initialize(form_context:, step_factory:)
       @form_context = form_context
       @step_factory = step_factory
-      generate_completed_steps
+      @completed_steps = generate_completed_steps
     end
 
   private
 
-    def find_completed_step(page_slug)
-      step = @step_factory.create_step(page_slug)
-
+    def step_is_completed?(question_page_step)
       # A step has been completed if it is a question page that has been answered.
-      # We also need to load the answer into the step for next_page_with_routing to give the correct result.
-      step.load_from_context(@form_context) unless @form_context.get_stored_answer(step).nil?
-    rescue ActiveModel::UnknownAttributeError, ArgumentError
-      @form_context.clear_stored_answer(step)
-      nil
+      question_page_step.question.answered?
     end
 
     def generate_completed_steps
-      @completed_steps = []
-      current_step = find_completed_step(:_start)
+      each_step_with_routing.take_while do |step|
+        step_is_completed?(step)
+      end
+    end
 
-      while current_step
-        next_page_slug = current_step.next_page_slug_after_routing
+    def each_step_with_routing
+      current_step = @step_factory.create_step(:_start)
+      visited_page_slugs = []
 
-        # Prevent infinite loop if a route goes back on itself
-        break if @completed_steps.map(&:page_slug).include?(next_page_slug)
+      Enumerator.new do |yielder|
+        loop do
+          break if current_step.nil?
+          break if current_step.is_a? CheckYourAnswersStep # CheckYourAnswers step signals end of steps
 
-        @completed_steps << current_step
+          # We need to load the answer into the step for next_page_with_routing to give the correct result.
+          current_step = safe_load_from_context(current_step)
 
-        break if next_page_slug.nil?
+          next_page_slug = current_step.next_page_slug_after_routing
 
-        current_step = find_completed_step(next_page_slug)
+          # Prevent infinite loop if a route goes back on itself
+          break if visited_page_slugs.include?(next_page_slug)
+
+          yielder << current_step
+          visited_page_slugs << current_step.page_slug
+
+          break if next_page_slug.nil?
+
+          current_step = @step_factory.create_step(next_page_slug)
+        end
+      end
+    end
+
+    def safe_load_from_context(step)
+      return step unless step.respond_to? :load_from_context # step may be a CheckYourAnswersStep without load_from_context method
+
+      original_step = step.deep_dup # load_from_context method for RepeatableStep can fail with data half loaded
+
+      begin
+        step.load_from_context(@form_context)
+      rescue ActiveModel::UnknownAttributeError, ArgumentError
+        original_step
       end
     end
   end

--- a/app/lib/flow/journey.rb
+++ b/app/lib/flow/journey.rb
@@ -17,8 +17,6 @@ module Flow
   # array will be empty.
 
   class Journey
-    include Enumerable
-
     attr_reader :completed_steps
 
     def initialize(form_context:, step_factory:)

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -21,6 +21,10 @@ module Question
       attribute_names.index_with { |_k| nil }
     end
 
+    def answered?
+      @attributes.to_hash.any? { |_key, value| !value.nil? }
+    end
+
     def show_answer
       attribute_names.map { |attribute| send(attribute) }.reject(&:blank?)&.join(", ")
     end

--- a/spec/lib/flow/journey_spec.rb
+++ b/spec/lib/flow/journey_spec.rb
@@ -53,6 +53,10 @@ RSpec.describe Flow::Journey do
       it "includes only the pages that have been completed" do
         expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey].to_json
       end
+
+      it "includes the answer data in the question pages" do
+        expect(journey.completed_steps.map(&:question)).to all be_answered
+      end
     end
 
     context "when there is a gap in the pages that have been completed" do
@@ -68,6 +72,10 @@ RSpec.describe Flow::Journey do
 
       it "includes all pages" do
         expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
+      end
+
+      it "includes the answer data in the question pages" do
+        expect(journey.completed_steps.map(&:question)).to all be_answered
       end
     end
 
@@ -119,6 +127,10 @@ RSpec.describe Flow::Journey do
           expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
         end
 
+        it "includes the answer data in the question pages" do
+          expect(journey.completed_steps.map(&:question)).to all be_answered
+        end
+
         context "and the repeatable question has been answered more than once" do
           let(:store) { { answers: { "2" => { "1" => { selection: "Option 2" }, "2" => [{ text: "Example text" }, { text: "Different example text" }], "3" => { text: "More example text" } } } } }
 
@@ -145,6 +157,10 @@ RSpec.describe Flow::Journey do
           expect(journey.completed_steps.to_json).to eq [first_step_in_journey, third_step_in_journey].to_json
         end
 
+        it "includes the answer data in the question pages" do
+          expect(journey.completed_steps.map(&:question)).to all be_answered
+        end
+
         context "when there are answers to questions not in the matched route" do
           let(:store) { { answers: { "2" => { "1" => { selection: "Option 1" }, "2" => { text: "Example text" }, "3" => { text: "More example text" } } } } }
 
@@ -160,6 +176,10 @@ RSpec.describe Flow::Journey do
 
       it "includes only pages before the answer with the wrong type" do
         expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey].to_json
+      end
+
+      it "includes the answer data in the question pages" do
+        expect(journey.completed_steps.map(&:question)).to all be_answered
       end
     end
 

--- a/spec/lib/flow/journey_spec.rb
+++ b/spec/lib/flow/journey_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Flow::Journey do
+  subject(:journey) { described_class.new(form_context:, step_factory:) }
+
   let(:store) { {} }
   let(:form_context) { Flow::FormContext.new(store) }
   let(:step_factory) { Flow::StepFactory.new(form:) }
-  let(:journey) { described_class.new(form_context:, step_factory:) }
 
   let(:form) do
     build(:form, :with_support,
@@ -39,42 +40,44 @@ RSpec.describe Flow::Journey do
   let(:second_step_in_journey) { step_factory.create_step(second_page_in_form.id.to_s).load_from_context(form_context) }
   let(:third_step_in_journey) { step_factory.create_step(third_page_in_form.id.to_s).load_from_context(form_context) }
 
-  context "when no pages have been completed" do
-    it "completed_steps is empty" do
-      expect(journey.completed_steps).to eq []
-    end
-  end
-
-  context "when all pages have been completed" do
-    let(:store) { { answers: { "2" => { "1" => { selection: "Option 2" }, "2" => { text: "Example text" }, "3" => { text: "More example text" } } } } }
-
-    it "completed_steps includes all pages" do
-      expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
-    end
-  end
-
-  context "when page has a cannot_have_goto_page_before_routing_page error" do
-    let(:validation_errors) { [{ name: "cannot_have_goto_page_before_routing_page" }] }
-
-    let(:first_page_in_form) do
-      build :page, :with_text_settings,
-            id: 1,
-            next_page: 2
+  describe "#completed_steps" do
+    context "when no pages have been completed" do
+      it "is empty" do
+        expect(journey.completed_steps).to eq []
+      end
     end
 
-    let(:second_page_in_form) do
-      build :page, :with_selections_settings,
-            id: 2,
-            next_page: 3,
-            routing_conditions: [DataStruct.new(id: 1, routing_page_id: 2, check_page_id: 2, goto_page_id: 1, answer_value: "Option 1", validation_errors:)],
-            is_optional: false
+    context "when all pages have been completed" do
+      let(:store) { { answers: { "2" => { "1" => { selection: "Option 2" }, "2" => { text: "Example text" }, "3" => { text: "More example text" } } } } }
+
+      it "includes all pages" do
+        expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
+      end
     end
 
-    let(:store) { { answers: { "2" => { "1" => { text: "Example text" }, "2" => { selection: second_page_in_form.routing_conditions.first.answer_value }, "3" => { text: "More example text" } } } } }
-    let(:pages_data) { [first_page_in_form, second_page_in_form, third_page_in_form] }
+    context "when page has a cannot_have_goto_page_before_routing_page error" do
+      let(:validation_errors) { [{ name: "cannot_have_goto_page_before_routing_page" }] }
 
-    it "stops generating the completed_steps when it reaches the question with the error" do
-      expect(journey.completed_steps.to_json).to eq [first_step_in_journey].to_json
+      let(:first_page_in_form) do
+        build :page, :with_text_settings,
+              id: 1,
+              next_page: 2
+      end
+
+      let(:second_page_in_form) do
+        build :page, :with_selections_settings,
+              id: 2,
+              next_page: 3,
+              routing_conditions: [DataStruct.new(id: 1, routing_page_id: 2, check_page_id: 2, goto_page_id: 1, answer_value: "Option 1", validation_errors:)],
+              is_optional: false
+      end
+
+      let(:store) { { answers: { "2" => { "1" => { text: "Example text" }, "2" => { selection: second_page_in_form.routing_conditions.first.answer_value }, "3" => { text: "More example text" } } } } }
+      let(:pages_data) { [first_page_in_form, second_page_in_form, third_page_in_form] }
+
+      it "stops generating the completed_steps when it reaches the question with the error" do
+        expect(journey.completed_steps.to_json).to eq [first_step_in_journey].to_json
+      end
     end
   end
 end

--- a/spec/models/question/question_base_spec.rb
+++ b/spec/models/question/question_base_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Question::QuestionBase do
+  describe "#answered?" do
+    context "when question class has a single answer attribute" do
+      let(:question_class) do
+        Class.new(described_class) do
+          attribute :answer
+        end
+      end
+
+      it "returns false if question does not have answer data" do
+        expect(question_class.new).not_to be_answered
+      end
+
+      it "returns true if question has answer data" do
+        expect(question_class.new(answer: "Yes")).to be_answered
+      end
+
+      it "returns true if question has been answered with blank answer" do
+        expect(question_class.new(answer: "")).to be_answered
+      end
+    end
+
+    context "when question class has more than one answer attribute" do
+      let(:question_class) do
+        Class.new(described_class) do
+          attribute :part1
+          attribute :part2
+        end
+      end
+
+      it "returns true if question has answer data" do
+        expect(question_class.new(part1: "Hello", part2: "World")).to be_answered
+      end
+
+      it "returns true if question has partial answer data" do
+        expect(question_class.new(part1: "Hello")).to be_answered
+      end
+
+      it "returns true if question has been answered with blank answer" do
+        expect(question_class.new(part1: "", part2: "")).to be_answered
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/mOvI9EEw/43-allow-form-preview-to-skip-to-a-specific-question <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

As part of firebreak, I ended up having to play around with the `Journey` class that we use to hold the steps that a form filler has followed while filling out a form.

I wanted to create a subclass that tweaked the behaviour slightly, but I found this class a bit hard to wrap my head around, with a lot of tight logic wrapped up into one method.

This PR does a big refactor with the aim of making the class easier to understand (at least, I think it is easier to understand now). I also added some comments trying to explain what I think the class is for. I also added a bunch more tests, so I could feel confident that the refactor retained the essential behaviour.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated