### PR TITLE
rename aws s3 submission variable

### DIFF
--- a/app/services/s3_submission_service.rb
+++ b/app/services/s3_submission_service.rb
@@ -52,7 +52,7 @@ private
     role_session_name = "forms-runner-#{@submission_reference}"
     credentials = Aws::AssumeRoleCredentials.new(
       client: Aws::STS::Client.new,
-      role_arn: Settings.aws_s3_submissions.iam_role_arn,
+      role_arn: Settings.aws.s3_submission_iam_role_arn,
       role_session_name:,
     )
     Rails.logger.info "Assumed S3 role", { role_session_name: }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,8 +24,8 @@ sentry:
   environment: local
   filter_mask: "[Filtered (client-side)]"
 
-aws_s3_submissions:
-  iam_role_arn: changeme
+aws:
+  s3_submission_iam_role_arn: changeme
 
 maintenance_mode:
   # When set to true, All pages will render 'Maintenance mode' message

--- a/spec/services/s3_submission_service_spec.rb
+++ b/spec/services/s3_submission_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe S3SubmissionService do
         allow(Aws::STS::Client).to receive(:new).and_return(mock_sts_client)
         allow(Aws::S3::Client).to receive(:new).and_return(mock_s3_client)
         allow(mock_s3_client).to receive(:put_object)
-        allow(Settings.aws_s3_submissions).to receive(:iam_role_arn).and_return(role_arn)
+        allow(Settings.aws).to receive(:s3_submission_iam_role_arn).and_return(role_arn)
 
         service.submit
       end


### PR DESCRIPTION
### What problem does this pull request solve?

this commit renames the aws s3 submission iam role variable. This is so that we a have a top level of aws in the settings.yml file for when we add more aws variables in the future

[Trello card](https://trello.com/c/snn0svAW/2052-rename-awss3submissions-runner-setting)

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
