### PR TITLE
Conditionally auto-approve dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -84,10 +84,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Approve a PR if not already approved
         run: |
-          gh pr checkout "$PR_URL" # sets the upstream metadata for `gh pr status`
+          # Sets the upstream metadata for `gh pr status`
+          gh pr checkout {"$PR_URL"}
+
           if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
-          then gh pr review --approve "$PR_URL"
-          else echo "PR already approved, skipping additional approvals to minimize emails/notification noise.";
+          then
+            gh pr review --approve "$PR_URL"
+          else
+            echo "PR already approved, skipping additional approvals to minimize emails/notification noise.";
           fi
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -36,8 +36,8 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      # - name: Enable auto-merge for Dependabot PRs
-      #   run: gh pr merge --auto --merge "$PR_URL"
-      #   env:
-      #     PR_URL: ${{github.event.pull_request.html_url}}
-      #     GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -85,11 +85,11 @@ jobs:
       - name: Approve a PR if not already approved
         run: |
           # Sets the upstream metadata for `gh pr status`
-          gh pr checkout {"$PR_URL"}
+          gh pr checkout "${PR_URL}"
 
           if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
           then
-            gh pr review --approve "$PR_URL"
+            gh pr review --approve "${PR_URL}"
           else
             echo "PR already approved, skipping additional approvals to minimize emails/notification noise.";
           fi

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -11,6 +11,8 @@ jobs:
   validate_this_is_an_allowed_dependency:
     needs: validate_dependabot_opened_this_PR
     runs-on: ubuntu-latest
+    outputs:
+      is_allowed_dependency: ${{ steps.check_if_allowed_dependency.outputs.is_allowed_dependency }}
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,7 +1,7 @@
 name: Dependabot auto-approve
 on: pull_request
 permissions:
-  pull-requests: write
+  pull-requests: read
 jobs:
   validate_dependabot_opened_this_PR:
     runs-on: ubuntu-latest
