### PR TITLE
Fix issue in runner displaying forms with incomplete routes

### DIFF
--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -105,10 +105,11 @@ module Forms
     end
 
     def check_goto_page_routing_error
-      return unless @step.routing_conditions.filter { |condition| condition.validation_errors.filter { |error| %w[cannot_have_goto_page_before_routing_page goto_page_doesnt_exist].include? error.name }.any? }.any?
+      return if @step.conditions_with_goto_errors.blank?
 
       EventLogger.log_page_event("goto_page_before_routing_page_error", @step.question.question_text, nil)
-      render template: "errors/goto_page_before_routing_page", locals: { link_url: admin_edit_condition_url(@step.form_id, @step.page_slug), question_number: @step.page_number }, status: :unprocessable_entity
+      routes_page_id = @step.conditions_with_goto_errors.first.check_page_id
+      render template: "errors/goto_page_before_routing_page", locals: { link_url: admin_edit_condition_url(@step.form_id, routes_page_id), question_number: @step.page_number }, status: :unprocessable_entity
     end
 
     def admin_edit_condition_url(form_id, page_id)

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -109,7 +109,7 @@ module Forms
 
       EventLogger.log_page_event("goto_page_before_routing_page_error", @step.question.question_text, nil)
       routes_page_id = @step.conditions_with_goto_errors.first.check_page_id
-      render template: "errors/goto_page_before_routing_page", locals: { link_url: admin_edit_condition_url(@step.form_id, routes_page_id), question_number: @step.page_number }, status: :unprocessable_entity
+      render template: "errors/goto_page_routing_error", locals: { link_url: admin_edit_condition_url(@step.form_id, routes_page_id), question_number: @step.page_number }, status: :unprocessable_entity
     end
 
     def admin_edit_condition_url(form_id, page_id)

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -1,6 +1,6 @@
 module Forms
   class PageController < BaseController
-    before_action :prepare_step, :set_logging_attributes, :changing_existing_answer, :check_goto_page_before_routing_page
+    before_action :prepare_step, :set_logging_attributes, :changing_existing_answer, :check_goto_page_routing_error
 
     def set_logging_attributes
       super
@@ -104,7 +104,7 @@ module Forms
       step.repeatable? && !step.skipped?
     end
 
-    def check_goto_page_before_routing_page
+    def check_goto_page_routing_error
       return unless @step.routing_conditions.filter { |condition| condition.validation_errors.filter { |error| %w[cannot_have_goto_page_before_routing_page goto_page_doesnt_exist].include? error.name }.any? }.any?
 
       EventLogger.log_page_event("goto_page_before_routing_page_error", @step.question.question_text, nil)

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -108,11 +108,11 @@ module Forms
       return unless @step.routing_conditions.filter { |condition| condition.validation_errors.filter { |error| %w[cannot_have_goto_page_before_routing_page goto_page_doesnt_exist].include? error.name }.any? }.any?
 
       EventLogger.log_page_event("goto_page_before_routing_page_error", @step.question.question_text, nil)
-      render template: "errors/goto_page_before_routing_page", locals: { link_url: admin_edit_condition_url(@step.form_id, @step.page_slug, @step.routing_conditions.first.id), question_number: @step.page_number }, status: :unprocessable_entity
+      render template: "errors/goto_page_before_routing_page", locals: { link_url: admin_edit_condition_url(@step.form_id, @step.page_slug), question_number: @step.page_number }, status: :unprocessable_entity
     end
 
-    def admin_edit_condition_url(form_id, page_id, condition_id)
-      "#{Settings.forms_admin.base_url}/forms/#{form_id}/pages/#{page_id}/conditions/#{condition_id}"
+    def admin_edit_condition_url(form_id, page_id)
+      "#{Settings.forms_admin.base_url}/forms/#{form_id}/pages/#{page_id}/routes"
     end
 
     def is_first_page?

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -108,7 +108,11 @@ module Forms
       return unless @step.routing_conditions.filter { |condition| condition.validation_errors.filter { |error| %w[cannot_have_goto_page_before_routing_page goto_page_doesnt_exist].include? error.name }.any? }.any?
 
       EventLogger.log_page_event("goto_page_before_routing_page_error", @step.question.question_text, nil)
-      render template: "errors/goto_page_before_routing_page", locals: { link_url: "#{Settings.forms_admin.base_url}/forms/#{@step.form_id}/pages/#{@step.page_slug}/conditions/#{@step.routing_conditions.first.id}", question_number: @step.page_number }, status: :unprocessable_entity
+      render template: "errors/goto_page_before_routing_page", locals: { link_url: admin_edit_condition_url(@step.form_id, @step.page_slug, @step.routing_conditions.first.id), question_number: @step.page_number }, status: :unprocessable_entity
+    end
+
+    def admin_edit_condition_url(form_id, page_id, condition_id)
+      "#{Settings.forms_admin.base_url}/forms/#{form_id}/pages/#{page_id}/conditions/#{condition_id}"
     end
 
     def is_first_page?

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -105,7 +105,7 @@ module Forms
     end
 
     def check_goto_page_before_routing_page
