### PR TITLE
Add basic file upload component

### DIFF
--- a/app/components/question/file_component/view.html.erb
+++ b/app/components/question/file_component/view.html.erb
@@ -1,0 +1,7 @@
+<%= form_builder.govuk_file_field :file,
+                                  label: {
+                                    text: question_text_with_extra_suffix,
+                                    **question_text_size_and_tag
+                                  },
+                                  hint: { text: question.hint_text }
+%>

--- a/app/components/question/file_component/view.rb
+++ b/app/components/question/file_component/view.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Question::FileComponent
+  class View < Question::Base
+  end
+end

--- a/app/lib/flow/question_register.rb
+++ b/app/lib/flow/question_register.rb
@@ -22,6 +22,8 @@ module Flow
                 Question::Text
               when :name
                 Question::Name
+              when :file
+                Question::File
               else
                 raise ArgumentError, "Unexpected answer_type for page #{page.id}: #{page.answer_type}"
               end

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -1,0 +1,5 @@
+module Question
+  class File < Question::QuestionBase
+    attribute :file
+  end
+end

--- a/spec/components/question/file_component/file_component_preview.rb
+++ b/spec/components/question/file_component/file_component_preview.rb
@@ -1,0 +1,20 @@
+class Question::FileComponent::FileComponentPreview < ViewComponent::Preview
+  def file_field
+    question = OpenStruct.new(answer_type: "file",
+                              question_text_with_optional_suffix: "Upload your photo",
+                              answer_settings: nil)
+    form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                                 ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+    render(Question::FileComponent::View.new(form_builder:, question:, extra_question_text_suffix: ""))
+  end
+
+  def file_field_with_hint
+    question = OpenStruct.new(answer_type: "file",
+                              question_text_with_optional_suffix: "Upload your photo",
+                              hint_text: "Make sure your face is clearly visible",
+                              answer_settings: nil)
+    form_builder = GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                                 ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+    render(Question::FileComponent::View.new(form_builder:, question:, extra_question_text_suffix: ""))
+  end
+end

--- a/spec/components/question/file_component/view_spec.rb
+++ b/spec/components/question/file_component/view_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe Question::FileComponent::View, type: :component do
+  let(:question_page) { build :page, answer_type: "file" }
+  let(:answer_text) { nil }
+  let(:question) do
+    OpenStruct.new(
+      question_text_with_optional_suffix: question_page.question_text,
+      hint_text: question_page.hint_text,
+      answer_settings: nil,
+      page_heading: question_page.page_heading,
+      guidance_markdown: question_page.guidance_markdown,
+    )
+  end
+  let(:extra_question_text_suffix) { nil }
+  let(:form_builder) do
+    GOVUKDesignSystemFormBuilder::FormBuilder.new(:form, question,
+                                                  ActionView::Base.new(ActionView::LookupContext.new(nil), {}, nil), {})
+  end
+
+  before do
+    render_inline(described_class.new(form_builder:, question:, extra_question_text_suffix:))
+  end
+
+  describe "when component is a file upload field" do
+    it "renders the question text as a heading" do
+      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
+    end
+
+    it "renders a file input field" do
+      expect(page).to have_css("input[type='file'][name='form[file]']")
+    end
+
+    context "when the question has hint text" do
+      let(:question_page) { build :page, :with_hints, answer_type: "file" }
+
+      it "outputs the hint text" do
+        expect(page.find(".govuk-hint")).to have_text(question.hint_text)
+      end
+    end
+
+    context "when there is an extra suffix to be added to the heading" do
+      let(:extra_question_text_suffix) { "Some extra text to add to the question text" }
+
+      it "renders the question text and extra suffix as a heading" do
+        expect(page.find("h1 label")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+      end
+    end
+
+    context "with unsafe question text" do
+      let(:question_page) { build :page, answer_type: "file", question_text: "What is your name? <script>alert(\"Hi\")</script>" }
+      let(:extra_question_text_suffix) { "<span>Some trusted html</span>" }
+
+      it "returns the escaped title with the optional suffix" do
+        expected_output = "What is your name? &lt;script&gt;alert(\"Hi\")&lt;/script&gt; <span>Some trusted html</span>"
+        expect(page.find("h1 .govuk-label").native.inner_html).to eq(expected_output)
+      end
+    end
+
+    context "when question has guidance" do
+      let(:question_page) { build :page, :with_guidance, answer_type: "file" }
+
+      it "renders the question text as a label" do
+        expect(page.find("label.govuk-label--m")).to have_text(question_page.question_text)
+      end
+    end
+  end
+end

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe Question::File, type: :model do
+  subject(:question) { described_class.new({}, options) }
+
+  let(:options) { { is_optional:, question_text: } }
+
+  let(:is_optional) { false }
+  let(:question_text) { Faker::Lorem.question }
+
+  it_behaves_like "a question model"
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/8v2L1Cd7/2042-build-an-add-file-component-to-embed-in-a-form-for-form-fillers-%F0%9F%A6%B4?filter=label:Feature%20team%20one

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Adds:
- a component for rendering a file upload input in a form. 
- a vvery basic question model to enable rendering the input

Doesn't include any file handling or validation logic.

### Screenshot
![image](https://github.com/user-attachments/assets/ed9f3145-f55d-4275-8430-5c0105cd5ea1)

### Testing instructions
To test this, you'll need to create a question with `answer_type: "file"`. To do that you  need to:
- enable the `file_upload_enabled` flag for a group on your local machine (`rake groups:enable_file_upload[<group_external_id>]`
- create a new question in a form within that group
- choose the 'file' answer type

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
