### PR TITLE
Play back what file has been uploaded to users, and allow them to change file

### DIFF
--- a/app/components/question/file_review_component/view.html.erb
+++ b/app/components/question/file_review_component/view.html.erb
@@ -13,7 +13,8 @@
       row.with_cell(text: question.original_filename)
       row.with_cell do |cell|
         form_with url: @remove_file_url, method: :post do |form|
-          form.govuk_submit t('forms.review_file.show.remove'), secondary: true
+          button_content = "#{t('forms.review_file.show.remove')} <span class='govuk-visually-hidden'>#{t('forms.review_file.show.hidden_text')}</span>".html_safe
+          form.govuk_submit button_content, secondary: true
         end
       end
     end

--- a/app/components/question/file_review_component/view.html.erb
+++ b/app/components/question/file_review_component/view.html.erb
@@ -1,0 +1,25 @@
+<% if question.page_heading.present? %>
+  <h2 class="govuk-heading-m"><%= question_text_with_extra_suffix %></h2>
+<% else %>
+  <h1 class="govuk-heading-l"><%= question_text_with_extra_suffix %></h1>
+<% end %>
+
+<%= hint_text %>
+
+<%= govuk_table(classes: "govuk-!-margin-top-7") do |table|
+  table.with_caption(size: 'm', text: t('forms.review_file.show.table_heading'))
+  table.with_body do |body|
+    body.with_row do |row|
+      row.with_cell(text: question.original_filename)
+      row.with_cell do |cell|
+        form_with url: @remove_file_url, method: :post do |form|
+          form.govuk_submit t('forms.review_file.show.remove'), secondary: true
+        end
+      end
+    end
+  end
+end %>
+
+<p>
+  <% t('forms.review_file.show.remove_file_guidance') %>
+</p>

--- a/app/components/question/file_review_component/view.html.erb
+++ b/app/components/question/file_review_component/view.html.erb
@@ -1,8 +1,4 @@
-<% if question.page_heading.present? %>
-  <h2 class="govuk-heading-m"><%= question_text_with_extra_suffix %></h2>
-<% else %>
-  <h1 class="govuk-heading-l"><%= question_text_with_extra_suffix %></h1>
-<% end %>
+<h1 class="govuk-heading-l"><%= question_text_with_extra_suffix %></h1>
 
 <%= hint_text %>
 

--- a/app/components/question/file_review_component/view.html.erb
+++ b/app/components/question/file_review_component/view.html.erb
@@ -3,13 +3,14 @@
 <%= hint_text %>
 
 <%= govuk_table(classes: "govuk-!-margin-top-7") do |table|
-  table.with_caption(size: 'm', text: t('forms.review_file.show.table_heading'))
+  table.with_caption(size: 'm', text: t('forms.review_file.show.table_caption'))
   table.with_body do |body|
     body.with_row do |row|
+      row.with_cell(text: t('forms.review_file.show.table_header'), header: true)
       row.with_cell(text: question.original_filename)
       row.with_cell do |cell|
         form_with url: @remove_file_url, method: :post do |form|
-          button_content = "#{t('forms.review_file.show.remove')} <span class='govuk-visually-hidden'>#{t('forms.review_file.show.hidden_text')}</span>".html_safe
+          button_content = "#{t('forms.review_file.show.remove')} <span class='govuk-visually-hidden'>#{t('forms.review_file.show.table_header')}</span>".html_safe
           form.govuk_submit button_content, secondary: true
         end
       end

--- a/app/components/question/file_review_component/view.html.erb
+++ b/app/components/question/file_review_component/view.html.erb
@@ -18,5 +18,5 @@
 end %>
 
 <p>
-  <% t('forms.review_file.show.remove_file_guidance') %>
+  <%= t('forms.review_file.show.remove_file_guidance') %>
 </p>

--- a/app/components/question/file_review_component/view.rb
+++ b/app/components/question/file_review_component/view.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Question::FileReviewComponent
+  class View < Question::Base
+    def initialize(question:, extra_question_text_suffix:, remove_file_url:)
+      @remove_file_url = remove_file_url
+      super(form_builder: nil, question:, extra_question_text_suffix:)
+    end
+  end
+end

--- a/app/components/success_banner_component/view.html.erb
+++ b/app/components/success_banner_component/view.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_notification_banner(title_text: t("banner.success.title"), success: true) do |nb| %>
+      <% nb.with_heading(text: @success, tag: "p") %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/success_banner_component/view.rb
+++ b/app/components/success_banner_component/view.rb
@@ -1,0 +1,12 @@
+module SuccessBannerComponent
+  class View < ViewComponent::Base
+    def initialize(success:)
+      @success = success
+      super
+    end
+
+    def render?
+      @success.present?
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   before_action :check_maintenance_mode_is_enabled
   after_action :add_robots_header
 
