### PR TITLE
Add id to submission reference number

### DIFF
--- a/app/views/forms/submitted/_submitted_panel.html.erb
+++ b/app/views/forms/submitted/_submitted_panel.html.erb
@@ -7,6 +7,6 @@
 ) do %>
   <% if current_context.get_submission_reference.present? %>
     <%= t('form.submitted.your_reference') %><br>
-    <strong><%= current_context.get_submission_reference %></strong>
+    <strong id="submission-reference"><%= current_context.get_submission_reference %></strong>
   <% end %>
 <% end %>


### PR DESCRIPTION
When the submission type of a form is S3, we save the form to a specified bucket, using the submission reference number as part of the key. When running end to end tests, we want to be able to submit a form, then look into an S3 bucket to find the submission.

Adding an ID here allows the end to end tests to easily find the reference number and use it to look for the submitted form in S3.

### What problem does this pull request solve?

[Trello card](https://trello.com/c/64CM50hZ/1921-add-an-e2e-test-for-s3-submissions)

this relates to this PR: https://github.com/alphagov/forms-e2e-tests

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
