### PR TITLE
Add a test for GDS Transport font loading

### DIFF
--- a/spec/features/components/preview_components_spec.rb
+++ b/spec/features/components/preview_components_spec.rb
@@ -9,4 +9,11 @@ describe "Previewing components", type: :feature do
       expect_component_to_have_no_axe_errors(page)
     end
   end
+
+  it "checks GDS Transport font is available" do
+    visit "/preview/"
+    font_loaded = evaluate_script("document.fonts.check('12px GDS Transport')")
+
+    expect(font_loaded).to be true
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

It's possible for changes to our build to cause assets not to be built properly. One of the problems this causes is a failure to load the GDS Transport font.

This commit adds a test which will fail if the GDS Transport font is referenced in a font-face declaration but fails to load.

See also:
- original forms-admin PR (https://github.com/alphagov/forms-admin/pull/1658)
- accompanying forms-runner PR: https://github.com/alphagov/forms-product-page/pull/574

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
