### PR TITLE
Revert "Change CsvGenerator to use all_steps"

### DIFF
--- a/app/lib/csv_generator.rb
+++ b/app/lib/csv_generator.rb
@@ -7,7 +7,7 @@ class CsvGenerator
   def self.write_submission(current_context:, submission_reference:, timestamp:, output_file_path:)
     headers = ["Reference", "Submitted at"]
     values = [submission_reference, timestamp.iso8601]
-    current_context.all_steps.map do |page|
+    current_context.completed_steps.map do |page|
       headers.push(*page.show_answer_in_csv.keys)
       values.push(*page.show_answer_in_csv.values)
     end

--- a/spec/features/fill_in_and_submit_form_with_csv_spec.rb
+++ b/spec/features/fill_in_and_submit_form_with_csv_spec.rb
@@ -113,8 +113,8 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
     delivered_email = ActionMailer::Base.deliveries.first
 
     expected_content = [
-      ["Reference", "Submitted at", question_text, "An optional question?", "A routing question?", "a question skipped through routing"],
-      [reference, formatted_timestamp, answer_text, "", "Option 1", ""],
+      ["Reference", "Submitted at", question_text, "An optional question?", "A routing question?"],
+      [reference, formatted_timestamp, answer_text, "", "Option 1"],
     ]
 
     expect(parse_email_csv(delivered_email)).to match_array(expected_content)

--- a/spec/lib/csv_generator_spec.rb
+++ b/spec/lib/csv_generator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CsvGenerator do
   let(:name_question) { build :first_middle_last_name_question, question_text: "What is your name?" }
   let(:first_step) { build :step, question: text_question }
   let(:second_step) { build :step, question: name_question }
-  let(:current_context) { OpenStruct.new(form:, all_steps: [first_step, second_step], support_details: OpenStruct.new(call_back_url: "http://gov.uk")) }
+  let(:current_context) { OpenStruct.new(form:, completed_steps: [first_step, second_step], support_details: OpenStruct.new(call_back_url: "http://gov.uk")) }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
   let(:timestamp) do
     Time.use_zone("London") { Time.zone.local(2022, 9, 14, 8, 0o0, 0o0) }


### PR DESCRIPTION
This reverts commit ec8588c3a3b5bbed3939a3ab53406a2eefcfddc0.

### Revert the change to CSV output

Errors submitting production forms indicate that this change is responsible.

This PR reverts the commit which changes the CSV generator to use all questions within a form, even if they haven't been answerd.

At first glance, it looks like empty selection questions are causing the errors to be thrown.

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