+  add_flash_types :success
+
   def accessibility_statement; end
 
   def cookies; end

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -9,6 +9,8 @@ module Forms
 
     def show
       redirect_to form_page_path(@step.form_id, @step.form_slug, current_context.next_page_slug) unless current_context.can_visit?(@step.page_slug)
+      redirect_to review_file_page if answered_file_question?
+
       back_link(@step.page_slug)
       setup_instance_vars_for_view
     end
@@ -69,11 +71,17 @@ module Forms
     end
 
     def save_redirect_path
-      if @step.question.is_a?(Question::File) && @step.question.file_uploaded?
-        return review_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
-      end
+      return review_file_page if answered_file_question?
 
       next_page
+    end
+
+    def answered_file_question?
+      @step.question.is_a?(Question::File) && @step.question.file_uploaded?
+    end
+
+    def review_file_page
+      review_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
     end
 
     def next_page
@@ -122,10 +130,10 @@ module Forms
       }.name
 
       event_name = if first_goto_error_name == "cannot_have_goto_page_before_routing_page"
-                     "goto_page_before_routing_page_error"
-                   else
-                     "goto_page_doesnt_exist_error"
-                   end
+        "goto_page_before_routing_page_error"
+      else
+        "goto_page_doesnt_exist_error"
+      end
 
       EventLogger.log_page_event(event_name, @step.question.question_text, nil)
 
@@ -148,5 +156,6 @@ module Forms
     def save_url
       save_form_page_path(@step.form_id, @step.form_slug, @step.id, changing_existing_answer: @changing_existing_answer, answer_index:)
     end
+
   end
 end

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -26,7 +26,7 @@ module Forms
           LogEventService.new(current_context, @step, request, changing_existing_answer, page_params).log_page_save
         end
 
-        redirect_to save_redirect_path
+        redirect_post_save
       else
         setup_instance_vars_for_view
         render :show, status: :unprocessable_entity
@@ -70,10 +70,10 @@ module Forms
       end
     end
 
-    def save_redirect_path
-      return review_file_page if answered_file_question?
+    def redirect_post_save
+      return redirect_to review_file_page, success: t("banner.success.file_uploaded") if answered_file_question?
 
-      next_page
+      redirect_to next_page
     end
 
     def answered_file_question?

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -24,7 +24,7 @@ module Forms
           LogEventService.new(current_context, @step, request, changing_existing_answer, page_params).log_page_save
         end
 
-        redirect_to next_page
+        redirect_to save_redirect_path
       else
         setup_instance_vars_for_view
         render :show, status: :unprocessable_entity
@@ -66,6 +66,14 @@ module Forms
       elsif previous_step
         @back_link = previous_step.repeatable? ? add_another_answer_path(form_id: current_context.form.id, form_slug: current_context.form.form_slug, page_slug: previous_step.page_slug) : form_page_path(@step.form_id, @step.form_slug, previous_step.page_id)
       end
+    end
+
+    def save_redirect_path
+      if @step.question.is_a?(Question::File) && @step.question.file_uploaded?
+        return review_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
+      end
+
+      next_page
     end
 
     def next_page

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -81,7 +81,7 @@ module Forms
     end
 
     def review_file_page
-      review_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
+      review_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
     end
 
     def next_page
@@ -130,10 +130,10 @@ module Forms
       }.name
 
       event_name = if first_goto_error_name == "cannot_have_goto_page_before_routing_page"
-        "goto_page_before_routing_page_error"
-      else
-        "goto_page_doesnt_exist_error"
-      end
+                     "goto_page_before_routing_page_error"
+                   else
+                     "goto_page_doesnt_exist_error"
+                   end
 
       EventLogger.log_page_event(event_name, @step.question.question_text, nil)
 
@@ -156,6 +156,5 @@ module Forms
     def save_url
       save_form_page_path(@step.form_id, @step.form_slug, @step.id, changing_existing_answer: @changing_existing_answer, answer_index:)
     end
-
   end
 end

--- a/app/controllers/forms/review_file_controller.rb
+++ b/app/controllers/forms/review_file_controller.rb
@@ -12,11 +12,7 @@ module Forms
       @step.question.delete_from_s3
       current_context.clear_stored_answer(@step)
 
-      if changing_existing_answer
-        redirect_to form_change_answer_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
-      else
-        redirect_to form_page_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
-      end
+      redirect_to redirect_after_delete_path, success: t("banner.success.file_removed")
     end
 
     def continue
@@ -29,6 +25,14 @@ module Forms
       unless @step.question.is_a?(Question::File) && @step.question.file_uploaded?
         redirect_to form_page_path(@step.form_id, @step.form_slug, @step.page_slug)
       end
+    end
+
+    def redirect_after_delete_path
+      if changing_existing_answer
+        return form_change_answer_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
+      end
+
+      form_page_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
     end
   end
 end

--- a/app/controllers/forms/review_file_controller.rb
+++ b/app/controllers/forms/review_file_controller.rb
@@ -4,13 +4,19 @@ module Forms
 
     def show
       back_link(@step.page_slug)
