### PR TITLE
Add logging for file upload

### DIFF
--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -22,6 +22,10 @@ module Question
       tempfile = file.tempfile
       key = file_upload_s3_key(tempfile)
       upload_to_s3(tempfile, key)
+      Rails.logger.info("Uploaded file to S3 for file upload question", {
+        file_size_in_bytes: file.size,
+        file_type: file.content_type,
+      })
 
       self.original_filename = file.original_filename
       self.uploaded_file_key = key
@@ -42,6 +46,10 @@ module Question
 
     def validate_file_size
       if file.present? && file.size > FILE_UPLOAD_MAX_SIZE_IN_MB.megabytes
+        Rails.logger.info("File upload question validation failed: file too big", {
+          file_size_in_bytes: file.size,
+          file_type: file.content_type,
+        })
         errors.add(:file, :too_big)
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/7qrLP1gH/2067-restrict-file-uploads-to-5-questions-of-7mb-each

Add logging when a file is uploaded to S3 for a file upload question, or when validation fails due to a file being too big.

This information can help us analyse what file types people are attempting to or successfully uploading and do analysis of the file sizes.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
