### PR TITLE
Rename host logging field

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_logging_attributes
-    CurrentLoggingAttributes.host = request.host
+    CurrentLoggingAttributes.request_host = request.host
     CurrentLoggingAttributes.request_id = request.request_id
     CurrentLoggingAttributes.form_id = params[:form_id] if params[:form_id].present?
     CurrentLoggingAttributes.page_id = params[:page_slug] if params[:page_slug].present? && params[:page_slug].match(Page::PAGE_ID_REGEX)

--- a/app/models/current_logging_attributes.rb
+++ b/app/models/current_logging_attributes.rb
@@ -1,11 +1,11 @@
 class CurrentLoggingAttributes < ActiveSupport::CurrentAttributes
-  attribute :host, :request_id, :form_id, :form_name, :page_id, :page_slug, :session_id_hash, :trace_id,
+  attribute :request_host, :request_id, :form_id, :form_name, :page_id, :page_slug, :session_id_hash, :trace_id,
             :question_number, :submission_reference, :submission_email_reference, :submission_email_id,
             :confirmation_email_reference, :confirmation_email_id, :rescued_exception, :rescued_exception_trace
 
   def as_hash
     {
-      host:,
+      request_host:,
       request_id:,
       form_id:,
       form_name:,

--- a/spec/models/current_logging_attributes_spec.rb
+++ b/spec/models/current_logging_attributes_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CurrentLoggingAttributes, type: :model do
     end
 
     it "includes all properties when they are set" do
-      current.host = "www.example.com"
+      current.request_host = "www.example.com"
       current.request_id = "a-request-id"
       current.form_id = 1
       current.form_name = "A form"
@@ -31,7 +31,7 @@ RSpec.describe CurrentLoggingAttributes, type: :model do
       current.rescued_exception_trace = "a trace"
 
       expect(current.as_hash).to eq({
-        host: "www.example.com",
+        request_host: "www.example.com",
         request_id: "a-request-id",
         form_id: 1,
         form_name: "A form",

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe ApplicationController, type: :request do
       }
     end
 
-    it "includes the host on log lines" do
-      expect(log_lines[0]["host"]).to eq("www.example.com")
+    it "includes the request_host on log lines" do
+      expect(log_lines[0]["request_host"]).to eq("www.example.com")
     end
 
     it "includes the request_id on log lines" do

--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe Forms::BaseController, type: :request do
       expect(log_lines[0]["trace_id"]).to eq(trace_id)
     end
 
-    it "includes the host on log lines" do
-      expect(log_lines[0]["host"]).to eq("www.example.com")
+    it "includes the request_host on log lines" do
+      expect(log_lines[0]["request_host"]).to eq("www.example.com")
     end
 
     it "includes the request_id on log lines" do


### PR DESCRIPTION
### What problem does this pull request solve?

Rename the "host" logging field to "hostname". An additional "host" field is added to the logs that go to Splunk for Kenesis. This means we end up with 2 values for "host" making it difficult to filter searches by it.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