@@ -17,9 +17,12 @@ jobs:
       - name: Dependabot metadata
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v2
-      - if: "!contains(steps.dependabot-metadata.outputs.package-ecosystem, 'npm') && (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch')"
+      - if: |
+          contains(steps.dependabot-metadata.outputs.package-ecosystem, 'bundler') &&
+          (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch')
         id: check_if_allowed_dependency
-        run: echo "is_allowed_dependency=1" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "is_allowed_dependency=1" >> "$GITHUB_OUTPUT"
   wait_for_checks:
     runs-on: ubuntu-latest
     needs: [ validate_dependabot_opened_this_PR, validate_this_is_an_allowed_dependency ]
@@ -77,6 +80,9 @@ jobs:
           echo "Timed out waiting for checks to complete."
           exit 1
   auto_approve_and_merge:
+    permissions:
+      pull-requests: write
+      contents: write
     runs-on: ubuntu-latest
     needs: [validate_dependabot_opened_this_PR, validate_this_is_an_allowed_dependency, wait_for_checks]
     if: ${{ needs.validate_this_is_an_allowed_dependency.outputs.is_allowed_dependency == 1 }}

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -26,6 +26,7 @@ jobs:
   wait_for_checks:
     runs-on: ubuntu-latest
     needs: [ validate_dependabot_opened_this_PR, validate_this_is_an_allowed_dependency ]
+    if: ${{ needs.validate_this_is_an_allowed_dependency.outputs.is_allowed_dependency == 1 }}
     steps:
       - name: Wait for required checks to pass
         env:

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-approve
+on: pull_request
+permissions:
+  pull-requests: write
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    # Checking the author will prevent your Action run failing on non-Dependabot PRs
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v2
+      - uses: actions/checkout@v4
+      - name: Approve a PR if not already approved
+      # as long as it's not a npm PR, and the update is a patch version
+        if: "!contains(steps.dependabot-metadata.outputs.package-ecosystem, 'npm') && steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch'"
+        run: |
+          gh pr checkout "$PR_URL" # sets the upstream metadata for `gh pr status`
+          if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
+          then gh pr review --approve "$PR_URL"
+          else echo "PR already approved, skipping additional approvals to minimize emails/notification noise.";
+          fi
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -3,18 +3,28 @@ on: pull_request
 permissions:
   pull-requests: write
 jobs:
-  dependabot:
+  validate_dependabot_opened_this_PR:
     runs-on: ubuntu-latest
-    # Checking the author will prevent your Action run failing on non-Dependabot PRs
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - run: echo "This PR was raised by Dependabot"
+  validate_this_is_an_allowed_dependency:
+    needs: validate_dependabot_opened_this_PR
+    runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v2
+      - if: "!contains(steps.dependabot-metadata.outputs.package-ecosystem, 'npm') && (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch')"
+        id: check_if_allowed_dependency
+        run: echo "is_allowed_dependency=1" >> "$GITHUB_OUTPUT"
+  auto_approve_and_merge:
+    runs-on: ubuntu-latest
+    needs: [validate_dependabot_opened_this_PR, validate_this_is_an_allowed_dependency]
+    if: ${{ needs.validate_this_is_an_allowed_dependency.outputs.is_allowed_dependency == 1 }}
+    steps:
       - uses: actions/checkout@v4
       - name: Approve a PR if not already approved
-      # as long as it's not a npm PR, and the update is a patch version
-        if: "!contains(steps.dependabot-metadata.outputs.package-ecosystem, 'npm') && steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch'"
         run: |
           gh pr checkout "$PR_URL" # sets the upstream metadata for `gh pr status`
           if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
@@ -24,3 +34,8 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      # - name: Enable auto-merge for Dependabot PRs
+      #   run: gh pr merge --auto --merge "$PR_URL"
+      #   env:
+      #     PR_URL: ${{github.event.pull_request.html_url}}
+      #     GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -20,9 +20,65 @@ jobs:
       - if: "!contains(steps.dependabot-metadata.outputs.package-ecosystem, 'npm') && (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch')"
         id: check_if_allowed_dependency
         run: echo "is_allowed_dependency=1" >> "$GITHUB_OUTPUT"
+  wait_for_checks:
+    runs-on: ubuntu-latest
+    needs: [ validate_dependabot_opened_this_PR, validate_this_is_an_allowed_dependency ]
+    steps:
+      - name: Wait for required checks to pass
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "Waiting for all required checks to pass on commit $SHA..."
+
+          MAX_RETRIES=30
+          RETRY_DELAY=10
+          ATTEMPT=0
+
+          while [ $ATTEMPT -lt $MAX_RETRIES ]; do
+            echo "Attempt $((ATTEMPT+1))/$MAX_RETRIES"
+
+            # Get all check runs for the commit
+            RESPONSE=$(curl -s -H "Authorization: token $GH_TOKEN" \
+              "https://api.github.com/repos/$REPO/commits/$SHA/check-runs")
+
+            # Exclude self (wait_for_checks)
+            EXCLUDED_CHECK="wait_for_checks"
+
+            echo "Ignoring ${EXCLUDED_CHECK}"
+
+            # Extract conclusions
+            CONCLUSIONS=$(echo "$RESPONSE" | jq -r '.check_runs[] | select(.name != "wait_for_checks") | .name + ":" + (.status + "/" + (.conclusion // "none"))')
+
+            echo "$CONCLUSIONS"
+
+            # Are there any in_progress or queued?
+            PENDING=$(echo "$RESPONSE" | jq -r --arg exclude "$EXCLUDED_CHECK" '[.check_runs[] | select(.name != $exclude and .status != "completed")] | length')
+
+            # Are all completed and successful?
+            FAILED=$(echo "$RESPONSE" | jq -r --arg exclude "$EXCLUDED_CHECK" '[.check_runs[] | select(.name != $exclude and .status == "completed" and .conclusion != "success")] | length')
+
+            if [ "$PENDING" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
+              echo "All checks completed successfully."
+              exit 0
+            fi
+
+            if [ "$FAILED" -gt 0 ]; then
+              echo "One or more checks failed."
+              exit 1
+            fi
+
+            echo "Some checks still pending. Waiting $RETRY_DELAY seconds..."
+            sleep $RETRY_DELAY
+            ATTEMPT=$((ATTEMPT + 1))
+          done
+
+          echo "Timed out waiting for checks to complete."
+          exit 1
   auto_approve_and_merge:
     runs-on: ubuntu-latest
-    needs: [validate_dependabot_opened_this_PR, validate_this_is_an_allowed_dependency]
+    needs: [validate_dependabot_opened_this_PR, validate_this_is_an_allowed_dependency, wait_for_checks]
     if: ${{ needs.validate_this_is_an_allowed_dependency.outputs.is_allowed_dependency == 1 }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint_workflows.yml
+++ b/.github/workflows/lint_workflows.yml
@@ -1,0 +1,19 @@
+name: "Lint Workflows"
+
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash

--- a/.github/workflows/lint_workflows.yml
+++ b/.github/workflows/lint_workflows.yml
@@ -12,8 +12,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download actionlint
         id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        run: |
+          curl -L "https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz" | tar -xvz actionlint
+          chmod +x actionlint
+          sudo mv actionlint /usr/local/bin/actionlint
         shell: bash
       - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        run: actionlint -color
         shell: bash

--- a/.github/workflows/review_apps_on_pr_change.yml
+++ b/.github/workflows/review_apps_on_pr_change.yml
@@ -64,12 +64,11 @@ jobs:
             -no-color \
             -auto-approve
 
-          {
-            echo "REVIEW_APP_URL=$(terraform output -raw review_app_url)" \
-                 "ADMIN_APP_URL=$(terraform output -raw admin_app_url)" \
-                 "ECS_CLUSTER_ID=$(terraform output -raw review_app_ecs_cluster_id)" \
-                 "ECS_SERVICE_NAME=$(terraform output -raw review_app_ecs_service_name)"
-          } >> "$GITHUB_OUTPUT"
+            # shellcheck disable=SC2129 # SC2129 is "mainly a stylistic issue" and it breaks our flow
+            echo "REVIEW_APP_URL=$(terraform output -raw review_app_url)" >> "$GITHUB_OUTPUT"
+            echo "ADMIN_APP_URL=$(terraform output -raw admin_app_url)" >> "$GITHUB_OUTPUT"
+            echo "ECS_CLUSTER_ID=$(terraform output -raw review_app_ecs_cluster_id)" >> "$GITHUB_OUTPUT"
+            echo "ECS_SERVICE_NAME=$(terraform output -raw review_app_ecs_service_name)" >> "$GITHUB_OUTPUT"
 
       - name: Wait for AWS ECS deployments to finish
         run: |

--- a/.github/workflows/review_apps_on_pr_change.yml
+++ b/.github/workflows/review_apps_on_pr_change.yml
@@ -65,9 +65,9 @@ jobs:
             -auto-approve
 
           {
-            echo "REVIEW_APP_URL=$(terraform output -raw review_app_url)"
-                 "ADMIN_APP_URL=$(terraform output -raw admin_app_url)"
-                 "ECS_CLUSTER_ID=$(terraform output -raw review_app_ecs_cluster_id)"
+            echo "REVIEW_APP_URL=$(terraform output -raw review_app_url)" \
+                 "ADMIN_APP_URL=$(terraform output -raw admin_app_url)" \
+                 "ECS_CLUSTER_ID=$(terraform output -raw review_app_ecs_cluster_id)" \
                  "ECS_SERVICE_NAME=$(terraform output -raw review_app_ecs_service_name)"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/review_apps_on_pr_change.yml
+++ b/.github/workflows/review_apps_on_pr_change.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Determine Terraform version
         id: terraform-version
         run: |
-          cat .review_apps/.terraform-version | xargs printf "TF_VERSION=%s" >> "$GITHUB_OUTPUT"
+          echo "TF_VERSION=$(< .review_apps/.terraform-version)" >> "$GITHUB_OUTPUT"
 
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -64,10 +64,12 @@ jobs:
             -no-color \
             -auto-approve
 
-          echo "REVIEW_APP_URL=$(terraform output -raw review_app_url)" >> "$GITHUB_OUTPUT"
-          echo "ADMIN_APP_URL=$(terraform output -raw admin_app_url)" >> "$GITHUB_OUTPUT"
-          echo "ECS_CLUSTER_ID=$(terraform output -raw review_app_ecs_cluster_id)" >> "$GITHUB_OUTPUT"
-          echo "ECS_SERVICE_NAME=$(terraform output -raw review_app_ecs_service_name)" >> "$GITHUB_OUTPUT"
+          {
+            echo "REVIEW_APP_URL=$(terraform output -raw review_app_url)"
+                 "ADMIN_APP_URL=$(terraform output -raw admin_app_url)"
+                 "ECS_CLUSTER_ID=$(terraform output -raw review_app_ecs_cluster_id)"
+                 "ECS_SERVICE_NAME=$(terraform output -raw review_app_ecs_service_name)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Wait for AWS ECS deployments to finish
         run: |
@@ -102,6 +104,8 @@ jobs:
           $COMMENT_MARKER
           EOF
 
+          # shellcheck disable=SC2016
+          # `jq` uses single-quote characters on Unix shells
           old_comment_ids=$(gh api "repos/{owner}/{repo}/issues/${{github.event.pull_request.number}}/comments" --jq 'map(select((.user.login == "github-actions[bot]") and (.body | endswith($ENV.COMMENT_MARKER + "\n")))) | .[].id')
           for comment_id in $old_comment_ids; do
             gh api -X DELETE "repos/{owner}/{repo}/issues/comments/${comment_id}"

--- a/.github/workflows/review_apps_on_pr_close.yml
+++ b/.github/workflows/review_apps_on_pr_close.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Determine Terraform version
         id: terraform-version
         run: |
-          cat .review_apps/.terraform-version | xargs printf "TF_VERSION=%s" >> "$GITHUB_OUTPUT"
+          echo "TF_VERSION=$(< .review_apps/.terraform-version)" >> "$GITHUB_OUTPUT"
 
       - uses: hashicorp/setup-terraform@v3
         with:


### PR DESCRIPTION
# What problem does this pull request solve?
We want to set up a flow to to auto-approve some dependabot PRs. PRs will only
be approved if:
- they are not `npm` updates, and
- the update is only a version patch

[Trello card](https://trello.com/c/2Nj1ipbb/2571-automate-patch-dependency-updates)

## Things to consider when reviewing

It would be great to sense check the workflow against what we're trying to achieve.

The workflow is configured to approve and merge a PR **only** if:

- The PR was raised by Dependabot
- The PR is a patch version and not part of an NPM package
- All checks have passed 

Otherwise, those steps will be skipped and the PR goes through the regular review process. You can see this in action in this PR, where all there a bunch of skipped checks relating to the auto-approving and auto-merging.

**General things to consider**
- Is there enough debug logging in the workflow?
- Are there any name changes you'd suggest?
- Can the workflow be optimised in any way?
- Ensure you consider the wider context.
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Has all relevant documentation been updated?

### Local testing

The only way to test if this really works will be to merge it into the main branch unfortunately. Below are the two testing strategies Cat and I took.

#### Cat
I wanted to try this workflow locally using [act](https://nektosact.com/introduction.html) but it keep getting an error at the step where we ask it to get the dependabot metadata.

```
[Dependabot auto-approve/dependabot]   💬  ::debug::Verifying the job is for an authentic Dependabot Pull Request
[Dependabot auto-approve/dependabot]   ❗  ::error::Api Error: (404) Not Found
[Dependabot auto-approve/dependabot]   ❌  Failure - Main dependabot/fetch-metadata@v2
[Dependabot auto-approve/dependabot] exitcode '1': failure
[Dependabot auto-approve/dependabot] 🏁  Job failed
<!-- If this section isn't relevant for your PR feel free to edit or remove it -->
```

#### Sarah

I ended up forking the `forms-runner` repo so I could test changes on a safe main branch (see fork here: https://github.com/sarahseewhy/forms-runner). I created a new file `review_apps_on_pr_change.yml` in the forked repo and copied the contents from this branch.

This was a useful approach because it allowed me to close and reopen Dependabot PRs to test the workflow and learn quite a bit.

Here's an example of the Actions at work on the forked repo: https://github.com/sarahseewhy/forms-runner/actions/runs/15110638823/job/42469149737?pr=39

However, forked repos don't have the Github permission to actually auto-merge so I'm returning to this branch and pull request.

You can take a similar approach by:

1. Forking the repo
2. Creating a new file `review_apps_on_pr_change.yml`
3. Copy and pasting the contents of `review_apps_on_pr_change.yml` from this branch into the forked repo
4. Configure the fork to have the same Dependabot and branch settings as this repo
5. Find a Dependabot PR which matches our criteria
6. Close the dependabot PR and then reopen it by typing `@dependabot reopen` in the comment section