-      @continue_url = review_file_continue_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
+      @remove_file_url = remove_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
+      @continue_url = review_file_continue_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
     end
 
     def delete
       @step.question.delete_from_s3
       current_context.clear_stored_answer(@step)
-      redirect_to form_page_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
+
+      if changing_existing_answer
+        redirect_to form_change_answer_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
+      else
+        redirect_to form_page_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
+      end
     end
 
     def continue

--- a/app/controllers/forms/review_file_controller.rb
+++ b/app/controllers/forms/review_file_controller.rb
@@ -7,7 +7,11 @@ module Forms
       @continue_url = review_file_continue_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
     end
 
-    def delete; end
+    def delete
+      @step.question.delete_from_s3
+      current_context.clear_stored_answer(@step)
+      redirect_to form_page_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
+    end
 
     def continue
       redirect_to next_page

--- a/app/controllers/forms/review_file_controller.rb
+++ b/app/controllers/forms/review_file_controller.rb
@@ -1,0 +1,24 @@
+module Forms
+  class ReviewFileController < PageController
+    before_action :redirect_if_not_answered_file_question
+
+    def show
+      back_link(@step.page_slug)
+      @continue_url = review_file_continue_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
+    end
+
+    def delete; end
+
+    def continue
+      redirect_to next_page
+    end
+
+  private
+
+    def redirect_if_not_answered_file_question
+      unless @step.question.is_a?(Question::File) && @step.question.file_uploaded?
+        redirect_to form_page_path(@step.form_id, @step.form_slug, @step.page_slug)
+      end
+    end
+  end
+end

--- a/app/lib/flow/context.rb
+++ b/app/lib/flow/context.rb
@@ -28,6 +28,10 @@ module Flow
       step.save_to_context(@form_context)
     end
 
+    def clear_stored_answer(step)
+      @form_context.clear_stored_answer(step)
+    end
+
     def previous_step(page_slug)
       index = completed_steps.find_index { |step| step.page_slug == page_slug }
       return nil if completed_steps.empty? || index&.zero?

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -60,6 +60,10 @@ module Question
       }).body.read
     end
 
+    def file_uploaded?
+      uploaded_file_key.present?
+    end
+
   private
 
     def validate_file_size

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -60,6 +60,14 @@ module Question
       }).body.read
     end
 
+    def delete_from_s3
+      s3 = Aws::S3::Client.new
+      s3.delete_object({
+        bucket: Settings.aws.file_upload_s3_bucket_name,
+        key: uploaded_file_key,
+      })
+    end
+
     def file_uploaded?
       uploaded_file_key.present?
     end

--- a/app/services/aws_ses_submission_service.rb
+++ b/app/services/aws_ses_submission_service.rb
@@ -51,7 +51,7 @@ private
 
   def uploaded_files_in_answers
     @current_context.completed_steps
-                   .select { |step| step.question.is_a?(Question::File) && step.question.uploaded_file_key.present? }
+                   .select { |step| step.question.is_a?(Question::File) && step.question.file_uploaded? }
                    .map { |step| [step.question.original_filename, step.question.file_from_s3] }
                    .to_h
   end

--- a/app/views/forms/review_file/show.html.erb
+++ b/app/views/forms/review_file/show.html.erb
@@ -10,8 +10,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render GuidanceComponent::View.new(@step.question) %>
 
-    <% remove_file_url = remove_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug) %>
-    <%= render Question::FileReviewComponent::View.new(question: @step.question, extra_question_text_suffix: hidden_text_mode(@mode).html_safe, remove_file_url: ) %>
+    <%= render Question::FileReviewComponent::View.new(question: @step.question, extra_question_text_suffix: hidden_text_mode(@mode).html_safe, remove_file_url: @remove_file_url ) %>
 
     <%= form_with model: @step.question, url: @continue_url, scope: :question, method: :post do |form| %>
       <%= form.govuk_submit %>

--- a/app/views/forms/review_file/show.html.erb
+++ b/app/views/forms/review_file/show.html.erb
@@ -1,0 +1,22 @@
+<% set_page_title(form_title(form_name: @current_context.form.name, page_name: (@step.question.page_heading.present? ? @step.question.page_heading : @step.question.question_text), mode: @mode, error: @step.question&.errors&.any?)) %>
+
+<% content_for :back_link do %>
+  <% if @back_link.present? %>
+    <%= link_to "Back", @back_link, class: "govuk-back-link" %>
+  <% end %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render GuidanceComponent::View.new(@step.question) %>
+
+    <% remove_file_url = remove_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug) %>
+    <%= render Question::FileReviewComponent::View.new(question: @step.question, extra_question_text_suffix: hidden_text_mode(@mode).html_safe, remove_file_url: ) %>
+
+    <%= form_with model: @step.question, url: @continue_url, scope: :question, method: :post do |form| %>
+      <%= form.govuk_submit %>
+    <% end %>
+
+    <%= render SupportDetailsComponent::View.new(@support_details) %>
+  </div>
+</div>

