### PR TITLE
Switch to modern Sass API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,6 +455,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -1,5 +1,4 @@
-$govuk-images-path: "@govuk/assets/images/";
-$govuk-fonts-path: "@govuk/assets/fonts/";
+$govuk-assets-path: "@govuk/assets/";
 $govuk-global-styles: true;
 
 @import "pkg:govuk-frontend";

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -3,6 +3,6 @@ $govuk-fonts-path: "@govuk/assets/fonts/";
 $govuk-global-styles: true;
 
 @import "pkg:govuk-frontend";
-@import "dfe-autocomplete/src/dfe-autocomplete";
+@import "pkg:dfe-autocomplete/src/dfe-autocomplete";
 @import "../../components/form_header_component/";
 @import "../styles/app-panel";

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -2,7 +2,7 @@ $govuk-images-path: "@govuk/assets/images/";
 $govuk-fonts-path: "@govuk/assets/fonts/";
 $govuk-global-styles: true;
 
-@import "@govuk/all";
+@import "pkg:govuk-frontend";
 @import "dfe-autocomplete/src/dfe-autocomplete";
 @import "../../components/form_header_component/";
 @import "../styles/app-panel";

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,8 @@ export default defineConfig({
   css: {
     preprocessorOptions: {
       scss: {
-        includePaths: ['./node_modules/govuk-frontend/'],
+        api: 'modern',
+        loadPaths: ['./node_modules/govuk-frontend/'],
         quietDeps: true
       },
       devSourcemaps: true

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 import RubyPlugin from 'vite-plugin-ruby'
 import * as path from 'node:path'
+import { NodePackageImporter } from 'sass'
 
 export default defineConfig({
   plugins: [RubyPlugin()],
@@ -9,7 +10,7 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         api: 'modern',
-        loadPaths: ['./node_modules/govuk-frontend/'],
+        importers: [new NodePackageImporter()],
         quietDeps: true
       },
       devSourcemaps: true


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/pfzCTVnB/2066-investigate-asset-building-issue-with-modern-sass-api

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
We were seeing [an issue with assets failing to build properly using the 'modern' Sass API](https://trello.com/c/pfzCTVnB/2066-investigate-asset-building-issue-with-modern-sass-api). After investigating this appears to be caused by a bug in the Vite internal sass importer (https://github.com/vitejs/vite/issues/19196). 

This PR:
- uses the sass NodePackageImporter to import govuk-frontend, which bypasses that bug and also offers us some other advantages (see commit message for more details)
- updates to use the modern API
- uses a more compact API for setting the asset paths

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