-      return unless @step.routing_conditions.filter { |condition| condition.validation_errors.filter { |error| error.name == "cannot_have_goto_page_before_routing_page" }.any? }.any?
+      return unless @step.routing_conditions.filter { |condition| condition.validation_errors.filter { |error| %w[cannot_have_goto_page_before_routing_page goto_page_doesnt_exist].include? error.name }.any? }.any?
 
       EventLogger.log_page_event("goto_page_before_routing_page_error", @step.question.question_text, nil)
       render template: "errors/goto_page_before_routing_page", locals: { link_url: "#{Settings.forms_admin.base_url}/forms/#{@step.form_id}/pages/#{@step.page_slug}/conditions/#{@step.routing_conditions.first.id}", question_number: @step.page_number }, status: :unprocessable_entity

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -2,6 +2,8 @@ class Step
   attr_accessor :page, :form, :question
   attr_reader :next_page_slug, :page_slug
 
+  GOTO_PAGE_ERROR_NAMES = %w[cannot_have_goto_page_before_routing_page goto_page_doesnt_exist].freeze
+
   def initialize(form:, page:, question:, next_page_slug:, page_slug:)
     @form = form
     @page = page
@@ -91,6 +93,14 @@ class Step
 
   def skipped?
     question.is_optional? && question.show_answer.blank?
+  end
+
+  def conditions_with_goto_errors
+    routing_conditions.filter do |condition|
+      condition.validation_errors.any? do |error|
+        GOTO_PAGE_ERROR_NAMES.include? error.name
+      end
+    end
   end
 
 private

--- a/app/views/errors/goto_page_before_routing_page.html.erb
+++ b/app/views/errors/goto_page_before_routing_page.html.erb
@@ -1,8 +1,0 @@
-<% set_page_title(t("goto_page_before_routing_page.title")) %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t('goto_page_before_routing_page.title') %></h1>
-    <%= t('goto_page_before_routing_page.body_html', link_url:, question_number:) %>
-  </div>
-</div>

--- a/app/views/errors/goto_page_routing_error.html.erb
+++ b/app/views/errors/goto_page_routing_error.html.erb
@@ -1,0 +1,8 @@
+<% set_page_title(t("goto_page_routing_error.title")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('goto_page_routing_error.title') %></h1>
+    <%= t('goto_page_routing_error.body_html', link_url:, question_number:) %>
+  </div>
+</div>

--- a/app/views/errors/goto_page_routing_error.html.erb
+++ b/app/views/errors/goto_page_routing_error.html.erb
@@ -3,6 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('goto_page_routing_error.title') %></h1>
-    <%= t('goto_page_routing_error.body_html', link_url:, question_number:) %>
+    <%= t("goto_page_routing_error.#{error_name}.body_html", link_url:, question_number:) %>
   </div>
 </div>

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -1,9 +1,14 @@
 ---
 en:
   goto_page_routing_error:
-    body_html: |
-      <p>The question you’re taking the person to is now above the question route, so the route cannot work.</p>
-      <p>To fix this <a href="%{link_url}">edit or delete question %{question_number}’s route</a>.</p>
+    cannot_have_goto_page_before_routing_page:
+      body_html: |
+        <p>Question %{question_number} has a route that takes the person to a question that‘s before the start of the route, so the route cannot work.</p>
+        <p>To fix this <a href="%{link_url}">edit or delete question %{question_number}’s route</a>.</p>
+    goto_page_doesnt_exist:
+      body_html: |
+        <p>Question %{question_number} has a route that takes people to a question that has been deleted.</p>
+        <p>To fix this <a href="%{link_url}">edit or delete question %{question_number}’s route</a>.</p>
     title: There’s a problem
   incomplete_submission:
     body_html: |

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -1,6 +1,6 @@
 ---
 en:
-  goto_page_before_routing_page:
+  goto_page_routing_error:
     body_html: |
       <p>The question you’re taking the person to is now above the question route, so the route cannot work.</p>
       <p>To fix this <a href="%{link_url}">edit or delete question %{question_number}’s route</a>.</p>

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -3,7 +3,7 @@ en:
   goto_page_routing_error:
     cannot_have_goto_page_before_routing_page:
       body_html: |
-        <p>Question %{question_number} has a route that takes the person to a question that‘s before the start of the route, so the route cannot work.</p>
+        <p>Question %{question_number} has a route that takes the person to a question that’s before the start of the route, so the route cannot work.</p>
         <p>To fix this <a href="%{link_url}">edit or delete question %{question_number}’s route</a>.</p>
     goto_page_doesnt_exist:
       body_html: |

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Forms::PageController, type: :request do
           get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
           link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/routes"
           question_number = first_step_in_form.position
-          expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))
+          expect(response.body).to include(I18n.t("goto_page_routing_error.body_html", link_url:, question_number:))
         end
       end
 