--- a/app/views/forms/review_file/show.html.erb
+++ b/app/views/forms/review_file/show.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(form_title(form_name: @current_context.form.name, page_name: (@step.question.page_heading.present? ? @step.question.page_heading : @step.question.question_text), mode: @mode, error: @step.question&.errors&.any?)) %>
+<% set_page_title(form_title(form_name: @current_context.form.name, page_name: @step.question.question_text, mode: @mode, error: @step.question&.errors&.any?)) %>
 
 <% content_for :back_link do %>
   <% if @back_link.present? %>
@@ -8,8 +8,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render GuidanceComponent::View.new(@step.question) %>
-
     <%= render Question::FileReviewComponent::View.new(question: @step.question, extra_question_text_suffix: hidden_text_mode(@mode).html_safe, remove_file_url: @remove_file_url ) %>
 
     <%= form_with model: @step.question, url: @continue_url, scope: :question, method: :post do |form| %>

--- a/app/views/forms/review_file/show.html.erb
+++ b/app/views/forms/review_file/show.html.erb
@@ -1,4 +1,4 @@
-<% set_page_title(form_title(form_name: @current_context.form.name, page_name: @step.question.question_text, mode: @mode, error: @step.question&.errors&.any?)) %>
+<% set_page_title("#{t('forms.review_file.show.table_caption')} - #{form_title(form_name: @current_context.form.name, page_name: @step.question.question_text, mode: @mode, error: @step.question&.errors&.any?)}") %>
 
 <% content_for :back_link do %>
   <% if @back_link.present? %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -43,6 +43,8 @@
       <%= yield(:before_content) %>
 
       <main class="govuk-main-wrapper" id="main-content">
+        <%= render(SuccessBannerComponent::View.new(success:)) %>
+
         <%= render(PreviewBannerComponent::View.new(mode: @mode)) %>
 
         <%= yield %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,10 +158,10 @@ en:
         short_answer_legend: Are you sure you want to remove ‘%{answer_text}’?
     review_file:
       show:
-        hidden_text: Your file
         remove: Remove
         remove_file_guidance: You can remove this file if you need to upload a different one.
-        table_heading: Your uploaded file
+        table_caption: Check your uploaded file
+        table_header: Your file
   helpers:
     hint:
       email_confirmation_input:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,10 @@ en:
               blank: You must select an option
   autocomplete:
     prompt: Select an answer
+  banner:
+    success:
+      file_removed: Your file has been removed
+      title: Success
   cookie_banner:
     accept: Accept analytics cookies
     content: We’d like to use analytics cookies so we can understand how you use this website and make improvements.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,7 @@ en:
   banner:
     success:
       file_removed: Your file has been removed
+      file_uploaded: Your file has been uploaded
       title: Success
   cookie_banner:
     accept: Accept analytics cookies

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,6 +152,11 @@ en:
         phone_number_heading: Remove phone number
         phone_number_radios_legend: Are you sure you want to remove this phone number?
         short_answer_legend: Are you sure you want to remove ‘%{answer_text}’?
+    review_file:
+      show:
+        remove: Remove
+        remove_file_guidance: You can remove this file if you need to upload a different one.
+        table_heading: Your uploaded file
   helpers:
     hint:
       email_confirmation_input:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,6 +158,7 @@ en:
         short_answer_legend: Are you sure you want to remove ‘%{answer_text}’?
     review_file:
       show:
+        hidden_text: Your file
         remove: Remove
         remove_file_guidance: You can remove this file if you need to upload a different one.
         table_heading: Your uploaded file

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,18 @@ Rails.application.routes.draw do
            as: :save_add_another_answer,
            constraints: page_constraints
 
+      # We don't currently support adding another answer for file upload questions, so these routes don't include an
+      # `answer_index` param
+      get "/:page_slug/review-file" => "forms/review_file#show",
+          as: :review_file,
+          constraints: page_constraints
+      post "/:page_slug/review-file" => "forms/review_file#continue",
+           as: :review_file_continue,
+           constraints: page_constraints
+      post "/:page_slug/remove-file" => "forms/review_file#delete",
+           as: :remove_file,
+           constraints: page_constraints
+
       get "/:page_slug/(/:answer_index)/change" => "forms/page#show",
           as: :form_change_answer,
           defaults: page_answer_defaults.merge(changing_existing_answer: true),

--- a/spec/components/question/file_review_component/file_review_component_preview.rb
+++ b/spec/components/question/file_review_component/file_review_component_preview.rb
@@ -1,0 +1,18 @@
+class Question::FileReviewComponent::FileReviewComponentPreview < ViewComponent::Preview
+  def file_review
+    question = OpenStruct.new(answer_type: "file",
+                              original_filename: "a_file.png",
+                              question_text_with_optional_suffix: "Upload your photo",
+                              answer_settings: nil)
+    render(Question::FileReviewComponent::View.new(question:, extra_question_text_suffix: "", remove_file_url: "/remove_file"))
+  end
+
+  def file_review_with_hint
+    question = OpenStruct.new(answer_type: "file",
+                              original_filename: "a_file.png",
+                              question_text_with_optional_suffix: "Upload your photo",
+                              hint_text: "Make sure your face is clearly visible",
+                              answer_settings: nil)
+    render(Question::FileReviewComponent::View.new(question:, extra_question_text_suffix: "", remove_file_url: "/remove_file"))
+  end
+end

