### PR TITLE
Change Step to keep a reference to its associated models

### DIFF
--- a/app/lib/flow/step_factory.rb
+++ b/app/lib/flow/step_factory.rb
@@ -27,7 +27,7 @@ module Flow
       next_page_slug = page.has_next_page? ? page.next_page.to_s : CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG
       question = QuestionRegister.from_page(page)
 
-      step_class(page).new(question:, page:, form_id: @form.id, form_slug: @form.form_slug, next_page_slug:, page_slug:)
+      step_class(page).new(question:, page:, form: @form, next_page_slug:, page_slug:)
     end
 
     def start_step

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,19 +1,37 @@
 class Step
-  attr_accessor :page_id, :form_id, :form_slug, :question
-  attr_reader :next_page_slug, :page_slug, :page_number, :routing_conditions
+  attr_accessor :page, :form, :question
+  attr_reader :next_page_slug, :page_slug
 
-  def initialize(question:, page:, form_id:, form_slug:, next_page_slug:, page_slug:)
+  def initialize(form:, page:, question:, next_page_slug:, page_slug:)
+    @form = form
+    @page = page
     @question = question
-    @page_id = page.id
-    @page_slug = page_slug
-    @form_id = form_id
-    @form_slug = form_slug
+
     @next_page_slug = next_page_slug
-    @page_number = page.position
-    @routing_conditions = page.respond_to?(:routing_conditions) ? page.routing_conditions : []
+    @page_slug = page_slug
   end
 
   alias_attribute :id, :page_id
+
+  def form_id
+    form&.id
+  end
+
+  def form_slug
+    form&.form_slug
+  end
+
+  def page_id
+    page&.id
+  end
+
+  def page_number
+    page&.position
+  end
+
+  def routing_conditions
+    page.respond_to?(:routing_conditions) ? page.routing_conditions : []
+  end
 
   def ==(other)
     other.class == self.class && other.state == state

--- a/spec/factories/models/repeatable_steps.rb
+++ b/spec/factories/models/repeatable_steps.rb
@@ -1,12 +1,11 @@
 FactoryBot.define do
   factory :repeatable_step, class: "RepeatableStep" do
+    form { association :form, pages: [page] }
     page { association :page }
     sequence(:page_slug) { |n| "page-#{n}" }
-    sequence(:form_slug) { |n| "form-#{n}" }
-    form_id { 1 }
     question { build(:full_name_question) }
     next_page_slug { nil }
 
-    initialize_with { new(question:, page:, form_id:, form_slug:, next_page_slug:, page_slug:) }
+    initialize_with { new(question:, page:, form:, next_page_slug:, page_slug:) }
   end
 end

--- a/spec/factories/models/steps.rb
+++ b/spec/factories/models/steps.rb
@@ -1,12 +1,11 @@
 FactoryBot.define do
   factory :step, class: "Step" do
+    form { association :form, pages: [page] }
     page { association :page }
     sequence(:page_slug) { |n| "page-#{n}" }
-    sequence(:form_slug) { |n| "form-#{n}" }
-    form_id { 1 }
     question { build(:full_name_question) }
     next_page_slug { nil }
 
-    initialize_with { new(question:, page:, form_id:, form_slug:, next_page_slug:, page_slug:) }
+    initialize_with { new(question:, page:, form:, next_page_slug:, page_slug:) }
   end
 end

--- a/spec/models/repeatable_step_spec.rb
+++ b/spec/models/repeatable_step_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe RepeatableStep, type: :model do
-  subject(:repeatable_step) { described_class.new(question:, page:, form_id: 1, form_slug: "form-slug", next_page_slug: 2, page_slug: page.id) }
+  subject(:repeatable_step) { described_class.new(question:, page:, form:, next_page_slug: 2, page_slug: page.id) }
 
-  let(:question) { build :name, is_optional: false }
+  let(:form) { build :form, id: 1, form_slug: "form-slug", pages: [page, build(:page, id: 2)] }
   let(:page) { build :page }
+  let(:question) { build :name, is_optional: false }
 
   describe "#repeatable?" do
     it "returns true" do

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe Step do
     described_class.new(
       question:,
       page:,
-      form_id: 3,
-      form_slug: "test-form",
+      form:,
       next_page_slug: "next-page",
       page_slug: "current-page",
     )
@@ -15,6 +14,7 @@ RSpec.describe Step do
   let(:question) { instance_double(Question::Text, serializable_hash: {}, attribute_names: %w[name], valid?: true) }
   let(:page) { build(:page, id: 2, position: 1, routing_conditions: []) }
   let(:form_context) { instance_double(Flow::FormContext) }
+  let(:form) { build(:form, id: 3, form_slug: "test-form", pages: [page]) }
 
   describe "#initialize" do
     it "sets the attributes correctly" do
@@ -34,8 +34,7 @@ RSpec.describe Step do
       other_step = described_class.new(
         question:,
         page:,
-        form_id: 3,
-        form_slug: "test-form",
+        form:,
         next_page_slug: "next-page",
         page_slug: "current-page",
       )
@@ -43,11 +42,11 @@ RSpec.describe Step do
     end
 
     it "returns false for steps with different states" do
+      form = build :form, id: 4, form_slug: "other-form"
       other_step = described_class.new(
         question:,
         page:,
-        form_id: 4,
-        form_slug: "other-form",
+        form:,
         next_page_slug: "other-page",
         page_slug: "other-current-page",
       )
@@ -58,14 +57,11 @@ RSpec.describe Step do
   describe "#state" do
     it "returns an array of instance variable values" do
       expected_state = [
+        step.form,
+        step.page,
         step.question,
-        step.page_id,
-        step.page_slug,
-        step.form_id,
-        step.form_slug,
         step.next_page_slug,
-        step.page_number,
-        step.routing_conditions,
+        step.page_slug,
       ]
 
       expect(step.state).to match_array(expected_state)
@@ -73,7 +69,7 @@ RSpec.describe Step do
 
     it "changes when an instance variable is modified" do
       original_state = step.state.dup
-      step.form_id = "new_form_id"
+      step.form = build :form, pages: [step.page]
       expect(step.state).not_to eq(original_state)
     end
   end
@@ -120,7 +116,7 @@ RSpec.describe Step do
   describe "#end_page?" do
     context "when next_page_slug is nil" do
       subject(:step) do
-        described_class.new(question:, page:, form_id: 3, form_slug: "test-form", next_page_slug: nil, page_slug: "current-page")
+        described_class.new(question:, page:, form:, next_page_slug: nil, page_slug: "current-page")
       end
 
       it { is_expected.to be_end_page }


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Steps belong to forms and have a page. Currently we keep the IDs of these associated objects as attributes in a step, along with some other bits of data from those records that we need, but this isn't super helpful if we need other details about those other objects.

Given that in forms-runner we will always fetch the form and build the question before instantiating a step, we can just keep references as an instance attribute, with little downside.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?