### PR TITLE
Upload to s3 for file upload questions

### DIFF
--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -1,5 +1,43 @@
 module Question
   class File < Question::QuestionBase
     attribute :file
+    attribute :original_filename
+    attribute :uploaded_file_key
+
+    def show_answer
+      original_filename
+    end
+
+    def update_answer(params)
+      file_param = params[:file]
+      file = file_param.tempfile
+
+      key = file_upload_s3_key(file)
+      upload_to_s3(file, key)
+
+      # we don't want to store the file itself on the session
+      self.file = nil
+
+      self.original_filename = file_param.original_filename
+      self.uploaded_file_key = key
+    end
+
+  private
+
+    def file_upload_s3_key(file)
+      uuid = SecureRandom.uuid
+      extension = ::File.extname(file.path)
+      "#{uuid}#{extension}"
+    end
+
+    def upload_to_s3(file, key)
+      s3 = Aws::S3::Client.new
+      s3.put_object({
+        body: file,
+        bucket: Settings.aws.file_upload_s3_bucket_name,
+        key:,
+      })
+      key
+    end
   end
 end

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -17,6 +17,10 @@ module Question
       @guidance_markdown = options[:guidance_markdown]
     end
 
+    def update_answer(params)
+      assign_attributes(params)
+    end
+
     def attributes
       attribute_names.index_with { |_k| nil }
     end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -53,7 +53,7 @@ class Step
   end
 
   def update!(params)
-    question.assign_attributes(params)
+    question.update_answer(params)
     question.valid?
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,7 @@ sentry:
 
 aws:
   s3_submission_iam_role_arn: changeme
+  file_upload_s3_bucket_name: changeme
 
 maintenance_mode:
   # When set to true, All pages will render 'Maintenance mode' message

--- a/spec/features/fill_in_file_upload_question_spec.rb
+++ b/spec/features/fill_in_file_upload_question_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+feature "Fill in and submit a form with a file upload question", type: :feature do
+  let(:steps) { [(build :v2_question_page_step, answer_type: "file", id: 1, routing_conditions: [], question_text:)] }
+  let(:form) { build :v2_form_document, :live?, id: 1, name: "Fill in this form", steps:, start_page: 1 }
+  let(:question_text) { Faker::Lorem.question }
+  let(:answer_text) { "Answer 1" }
+  let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:post_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Content-Type" => "application/json",
+    }
+  end
+
+  let(:test_file) { Tempfile.new(%w[a-file txt]) }
+
+  after do
+    test_file.unlink
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v2/forms/1/live", req_headers, form.to_json, 200
+    end
+
+    allow(ReferenceNumberService).to receive(:generate).and_return(reference)
+
+    mock_s3_client = Aws::S3::Client.new(stub_responses: true)
+    allow(Aws::S3::Client).to receive(:new).and_return(mock_s3_client)
+    allow(mock_s3_client).to receive(:put_object)
+  end
+
+  scenario "As a form filler" do
+    when_i_visit_the_form_start_page
+    then_i_should_see_the_first_question
+    then_i_see_the_file_upload_component
+    when_i_upload_a_file
+    and_i_click_on_continue
+    then_i_should_see_the_check_your_answers_page
+
+    when_i_opt_out_of_email_confirmation
+    and_i_submit_my_form
+    then_my_form_should_be_submitted
+    and_i_should_receive_a_reference_number
+  end
+
+  def when_i_visit_the_form_start_page
+    visit form_path(mode: "form", form_id: 1, form_slug: "fill-in-this-form")
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def then_i_should_see_the_first_question
+    expect(page.find("h1")).to have_text question_text
+  end
+
+  def then_i_see_the_file_upload_component
+    expect(page).to have_css("input[type=file]")
+  end
+
+  def when_i_upload_a_file
+    attach_file question_text, test_file.path
+  end
+
+  def and_i_click_on_continue
+    click_button "Continue"
+  end
+
+  def then_i_should_see_the_check_your_answers_page
+    expect(page.find("h1")).to have_text "Check your answers before submitting your form"
+    expect(page).to have_text question_text
+    expect(page).to have_text File.basename(test_file.path)
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def when_i_opt_out_of_email_confirmation
+    choose "No"
+  end
+
+  def and_i_submit_my_form
+    click_on "Submit"
+  end
+
+  def then_my_form_should_be_submitted
+    expect(page.find("h1")).to have_text "Your form has been submitted"
+    expect_page_to_have_no_axe_errors(page)
+  end
+
+  def and_i_should_receive_a_reference_number
+    expect(page).to have_text reference
+  end
+end

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -8,5 +8,67 @@ RSpec.describe Question::File, type: :model do
   let(:is_optional) { false }
   let(:question_text) { Faker::Lorem.question }
 
-  it_behaves_like "a question model"
+  describe "base question" do
+    let(:original_filename) { Faker::File.file_name }
+
+    before do
+      question.original_filename = original_filename
+    end
+
+    it_behaves_like "a question model"
+  end
+
+  describe "#update_answer" do
+    let(:mock_s3_client) { Aws::S3::Client.new(stub_responses: true) }
+    let(:uploaded_file) { instance_double(ActionDispatch::Http::UploadedFile) }
+    let(:params) { { file: uploaded_file } }
+    let(:original_filename) { "a-file.png" }
+    let(:bucket) { "an-s3-bucket" }
+    let(:key) { Faker::Alphanumeric.alphanumeric }
+    let(:tempfile) { Tempfile.new(%w[temp-file .png]) }
+
+    after do
+      tempfile.unlink
+    end
+
+    before do
+      allow(Aws::S3::Client).to receive(:new).and_return(mock_s3_client)
+      allow(mock_s3_client).to receive(:put_object)
+      allow(Settings.aws).to receive(:file_upload_s3_bucket_name).and_return(bucket)
+
+      allow(uploaded_file).to receive_messages(original_filename: original_filename, tempfile: tempfile)
+
+      allow(SecureRandom).to receive(:uuid).and_return key
+
+      question.update_answer(params)
+    end
+
+    it "puts object to S3" do
+      expect(mock_s3_client).to have_received(:put_object).with(
+        body: tempfile,
+        bucket: bucket,
+        key: "#{key}.png",
+      )
+    end
+
+    it "sets the uploaded_file_key" do
+      expect(question.uploaded_file_key).to eq "#{key}.png"
+    end
+
+    it "sets the original_filename" do
+      expect(question.original_filename).to eq original_filename
+    end
+  end
+
+  describe "#show_answer" do
+    let(:original_filename) { Faker::File.file_name }
+
+    before do
+      question.original_filename = original_filename
+    end
+
+    it "returns the original_filename" do
+      expect(question.show_answer).to eq original_filename
+    end
+  end
 end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Step do
   describe "#update!" do
     it "assigns attributes and validates the question" do
       params = { name: "New Name" }
-      expect(question).to receive(:assign_attributes).with(params)
+      expect(question).to receive(:update_answer).with(params)
       expect(question).to receive(:valid?)
       step.update!(params)
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/7CmjPY64/

Add a new `update_answer` method to question_base to set the answer attributes on the question. This is overridden by the `file` model to perform the upload to S3 when the answer is saved.

We do not want to save the file itself to the session, so we set this to `nil` on the model as this model is used to set the answer data on the session. Instead, set `original_filename` which is the name the file was uploaded with and `uploaded_file_key` which is the S3 object key on the session.

Make it so that we display the `original_filename` back to the user on the "Check your answers" page.

We generate a unique key for the file in S3 using UUID to ensure there is no chance of 2 files being uploaded with the same key.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