--- a/spec/components/question/file_review_component/view_spec.rb
+++ b/spec/components/question/file_review_component/view_spec.rb
@@ -14,18 +14,8 @@ RSpec.describe Question::FileReviewComponent::View, type: :component do
     render_inline(described_class.new(question:, extra_question_text_suffix:, remove_file_url:))
   end
 
-  context "when there is no page heading" do
-    it "renders the question text as a h1" do
-      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
-    end
-  end
-
-  context "when there is a page heading" do
-    let(:page_heading) { Faker::Lorem.sentence }
-
-    it "renders the question text as a h2" do
-      expect(page.find("h2")).to have_text(question.question_text_with_optional_suffix)
-    end
+  it "renders the question text as a h1" do
+    expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
   end
 
   context "when the question has hint text" do

--- a/spec/components/question/file_review_component/view_spec.rb
+++ b/spec/components/question/file_review_component/view_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe Question::FileReviewComponent::View, type: :component do
+  let(:question_page) { build :page, answer_type: "file" }
+  let(:is_optional) { false }
+  let(:question_text) { "Upload a file" }
+  let(:page_heading) { nil }
+  let(:hint_text) { nil }
+  let(:question) { build :file, :with_uploaded_file, question_text:, is_optional:, page_heading:, hint_text: }
+  let(:extra_question_text_suffix) { nil }
+  let(:remove_file_url) { "/remove_file" }
+
+  before do
+    render_inline(described_class.new(question:, extra_question_text_suffix:, remove_file_url:))
+  end
+
+  context "when there is no page heading" do
+    it "renders the question text as a h1" do
+      expect(page.find("h1")).to have_text(question.question_text_with_optional_suffix)
+    end
+  end
+
+  context "when there is a page heading" do
+    let(:page_heading) { Faker::Lorem.sentence }
+
+    it "renders the question text as a h2" do
+      expect(page.find("h2")).to have_text(question.question_text_with_optional_suffix)
+    end
+  end
+
+  context "when the question has hint text" do
+    let(:hint_text) { Faker::Lorem.sentence }
+
+    it "outputs the hint text" do
+      expect(page.find(".govuk-hint")).to have_text(hint_text)
+    end
+  end
+
+  context "when the question has no hint text" do
+    it "does not output the hint text" do
+      expect(page).not_to have_css(".govuk-hint")
+    end
+  end
+
+  it "renders the original file name" do
+    expect(page).to have_content(question.original_filename)
+  end
+
+  it "has a button to delete the file" do
+    within(page.find("form[action='#{remove_file_url}'][method='post']")) do
+      expect(page).to have_button("Remove")
+    end
+  end
+
+  context "when there is an extra suffix to be added to the heading" do
+    let(:extra_question_text_suffix) { "Some extra text to add to the question text" }
+
+    it "renders the question text and extra suffix as a heading" do
+      expect(page.find("h1")).to have_text("#{question.question_text} #{extra_question_text_suffix}")
+    end
+  end
+
+  context "with unsafe question text" do
+    let(:question_text) { "What is your name? <script>alert(\"Hi\")</script>" }
+    let(:extra_question_text_suffix) { "<span>Some trusted html</span>" }
+
+    it "returns the escaped title with the optional suffix" do
+      expected_output = "What is your name? &lt;script&gt;alert(\"Hi\")&lt;/script&gt; <span>Some trusted html</span>"
+      expect(page.find("h1").native.inner_html).to eq(expected_output)
+    end
+  end
+end

--- a/spec/components/question/file_review_component/view_spec.rb
+++ b/spec/components/question/file_review_component/view_spec.rb
@@ -66,4 +66,8 @@ RSpec.describe Question::FileReviewComponent::View, type: :component do
       expect(page.find("h1").native.inner_html).to eq(expected_output)
     end
   end
+
+  it "has text to explain the file can be removed" do
+    expect(page).to have_content(I18n.t("forms.review_file.show.remove_file_guidance"))
+  end
 end

--- a/spec/components/question/file_review_component/view_spec.rb
+++ b/spec/components/question/file_review_component/view_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe Question::FileReviewComponent::View, type: :component do
   it "has a button to delete the file" do
     within(page.find("form[action='#{remove_file_url}'][method='post']")) do
       expect(page).to have_button("Remove")
