### PR TITLE
Change key name for submission uploaded to s3

### DIFF
--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -73,6 +73,7 @@ private
       current_context: @current_context,
       timestamp: @timestamp,
       submission_reference: @submission_reference,
+      preview_mode: @preview_mode,
     )
   end
 

--- a/app/services/s3_submission_service.rb
+++ b/app/services/s3_submission_service.rb
@@ -1,11 +1,13 @@
 class S3SubmissionService
   def initialize(current_context:,
                  timestamp:,
-                 submission_reference:)
+                 submission_reference:,
+                 preview_mode:)
     @current_context = current_context
     @form = current_context.form
     @timestamp = timestamp
     @submission_reference = submission_reference
+    @preview_mode = preview_mode
   end
 
   def submit
@@ -58,6 +60,8 @@ private
   end
 
   def key_name
-    "form_submission/#{@form.id}_#{@timestamp}_#{@submission_reference}.csv"
+    folder = @preview_mode ? "test_form_submissions" : "form_submissions"
+    formatted_timestamp = @timestamp.utc.strftime("%Y%m%dT%H%M%SZ")
+    "#{folder}/#{@form.id}/#{formatted_timestamp}_#{@submission_reference}.csv"
   end
 end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe FormSubmissionService do
               current_context:,
               timestamp: Time.zone.now,
               submission_reference: reference,
+              preview_mode:,
             ).once
           end
         end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ToXPf8zb/

Change the key name so that:

- The root folder is pluralized to "form_submissions/"
- If the form is a preview, the root folder is "test_form_submissions/"
- The form ID is a folder rather than a prefix to the filename
- The timestamp is in UTC and does not contain any special characters, as colons (:) and plus signs (+) are not in AWS's list of safe characters for key names.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
