### PR TITLE
Add file type validation

### DIFF
--- a/app/components/question/file_component/view.html.erb
+++ b/app/components/question/file_component/view.html.erb
@@ -6,7 +6,8 @@
                                   hint: {
                                     text: question.hint_text,
                                     class: "govuk-!-margin-bottom-7"
-                                  }
+                                  },
+                                  accept: Question::File::FILE_TYPES.join(", ")
 %>
 
 <p class="govuk-body govuk-!-margin-bottom-8"><%= t("question/file.your_file_must_be_smaller_than")%></p>

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -5,8 +5,26 @@ module Question
     attribute :uploaded_file_key
     validates :file, presence: true, unless: :is_optional?
     validate :validate_file_size
+    validate :validate_file_extension
 
     FILE_UPLOAD_MAX_SIZE_IN_MB = 7
+    FILE_TYPES = [
+      "text/csv",
+      "image/jpeg",
+      "image/png",
+      "application/rtf",
+      "text/plain",
+      "application/pdf",
+      "application/json",
+      # .xlsx:
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      # .doc:
+      "application/msword",
+      # .docx:
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      # .odt:
+      "application/vnd.oasis.opendocument.text",
+    ].freeze
 
     def show_answer
       original_filename
@@ -51,6 +69,16 @@ module Question
           file_type: file.content_type,
         })
         errors.add(:file, :too_big)
+      end
+    end
+
+    def validate_file_extension
+      if file.present? && FILE_TYPES.exclude?(file.content_type)
+        Rails.logger.info("File upload question validation failed: disallowed file type", {
+          file_size_in_bytes: file.size,
+          file_type: file.content_type,
+        })
+        errors.add(:file, :disallowed_type)
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
           attributes:
             file:
               blank: Select a file
+              disallowed_type: The selected file must be a CSV, JPEG, JPG, PNG, XLSX, DOC, DOCX, PDF, JSON, ODT, RTF or TXT
               too_big: The selected file must be smaller than 7MB
         question/name:
           attributes:

--- a/spec/components/question/file_component/view_spec.rb
+++ b/spec/components/question/file_component/view_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Question::FileComponent::View, type: :component do
       expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
     end
 
-    it "renders a file input field" do
-      expect(page).to have_css("input[type='file'][name='form[file]']")
+    it "renders a file input field with the correct accept attribute" do
+      expect(page).to have_css("input[type='file'][name='form[file]'][accept='#{Question::File::FILE_TYPES.join(', ')}']")
     end
 
     context "when the question has hint text" do

--- a/spec/features/fill_in_file_upload_question_spec.rb
+++ b/spec/features/fill_in_file_upload_question_spec.rb
@@ -21,10 +21,10 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
     }
   end
 
-  let(:test_file) { Tempfile.new(%w[a-file txt]) }
+  let(:test_file) { "tmp/a-file.txt" }
 
   after do
-    test_file.unlink
+    File.delete(test_file) if File.exist?(test_file)
   end
 
   before do
@@ -37,6 +37,8 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
     mock_s3_client = Aws::S3::Client.new(stub_responses: true)
     allow(Aws::S3::Client).to receive(:new).and_return(mock_s3_client)
     allow(mock_s3_client).to receive(:put_object)
+
+    FileUtils.touch test_file
   end
 
   scenario "As a form filler" do
@@ -67,7 +69,7 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
   end
 
   def when_i_upload_a_file
-    attach_file question_text, test_file.path
+    attach_file question_text, test_file
   end
 
   def and_i_click_on_continue
@@ -77,7 +79,7 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
   def then_i_should_see_the_check_your_answers_page
     expect(page.find("h1")).to have_text "Check your answers before submitting your form"
     expect(page).to have_text question_text
-    expect(page).to have_text File.basename(test_file.path)
+    expect(page).to have_text File.basename(test_file)
     expect_page_to_have_no_axe_errors(page)
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/Nr7OQkk2/2092-limit-the-file-types-that-can-be-uploaded

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Adds:
- backend validation to restrict the files we accept to the following MIME types:
  - text/csv (.csv)
  - image/jpeg (.jpg, .jpeg)
  - image/png (.png)
  - application/rtf (.rtf)
  - text/plain (.txt)
  - application/pdf (.pdf)
  - application/json (.json)
  - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet (.xlsx)
  - application/msword (.doc)
  - application/vnd.openxmlformats-officedocument.wordprocessingml.document (.docx)
  - application/vnd.oasis.opendocument.text (.odt)
- an `accept` attribute on the file input with the same MIME types above. This will provide hints to the user's operating system on what kinds of files they should choose.

### Testing instructions
If you want to bypass the `accept` attribute on a Mac in order to test the backend validation, you can:
- click 'Browse', click Show Options in the Finder window that pops up, then change 'Format' to  'All files'.

### Screenshots
When selecting a file, you should see hints about allowed files - in Finder on a Mac it looks like this:
![image](https://github.com/user-attachments/assets/94629cd6-2aeb-435f-99f3-8127608f2b55)

After submitting a file of the wrong type, you should see this error message:
![The selected file must be a CSV, JPEG, JPG, PNG, XLSX, DOC, DOCX, PDF, JSON, ODT, RTF or TXT](https://github.com/user-attachments/assets/0978ccdb-9cec-4e70-98af-23623335d525)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