+      expect(page).to have_css("button span.hidden-text", text: t("forms.review_file.show.hidden_text"))
+    end
+  end
+
+  it "the button to delete the file has hidden text" do
+    within(page.find("form[action='#{remove_file_url}'][method='post']")) do
+      expect(page).to have_css("button span.hidden-text", text: t("forms.review_file.show.hidden_text"))
     end
   end
 

--- a/spec/factories/models/question/file.rb
+++ b/spec/factories/models/question/file.rb
@@ -18,5 +18,10 @@ FactoryBot.define do
       is_optional { true }
       original_filename { "" }
     end
+
+    trait :with_guidance do
+      page_heading { Faker::Lorem.sentence }
+      guidance_markdown { Faker::Lorem.paragraph }
+    end
   end
 end

--- a/spec/features/fill_in_file_upload_question_spec.rb
+++ b/spec/features/fill_in_file_upload_question_spec.rb
@@ -80,8 +80,8 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
 
   def then_i_see_the_review_file_page
     expect(page.find("h1")).to have_text question_text
-    expect(page).to have_text "Your uploaded file"
-    expect(page).to have_text File.basename(test_file.path)
+    expect(page).to have_text "Check your uploaded file"
+    expect(page).to have_text File.basename(File.path(test_file))
   end
 
   def then_i_should_see_the_check_your_answers_page

--- a/spec/features/fill_in_file_upload_question_spec.rb
+++ b/spec/features/fill_in_file_upload_question_spec.rb
@@ -47,6 +47,8 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
     then_i_see_the_file_upload_component
     when_i_upload_a_file
     and_i_click_on_continue
+    then_i_see_the_review_file_page
+    and_i_click_on_continue
     then_i_should_see_the_check_your_answers_page
 
     when_i_opt_out_of_email_confirmation
@@ -74,6 +76,12 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
 
   def and_i_click_on_continue
     click_button "Continue"
+  end
+
+  def then_i_see_the_review_file_page
+    expect(page.find("h1")).to have_text question_text
+    expect(page).to have_text "Your uploaded file"
+    expect(page).to have_text File.basename(test_file.path)
   end
 
   def then_i_should_see_the_check_your_answers_page

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -123,6 +123,30 @@ RSpec.describe Question::File, type: :model do
     end
   end
 
+  describe "#delete_from_s3" do
+    subject(:question) { described_class.new({ original_filename: "a-file.png", uploaded_file_key: }, options) }
+
+    let(:mock_s3_client) { Aws::S3::Client.new(stub_responses: true) }
+    let(:bucket) { "an-s3-bucket" }
+    let(:uploaded_file_key) { Faker::Alphanumeric.alphanumeric }
+
+    before do
+      allow(Aws::S3::Client).to receive(:new).and_return(mock_s3_client)
+      allow(mock_s3_client).to receive(:delete_object)
+      allow(Settings.aws).to receive(:file_upload_s3_bucket_name).and_return(bucket)
+    end
+
+    it("calls S3 to delete the file") do
+      expect(mock_s3_client).to receive(:delete_object).with(
+        {
+          bucket:,
+          key: uploaded_file_key,
+        },
+      )
+      question.delete_from_s3
+    end
+  end
+
   describe "#file_uploaded?" do
     subject(:question) { described_class.new({ uploaded_file_key: }, options) }
 

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -123,6 +123,26 @@ RSpec.describe Question::File, type: :model do
     end
   end
 
+  describe "#file_uploaded?" do
+    subject(:question) { described_class.new({ uploaded_file_key: }, options) }
+
+    context "when a file has been uploaded" do
+      let(:uploaded_file_key) { Faker::Alphanumeric.alphanumeric }
+
+      it "returns true" do
+        expect(question.file_uploaded?).to be true
+      end
+    end
+
+    context "when a file has not been uploaded" do
+      let(:uploaded_file_key) { nil }
+
+      it "returns false" do
+        expect(question.file_uploaded?).to be false
+      end
+    end
+  end
+
   describe "validations" do
     context "when the question is mandatory" do
       context "when no file is set" do

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -627,6 +627,12 @@ RSpec.describe Forms::PageController, type: :request do
           expect(response).to redirect_to review_file_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
         end
 
+        it "displays a success banner" do
+          post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: }
+
+          expect(flash[:success]).to eq(I18n.t("banner.success.file_uploaded"))
+        end
+
         context "when changing an existing answer" do
           it "includes the changing_existing_answer query parameter in the redirect" do
             post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1, changing_existing_answer: true), params: { question: }

