### PR TITLE
Implement submission to s3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem "lograge"
 # For AWS interactions
 gem "aws-sdk-cloudwatch"
 gem "aws-sdk-codepipeline", "~> 1.88"
+gem "aws-sdk-s3"
 
 # For sending submissions as CSV
 gem "csv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,13 @@ GEM
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.9)
       jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.88.0)
+      aws-sdk-core (~> 3, >= 3.201.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.158.0)
+      aws-sdk-core (~> 3, >= 3.201.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
     aws-sigv4 (1.10.0)
       aws-eventstream (~> 1, >= 1.0.2)
     axe-core-api (4.10.1)
@@ -440,6 +447,7 @@ DEPENDENCIES
   activeresource
   aws-sdk-cloudwatch
   aws-sdk-codepipeline (~> 1.88)
+  aws-sdk-s3
   axe-core-rspec
   bootsnap
   brakeman (~> 6.2)

--- a/app/services/csv_submission_service.rb
+++ b/app/services/csv_submission_service.rb
@@ -1,7 +1,7 @@
 require "csv"
 require "tempfile"
 
-class SubmissionCsvService
+class CsvSubmissionService
   def initialize(current_context:, submission_reference:, timestamp:, output_file_path:)
     @current_context = current_context
     @submission_reference = submission_reference

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -91,7 +91,7 @@ private
 
   def deliver_submission_email_with_csv_attachment
     Tempfile.create do |file|
-      SubmissionCsvService.new(
+      CsvSubmissionService.new(
         current_context: @current_context,
         submission_reference: @submission_reference,
         timestamp: @timestamp,

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -39,16 +39,20 @@ private
     if @form.submission_type == "s3"
       upload_submission_csv_to_s3
     else
-      if !@preview_mode && @form.submission_email.blank?
-        raise StandardError, "Form id(#{@form.id}) is missing a submission email address"
-      end
+      submit_form_with_email_submission_type
+    end
+  end
 
-      unless @form.submission_email.blank? && @preview_mode
-        if @form.submission_type == "email_with_csv"
-          deliver_submission_email_with_csv_attachment_with_fallback
-        else
-          deliver_submission_email
-        end
+  def submit_form_with_email_submission_type
+    if !@preview_mode && @form.submission_email.blank?
+      raise StandardError, "Form id(#{@form.id}) is missing a submission email address"
+    end
+
+    unless @form.submission_email.blank? && @preview_mode
+      if @form.submission_type == "email_with_csv"
+        deliver_submission_email_with_csv_attachment_with_fallback
+      else
+        deliver_submission_email
       end
     end
   end

--- a/app/services/s3_submission_service.rb
+++ b/app/services/s3_submission_service.rb
@@ -5,6 +5,9 @@ class S3SubmissionService
                  s3_bucket_aws_account_id:,
                  timestamp:,
                  submission_reference:)
+    raise ArgumentError, "s3_bucket_name cannot be nil" if s3_bucket_name.nil?
+    raise ArgumentError, "s3_bucket_aws_account_id cannot be nil" if s3_bucket_aws_account_id.nil?
+
     @file_path = file_path
     @form_id = form_id
     @bucket = s3_bucket_name

--- a/app/services/s3_submission_service.rb
+++ b/app/services/s3_submission_service.rb
@@ -1,0 +1,45 @@
+class S3SubmissionService
+  def initialize(file_path:,
+                 form_id:,
+                 s3_bucket_name:,
+                 s3_bucket_aws_account_id:,
+                 timestamp:,
+                 submission_reference:)
+    @file_path = file_path
+    @form_id = form_id
+    @bucket = s3_bucket_name
+    @expected_bucket_owner = s3_bucket_aws_account_id
+    @timestamp = timestamp
+    @submission_reference = submission_reference
+  end
+
+  def upload_file_to_s3
+    s3 = Aws::S3::Client.new(
+      credentials: assume_role,
+    )
+    s3.put_object({
+      body: File.read(@file_path),
+      bucket: @bucket,
+      expected_bucket_owner: @expected_bucket_owner,
+      key: key_name,
+    })
+    Rails.logger.info("Uploaded submission to S3", { key_name: })
+  end
+
+private
+
+  def assume_role
+    role_session_name = "forms-runner-#{@submission_reference}"
+    credentials = Aws::AssumeRoleCredentials.new(
+      client: Aws::STS::Client.new,
+      role_arn: Settings.aws_s3_submissions.iam_role_arn,
+      role_session_name:,
+    )
+    Rails.logger.info "Assumed S3 role", { role_session_name: }
+    credentials
+  end
+
+  def key_name
+    "form_submission/#{@form_id}_#{@timestamp}_#{@submission_reference}.csv"
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,6 +24,9 @@ sentry:
   environment: local
   filter_mask: "[Filtered (client-side)]"
 
+aws_s3_submissions:
+  iam_role_arn: changeme
+
 maintenance_mode:
   # When set to true, All pages will render 'Maintenance mode' message
   enabled: false

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -20,6 +20,9 @@ FactoryBot.define do
 
     submission_type { :email }
 
+    s3_bucket_name { nil }
+    s3_bucket_aws_account_id { nil }
+
     trait :new_form do
       submission_email { nil }
       privacy_policy_url { nil }

--- a/spec/services/csv_submission_service_spec.rb
+++ b/spec/services/csv_submission_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe SubmissionCsvService do
+RSpec.describe CsvSubmissionService do
   subject(:service) { described_class.new(current_context:, submission_reference:, timestamp:, output_file_path: test_file.path) }
 
   let(:form) { build :form, id: 1 }

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -48,11 +48,11 @@ RSpec.describe FormSubmissionService do
   end
 
   describe "#submit" do
-    let(:submission_csv_service_spy) { instance_double(SubmissionCsvService) }
+    let(:csv_submission_service_spy) { instance_double(CsvSubmissionService) }
 
     before do
-      allow(SubmissionCsvService).to receive(:new).and_return submission_csv_service_spy
-      allow(submission_csv_service_spy).to receive(:write)
+      allow(CsvSubmissionService).to receive(:new).and_return csv_submission_service_spy
+      allow(csv_submission_service_spy).to receive(:write)
     end
 
     it "returns the submission reference" do
@@ -88,7 +88,7 @@ RSpec.describe FormSubmissionService do
 
         it "does not write a CSV file" do
           service.submit
-          expect(submission_csv_service_spy).not_to have_received(:write)
+          expect(csv_submission_service_spy).not_to have_received(:write)
         end
 
         it "logs submission" do
@@ -112,7 +112,7 @@ RSpec.describe FormSubmissionService do
 
         it "writes a CSV file" do
           service.submit
-          expect(submission_csv_service_spy).to have_received(:write)
+          expect(csv_submission_service_spy).to have_received(:write)
         end
 
         it "calls FormSubmissionMailer passing in a CSV file" do

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe FormSubmissionService do
       expect(log_lines[0]["submission_reference"]).to eq(reference)
     end
 
-    describe "sending the submission email" do
+    describe "submitting the form to the processing team" do
       context "when the submission type is email" do
         before do
           form.submission_type = "email"
@@ -190,6 +190,45 @@ RSpec.describe FormSubmissionService do
               csv_attached: false,
             )
           end
+        end
+      end
+
+      context "when the submission type is s3" do
+        let(:s3_submission_service_spy) { instance_double(S3SubmissionService) }
+
+        before do
+          form.submission_type = "s3"
+          form.s3_bucket_name = "a-bucket"
+          form.s3_bucket_aws_account_id = "123456789"
+          form.submission_email = nil
+
+          allow(S3SubmissionService).to receive(:new).and_return(s3_submission_service_spy)
+          allow(s3_submission_service_spy).to receive("upload_file_to_s3")
+        end
+
+        it "writes a CSV file" do
+          service.submit
+          expect(csv_submission_service_spy).to have_received(:write)
+        end
+
+        it "creates a S3SubmissionService instance passing in a CSV file" do
+          freeze_time do
+            service.submit
+
+            expect(S3SubmissionService).to have_received(:new).with(
+              file_path: an_instance_of(String),
+              form_id: form.id,
+              s3_bucket_name: form.s3_bucket_name,
+              s3_bucket_aws_account_id: form.s3_bucket_aws_account_id,
+              timestamp: Time.zone.now,
+              submission_reference: reference,
+            ).once
+          end
+        end
+
+        it "calls upload_file_to_s3" do
+          service.submit
+          expect(s3_submission_service_spy).to have_received(:upload_file_to_s3)
         end
       end
 

--- a/spec/services/s3_submission_service_spec.rb
+++ b/spec/services/s3_submission_service_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe S3SubmissionService do
+  subject(:service) do
+    described_class.new(file_path: test_file.path, form_id:, s3_bucket_name:,
+                        s3_bucket_aws_account_id:, timestamp:, submission_reference:)
+  end
+
+  let(:test_file) do
+    temp = Tempfile.new
+    temp << file_body
+    temp.flush
+    temp
+  end
+  let(:file_body) { "some body/n" }
+  let(:form_id) { 42 }
+  let(:s3_bucket_name) { "a-bucket" }
+  let(:s3_bucket_aws_account_id) { "23423423423423" }
+  let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+  let(:timestamp) do
+    Time.use_zone("London") { Time.zone.local(2022, 9, 14, 8, 0o0, 0o0) }
+  end
+
+  after do
+    test_file.unlink
+  end
+
+  describe "#upload_file_to_s3" do
+    let(:mock_credentials) { { foo: "bar" } }
+    let(:mock_sts_client) { Aws::STS::Client.new(stub_responses: true) }
+    let(:mock_s3_client) { Aws::S3::Client.new(stub_responses: true) }
+    let(:role_arn) { "arn:aws:iam::11111111111:role/test-role" }
+
+    before do
+      allow(Aws::AssumeRoleCredentials).to receive(:new).and_return(mock_credentials)
+      allow(Aws::STS::Client).to receive(:new).and_return(mock_sts_client)
+      allow(Aws::S3::Client).to receive(:new).and_return(mock_s3_client)
+      allow(mock_s3_client).to receive(:put_object)
+      allow(Settings.aws_s3_submissions).to receive(:iam_role_arn).and_return(role_arn)
+
+      service.upload_file_to_s3
+    end
+
+    it "calls AWS to assume the role to upload to S3" do
+      expected_session_name = "forms-runner-#{submission_reference}"
+      expect(Aws::AssumeRoleCredentials).to have_received(:new).with(client: mock_sts_client, role_arn:,
+                                                                     role_session_name: expected_session_name)
+    end
+
+    it "creates an S3 client with the credentials for the assumed role" do
+      expect(Aws::S3::Client).to have_received(:new).with(credentials: mock_credentials)
+    end
+
+    it "calls put_object" do
+      expected_key_name = "form_submission/#{form_id}_#{timestamp}_#{submission_reference}.csv"
+      expect(mock_s3_client).to have_received(:put_object).with(
+        body: file_body,
+        bucket: s3_bucket_name,
+        expected_bucket_owner: s3_bucket_aws_account_id,
+        key: expected_key_name,
+      )
+    end
+  end
+end

--- a/spec/services/s3_submission_service_spec.rb
+++ b/spec/services/s3_submission_service_spec.rb
@@ -25,6 +25,28 @@ RSpec.describe S3SubmissionService do
     test_file.unlink
   end
 
+  describe "initialize" do
+    context "when s3_bucket_name is nil" do
+      it "raises an ArgumentException" do
+        expect {
+          described_class.new(file_path: test_file.path, form_id:, s3_bucket_name: nil,
+                              s3_bucket_aws_account_id:, timestamp:, submission_reference:)
+        }
+          .to raise_error(ArgumentError, "s3_bucket_name cannot be nil")
+      end
+    end
+
+    context "when s3_bucket_aws_account_id is nil" do
+      it "raises an ArgumentException" do
+        expect {
+          described_class.new(file_path: test_file.path, form_id:, s3_bucket_name:,
+                              s3_bucket_aws_account_id: nil, timestamp:, submission_reference:)
+        }
+          .to raise_error(ArgumentError, "s3_bucket_aws_account_id cannot be nil")
+      end
+    end
+  end
+
   describe "#upload_file_to_s3" do
     let(:mock_credentials) { { foo: "bar" } }
     let(:mock_sts_client) { Aws::STS::Client.new(stub_responses: true) }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ToXPf8zb/

Implement uploading file containing submission data to an S3 bucket specified for a form if the `submission_type` is `s3`. 

To do this, we assume an AWS role that is defined per environment. We expect the bucket to have granted write permissions for this AWS role.

### How to test

1. Update `aws_s3_submissions.iam_role_arn` in the settings.yml file to be the ARN of the role with permissions to upload to the s3 bucket in the deploy environment.
2. Run the forms-api rake task to configure one of your local forms to send submissions to S3:

```
rake "forms:set_submission_type_to_s3[1, deploy-account-bucket-name, deploy-account-id]"
```

3. Start form-runner locally in an authenticated aws shell for the dev environment. This allows the app to assume the AWS role for writing to the S3 bucket:

```
gds aws forms-dev-readonly -- bundle exec rails s
```

4. Submit the form. Check the S3 bucket in the deploy account and verify that a submission CSV file has been uploaded.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
