### PR TITLE
Attach file uploads to emails

### DIFF
--- a/app/mailers/aws_ses_form_submission_mailer.rb
+++ b/app/mailers/aws_ses_form_submission_mailer.rb
@@ -9,7 +9,7 @@ class AwsSesFormSubmissionMailer < ApplicationMailer
     @subject = I18n.t("mailer.submission.subject", form_title: mailer_options.title, reference: mailer_options.submission_reference)
 
     files.each do |name, file|
-      attachments[name] = File.read(file.path)
+      attachments[name] = file
     end
 
     mail(to: submission_email_address, subject: @subject)

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -22,6 +22,14 @@ module Question
       self.uploaded_file_key = key
     end
 
+    def file_from_s3
+      s3 = Aws::S3::Client.new
+      s3.get_object({
+        bucket: Settings.aws.file_upload_s3_bucket_name,
+        key: uploaded_file_key,
+      }).body.read
+    end
+
   private
 
     def file_upload_s3_key(file)

--- a/spec/factories/models/question/file.rb
+++ b/spec/factories/models/question/file.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :file, class: "Question::File" do
+    question_text { Faker::Lorem.question }
+    hint_text { nil }
+    is_optional { false }
+    page_heading { nil }
+    guidance_markdown { nil }
+    file { nil }
+    original_filename { nil }
+    uploaded_file_key { nil }
+
+    trait :with_uploaded_file do
+      original_filename { Faker::File.file_name(ext: "txt") }
+      uploaded_file_key { Faker::Alphanumeric.alphanumeric }
+    end
+  end
+end

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -57,21 +57,28 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
     end
   end
 
-  context "when a file to attach is included in the arguments" do
-    let(:test_file) { Tempfile.new("csv") }
-    let(:filename) { "a-file.csv" }
-    let(:files) { { filename => test_file } }
-
-    after do
-      test_file.unlink
+  context "when files to attach are included in the arguments" do
+    let(:csv_file_name) { "first-file.csv" }
+    let(:png_file_name) { "second-file.png" }
+    let(:files) do
+      {
+        csv_file_name => Faker::Lorem.sentence,
+        png_file_name => Faker::Lorem.sentence,
+      }
     end
 
-    it "adds the file as an attachment" do
-      expect(mail.attachments.size).to eq(1)
+    it "has 2 attachments" do
+      expect(mail.attachments.size).to eq(2)
     end
 
-    it "uses the filename for the attachment" do
-      expect(mail.attachments.first.filename).to eq(filename)
+    it "has the files attached with expected filenames" do
+      expect(mail.attachments[0].filename).to eq(csv_file_name)
+      expect(mail.attachments[1].filename).to eq(png_file_name)
+    end
+
+    it "has the files attached with expected content" do
+      expect(mail.attachments[0].body).to eq(files[csv_file_name])
+      expect(mail.attachments[1].body).to eq(files[png_file_name])
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/JEWV7ew5/

Attach files for file upload questions to the email when sending the email using SES. This gets the file from S3 using the key stored against the answer in the session.

Files are stored in memory before the email is sent, but this is unavoidable as we need to read the raw content of the file to pass to ActionMailer to construct the raw email.

This assumes that all files are uploaded with unique filenames - which may not be the case in reality. We will need to ensure that files have unique names but this is not addressed in this PR.

### Testing

It is currently only possible to test this by pushing the branch to the dev environment. I have tested this and got an email with the file attached:

<img width="744" alt="Screenshot 2024-12-18 at 12 11 18" src="https://github.com/user-attachments/assets/eaacae0d-ad2b-4343-b09f-66ccbeb63d49" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