--- a/spec/requests/forms/review_file_controller_spec.rb
+++ b/spec/requests/forms/review_file_controller_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe Forms::ReviewFileController, type: :request do
+  let(:form_data) do
+    build(:v2_form_document, :with_support, :live?,
+          id: 1,
+          start_page: 1,
+          privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
+          what_happens_next_markdown: "Good things come to those that wait",
+          declaration_text: "agree to the declaration",
+          steps: steps_data)
+  end
+
+  let(:file_upload_step) do
+    build :v2_question_page_step,
+          id: 1,
+          next_step_id: 2,
+          answer_type: "file"
+  end
+
+  let(:text_question_step) do
+    build :v2_question_page_step, :with_text_settings,
+          id: 2
+  end
+
+  let(:steps_data) { [file_upload_step, text_question_step] }
+
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:api_url_suffix) { "/live" }
+  let(:mode) { "form" }
+
+  let(:uploaded_filename) { "test.jpg" }
+  let(:store) do
+    {
+      answers: {
+        form_data.id.to_s => {
+          file_upload_step.id.to_s => {
+            "original_filename" => uploaded_filename,
+            "uploaded_file_key" => "test_key",
+          },
+        },
+      },
+    }
+  end
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v2/forms/1#{api_url_suffix}", req_headers, form_data.to_json, 200
+    end
+
+    allow(Flow::Context).to receive(:new).and_wrap_original do |original_method, *args|
+      context_spy = original_method.call(form: args[0][:form], store:)
+      context_spy
+    end
+  end
+
+  describe "#show" do
+    before do
+      get review_file_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug:)
+    end
+
+    context "when the question is a file upload question" do
+      let(:page_slug) { file_upload_step.id }
+
+      context "when a file has been uploaded" do
+        it "renders the review file template" do
+          expect(response).to render_template("forms/review_file/show")
+        end
+
+        it "displays the uploaded filename" do
+          expect(response.body).to include(uploaded_filename)
+        end
+      end
+
+      context "when a file has not been uploaded" do
+        let(:store) { {} }
+
+        it "redirects to the show page route" do
+          expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, page_slug)
+        end
+      end
+    end
+
+    context "when the question isn't a file upload question" do
+      let(:page_slug) { text_question_step.id }
+
+      it "redirects to the show page route" do
+        expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, page_slug)
+      end
+    end
+  end
+end

--- a/spec/requests/forms/review_file_controller_spec.rb
+++ b/spec/requests/forms/review_file_controller_spec.rb
@@ -159,4 +159,36 @@ RSpec.describe Forms::ReviewFileController, type: :request do
       end
     end
   end
+
+  describe "#continue" do
+    before do
+      post review_file_continue_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug:)
+    end
+
+    context "when the question is a file upload question" do
+      let(:page_slug) { file_upload_step.id.to_s }
+
+      context "when a file has been uploaded" do
+        it "redirects to the next step in the form" do
+          expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, text_question_step.id)
+        end
+      end
+
+      context "when a file has not been uploaded" do
+        let(:uploaded_file_key) { nil }
+
+        it "redirects to the show page route" do
+          expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, page_slug)
+        end
+      end
+    end
+
+    context "when the question isn't a file upload question" do
+      let(:page_slug) { text_question_step.id }
+
+      it "redirects to the show page route" do
+        expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, page_slug)
+      end
+    end
+  end
 end

--- a/spec/requests/forms/review_file_controller_spec.rb
+++ b/spec/requests/forms/review_file_controller_spec.rb
@@ -139,6 +139,10 @@ RSpec.describe Forms::ReviewFileController, type: :request do
           expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, page_slug)
         end
 
+        it "displays a success banner" do
+          expect(flash[:success]).to eq(I18n.t("banner.success.file_removed"))
+        end
+
         context "when changing an existing answer" do
           let(:changing_existing_answer) { true }
 

--- a/spec/views/forms/review_file/show.html.erb_spec.rb
+++ b/spec/views/forms/review_file/show.html.erb_spec.rb
@@ -38,26 +38,12 @@ describe "forms/review_file/show.html.erb" do
     end
   end
 
-  context "when the question has guidance" do
-    let(:question) { build :file, :with_uploaded_file, :with_guidance }
-
-    it "has the correct page title" do
-      expect(view.content_for(:title)).to eq "#{question.page_heading} - #{form.name}"
-    end
-
-    it "has the correct heading" do
-      expect(rendered).to have_css("h1", text: question.page_heading)
-    end
+  it "has the correct page title" do
+    expect(view.content_for(:title)).to eq "#{question.question_text} - #{form.name}"
   end
 
-  context "when the question does not have guidance" do
-    it "has the correct page title" do
-      expect(view.content_for(:title)).to eq "#{question.question_text} - #{form.name}"
-    end
-
-    it "has the correct heading" do
-      expect(rendered).to have_css("h1", text: question.question_text)
-    end
+  it "has the correct heading" do
+    expect(rendered).to have_css("h1", text: question.question_text)
   end
 
   it "displays the review file component with the uploaded file name" do

--- a/spec/views/forms/review_file/show.html.erb_spec.rb
+++ b/spec/views/forms/review_file/show.html.erb_spec.rb
@@ -5,6 +5,7 @@ describe "forms/review_file/show.html.erb" do
   let(:mode) { OpenStruct.new(preview_draft?: false, preview_archived?: false, preview_live?: false) }
   let(:back_link) { "/back" }
   let(:continue_url) { "/review_file" }
