### PR TITLE
Add content about file upload size limit

### DIFF
--- a/app/components/question/file_component/view.html.erb
+++ b/app/components/question/file_component/view.html.erb
@@ -3,5 +3,10 @@
                                     text: question_text_with_extra_suffix,
                                     **question_text_size_and_tag
                                   },
-                                  hint: { text: question.hint_text }
+                                  hint: {
+                                    text: question.hint_text,
+                                    class: "govuk-!-margin-bottom-7"
+                                  }
 %>
+
+<p class="govuk-body govuk-!-margin-bottom-8"><%= t("question/file.your_file_must_be_smaller_than")%></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,6 +198,8 @@ en:
   preview_banner:
     heading: This is a preview of this form. Do not enter personal information.
     title: Important
+  question/file:
+    your_file_must_be_smaller_than: Your file must be smaller than 7MB.
   question/name:
     label:
       first_name: First name


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/7qrLP1gH/2067-restrict-file-uploads-to-5-questions-of-7mb-each

<img width="817" alt="Screenshot 2025-01-13 at 14 11 20" src="https://github.com/user-attachments/assets/9422d393-a854-4caf-a605-bd22a872292c" />

<img width="417" alt="Screenshot 2025-01-13 at 14 11 36" src="https://github.com/user-attachments/assets/852ba91c-3cf1-4274-9ac6-41fb1f11d8dc" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
