### PR TITLE
Add missing Help link on Check Your Answers page

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -14,10 +14,13 @@ module Forms
       setup_check_your_answers
       email_confirmation_input = EmailConfirmationInput.new
 
+      @support_details = current_context.support_details
+
       render template: "forms/check_your_answers/show", locals: { email_confirmation_input: }
     end
 
     def submit_answers
+      @support_details = current_context.support_details
       email_confirmation_input = EmailConfirmationInput.new(email_confirmation_input_params)
       requested_email_confirmation = email_confirmation_input.send_confirmation == "send_email"
 

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -50,5 +50,12 @@
 
       <%= form.govuk_submit(@current_context.form.declaration_text.present? ? t('form.check_your_answers.agree_and_submit') : t('form.check_your_answers.submit')) %>
     </div>
+
+
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <%= render SupportDetailsComponent::View.new(@support_details) %>
+    </div>
   </div>
 <% end %>

--- a/spec/views/forms/add_another_answer/show.html.erb_spec.rb
+++ b/spec/views/forms/add_another_answer/show.html.erb_spec.rb
@@ -16,7 +16,6 @@ describe "forms/add_another_answer/show.html.erb" do
   before do
     assign(:current_context, OpenStruct.new(form:))
     assign(:mode, mode)
-    assign(:changeing_exsiting_answer, false)
     assign(:rows, rows)
     assign(:step, step)
     assign(:back_link, back_link)

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 describe "forms/check_your_answers/show.html.erb" do
-  let(:form) { build :form, id: 1, declaration_text: }
+  let(:form) { build :form, :with_support, id: 1, declaration_text: }
+  let(:support_details) { OpenStruct.new(email: form.support_email) }
   let(:context) { OpenStruct.new(form:) }
   let(:full_width) { false }
   let(:declaration_text) { nil }
@@ -20,6 +21,7 @@ describe "forms/check_your_answers/show.html.erb" do
     assign(:form_submit_path, "/")
     assign(:full_width, full_width)
     assign(:rows, rows)
+    assign(:support_details, support_details)
     render template: "forms/check_your_answers/show", locals: { email_confirmation_input: }
   end
 
@@ -100,6 +102,10 @@ describe "forms/check_your_answers/show.html.erb" do
 
   it "contains a hidden notify reference for the confirmation email" do
     expect(rendered).to have_field("confirmation-email-reference", type: "hidden", with: email_confirmation_input.confirmation_email_reference)
+  end
+
+  it "displays the help link" do
+    expect(rendered).to have_text(I18n.t("support_details.get_help_with_this_form"))
   end
 
   # TODO: add view tests for playing back questions and Answers


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/2vKEI8SL/2473-add-get-help-link-to-the-cya-page 

The "Check your answers" page was missing the link to get help, which was surfaced during accessibility testing.

![Screenshot 2025-01-20 at 9 41 55 pm](https://github.com/user-attachments/assets/92ce6060-b42b-4815-b006-9c1e038f45b4)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