+  let(:remove_file_url) { "/remove_file" }
   let(:question) { build :file, :with_uploaded_file }
   let(:step) { build :step, question: }
   let(:support_details) { OpenStruct.new({ email: "help@example.gov.uk", phone: "Call 01610123456\n\nThis line is only open on Tuesdays.", url: "https://example.gov.uk/contact", url_text: "Contact form" }) }
@@ -15,6 +16,7 @@ describe "forms/review_file/show.html.erb" do
     assign(:step, step)
     assign(:back_link, back_link)
     assign(:continue_url, continue_url)
+    assign(:remove_file_url, remove_file_url)
     assign(:support_details, support_details)
 
     without_partial_double_verification do

--- a/spec/views/forms/review_file/show.html.erb_spec.rb
+++ b/spec/views/forms/review_file/show.html.erb_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+describe "forms/review_file/show.html.erb" do
+  let(:form) { build :form, :with_support, id: 1 }
+  let(:mode) { OpenStruct.new(preview_draft?: false, preview_archived?: false, preview_live?: false) }
+  let(:back_link) { "/back" }
+  let(:continue_url) { "/review_file" }
+  let(:question) { build :file, :with_uploaded_file }
+  let(:step) { build :step, question: }
+  let(:support_details) { OpenStruct.new({ email: "help@example.gov.uk", phone: "Call 01610123456\n\nThis line is only open on Tuesdays.", url: "https://example.gov.uk/contact", url_text: "Contact form" }) }
+
+  before do
+    assign(:current_context, OpenStruct.new(form:))
+    assign(:mode, mode)
+    assign(:step, step)
+    assign(:back_link, back_link)
+    assign(:continue_url, continue_url)
+    assign(:support_details, support_details)
+
+    without_partial_double_verification do
+      allow(view).to receive(:remove_file_path).and_return("/remove_file")
+    end
+
+    render
+  end
+
+  it "has a back link" do
+    expect(view.content_for(:back_link)).to have_link("Back", href: "/back")
+  end
+
+  context "when back link not preset" do
+    let(:back_link) { "" }
+
+    it "does not set back link" do
+      expect(view.content_for(:back_link)).to be_nil
+    end
+  end
+
+  context "when the question has guidance" do
+    let(:question) { build :file, :with_uploaded_file, :with_guidance }
+
+    it "has the correct page title" do
+      expect(view.content_for(:title)).to eq "#{question.page_heading} - #{form.name}"
+    end
+
+    it "has the correct heading" do
+      expect(rendered).to have_css("h1", text: question.page_heading)
+    end
+  end
+
+  context "when the question does not have guidance" do
+    it "has the correct page title" do
+      expect(view.content_for(:title)).to eq "#{question.question_text} - #{form.name}"
+    end
+
+    it "has the correct heading" do
+      expect(rendered).to have_css("h1", text: question.question_text)
+    end
+  end
+
+  it "displays the review file component with the uploaded file name" do
+    expect(rendered).to have_content(question.original_filename)
+  end
+
+  it "has a continue button" do
+    page = Capybara.string(rendered.html)
+    within(page.find("form[action='#{continue_url}'][method='post']")) do
+      expect(page).to have_button("Continue")
+    end
+  end
+end

--- a/spec/views/forms/review_file/show.html.erb_spec.rb
+++ b/spec/views/forms/review_file/show.html.erb_spec.rb
@@ -39,7 +39,7 @@ describe "forms/review_file/show.html.erb" do
   end
 
   it "has the correct page title" do
-    expect(view.content_for(:title)).to eq "#{question.question_text} - #{form.name}"
+    expect(view.content_for(:title)).to eq "#{I18n.t('forms.review_file.show.table_caption')} - #{question.question_text} - #{form.name}"
   end
 
   it "has the correct heading" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/mfhj3ufe/2068-play-back-what-file-has-been-uploaded-to-users-and-allow-them-to-change-file

This PR adds a review file page that allows a form filler to view the file they have uploaded, and optionally remove it. This is implemented usinga new `ReviewFileController` with new routes for showing the page and removing the file. This also requires tweaking the redirects in the `PageController` to take the user to the review file page:
- after uploading a file
- when editing an answer from check your answers
- when navigating to the file upload question directly with a file already uploaded

This PR will be followed by one which alters the flow slightly, to add a confirmation of removal screen. This will allow us to use the summary list component as intended by the design system (we think!).
### Screenshots

![Screenshot 2025-01-28 at 16 47 23](https://github.com/user-attachments/assets/7a5c830f-8d62-4bff-b7a8-e7acc7a811d4)
![Screenshot 2025-01-29 at 15 06 30](https://github.com/user-attachments/assets/caa9ebc9-c115-41af-94c9-134bcf4017ee)
![Screenshot 2025-01-28 at 16 48 41](https://github.com/user-attachments/assets/77ef53a4-bcb3-4683-b56d-e11de287d795)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