@@ -304,7 +304,7 @@ RSpec.describe Forms::PageController, type: :request do
           get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
           link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/routes"
           question_number = first_step_in_form.position
-          expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))
+          expect(response.body).to include(I18n.t("goto_page_routing_error.body_html", link_url:, question_number:))
         end
       end
     end
@@ -515,7 +515,7 @@ RSpec.describe Forms::PageController, type: :request do
           post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
           link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/routes"
           question_number = first_step_in_form.position
-          expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))
+          expect(response.body).to include(I18n.t("goto_page_routing_error.body_html", link_url:, question_number:))
         end
       end
 

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "shows the error page" do
           get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
-          link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/conditions/1"
+          link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/routes"
           question_number = first_step_in_form.position
           expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))
         end
@@ -302,7 +302,7 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "shows the error page" do
           get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
-          link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/conditions/1"
+          link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/routes"
           question_number = first_step_in_form.position
           expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))
         end
@@ -513,7 +513,7 @@ RSpec.describe Forms::PageController, type: :request do
 
         it "shows the error page" do
           post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
-          link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/conditions/1"
+          link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/routes"
           question_number = first_step_in_form.position
           expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))
         end

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -287,7 +287,12 @@ RSpec.describe Forms::PageController, type: :request do
           get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
           link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/routes"
           question_number = first_step_in_form.position
-          expect(response.body).to include(I18n.t("goto_page_routing_error.body_html", link_url:, question_number:))
+          expect(response.body).to include(I18n.t("goto_page_routing_error.cannot_have_goto_page_before_routing_page.body_html", link_url:, question_number:))
+        end
+
+        it "logs an error event" do
+          expect(EventLogger).to receive(:log_page_event).with("goto_page_before_routing_page_error", first_step_in_form.data.question_text, nil)
+          get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         end
       end
 
@@ -304,7 +309,12 @@ RSpec.describe Forms::PageController, type: :request do
           get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
           link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/routes"
           question_number = first_step_in_form.position
-          expect(response.body).to include(I18n.t("goto_page_routing_error.body_html", link_url:, question_number:))
+          expect(response.body).to include(I18n.t("goto_page_routing_error.goto_page_doesnt_exist.body_html", link_url:, question_number:))
+        end
+
+        it "logs an error event" do
+          expect(EventLogger).to receive(:log_page_event).with("goto_page_doesnt_exist_error", first_step_in_form.data.question_text, nil)
+          get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         end
       end
     end
@@ -515,7 +525,7 @@ RSpec.describe Forms::PageController, type: :request do
           post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { selection: "Option 2" }, changing_existing_answer: false }
           link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/routes"
           question_number = first_step_in_form.position
-          expect(response.body).to include(I18n.t("goto_page_routing_error.body_html", link_url:, question_number:))
+          expect(response.body).to include(I18n.t("goto_page_routing_error.cannot_have_goto_page_before_routing_page.body_html", link_url:, question_number:))
         end
       end
 

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -290,6 +290,23 @@ RSpec.describe Forms::PageController, type: :request do
           expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))
         end
       end
+
+      context "when the routing has a goto_page which does not exist" do
+        let(:pages_data) { [first_step_in_form, second_step_in_form, third_step_in_form] }
+        let(:validation_errors) { [{ name: "goto_page_doesnt_exist" }] }
+
+        it "returns a 422 response" do
+          get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "shows the error page" do
+          get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
+          link_url = "#{Settings.forms_admin.base_url}/forms/2/pages/1/conditions/1"
+          question_number = first_step_in_form.position
+          expect(response.body).to include(I18n.t("goto_page_before_routing_page.body_html", link_url:, question_number:))
+        end
+      end
     end
 
     context "when page is repeatable" do


### PR DESCRIPTION
Trello card: https://trello.com/c/rYsaVrIn/2040-bug-routing-question-with-no-go-to-question-leads-to-server-error-when-previewing-form

This PR changes the runner to be able to preview pages with multiple conditions and possibly missing goto_pages.

Different errors are displayed based on the error:

- No goto_page in the condition at all, probably because the goto_page has been deleted
- a goto_page before the selection question, which would cause a loop

In both cases the user is given the option to return to admin routes page to correct the issue.

## Screenshots of both errors

![image](https://github.com/user-attachments/assets/48993a7a-c52c-4797-9feb-eac9d9bffab5)

![image](https://github.com/user-attachments/assets/d99c39c0-6cb9-4436-b992-5a7fcc1c4f71)

# note
The error is based on only the first error on a page. It's possible for a question to have multiple conditions associated with it if it's a secondary skip question which is itself a condition.

We have another card to consider all error messages and how errors are displayed and we also have[ plans to prevent multiple conditions](https://trello.com/c/4mY3ULIo/2480-stop-form-creators-creating-an-any-other-answer-route-for-a-question-that-already-has-an-any-answer-route-from-a-branch-question).

This PR takes the pragmatic approach to display the first error found on a goto page and asks the user to fix it.
### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
