### PR TITLE
WIP: Fix the issue which prevented the CSV including all questions in

### DIFF
--- a/app/models/question/selection.rb
+++ b/app/models/question/selection.rb
@@ -48,6 +48,8 @@ module Question
     end
 
     def selection_without_blanks
+      return [] if selection.nil?
+
       selection.reject(&:blank?)
     end
 

--- a/spec/features/fill_in_and_submit_form_with_csv_spec.rb
+++ b/spec/features/fill_in_and_submit_form_with_csv_spec.rb
@@ -1,20 +1,123 @@
 require "rails_helper"
 
 feature "Fill in and submit a form with a CSV submission", type: :feature do
-  let(:steps) do
-    [
-      build(:v2_question_page_step, :with_text_settings, id: 1, question_text:, next_step_id: 2),
-      build(:v2_question_page_step, :with_text_settings, id: 2, is_optional: true, question_text: "An optional question?", next_step_id: 3),
-      build(:v2_question_page_step, :with_selections_settings, id: 3, question_text: "A routing question?", routing_conditions: [DataStruct.new(routing_page_id: 3, check_page_id: 3, answer_value: "Option 1", goto_page_id: nil, skip_to_end: true, validation_errors: [])]),
-      build(:v2_question_page_step, :with_text_settings, id: 4, question_text: "a question skipped through routing"),
-
-    ]
-  end
-  let(:form) { build :v2_form_document, :live?, id: 1, name: "Fill in this form", steps:, start_page: steps.first.id, submission_type: "email_with_csv" }
-  let(:question_text) { Faker::Lorem.question }
-  let(:answer_text) { "Answer text" }
-
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+
+  let(:json) do
+    <<~JSON
+      {
+        "form_id": "21",
+        "name": "A form which breaks CSVs",
+        "submission_email": "eaxmple@sub-domain.gov.uk",
+        "privacy_policy_url": "https://www.gov.uk/help/privacy-notice",
+        "form_slug": "a-form-which-breaks-csvs",
+        "support_email": null,
+        "support_phone": "0113 272727",
+        "support_url": null,
+        "support_url_text": null,
+        "declaration_text": "By submitting this form you’re confirming that, to the best of your knowledge, the answers you’re providing are correct. ",
+        "question_section_completed": true,
+        "declaration_section_completed": true,
+        "created_at": "2025-01-24T13:36:51.462Z",
+        "updated_at": "2025-01-24T15:09:03.424Z",
+        "creator_id": 1,
+        "what_happens_next_markdown": "We’ll send you an email to let you know the outcome. You’ll usually get a response within 10 working days.",
+        "payment_url": "https://www.gov.uk/payments/your-payment-link",
+        "submission_type": "email_with_csv",
+        "share_preview_completed": true,
+        "s3_bucket_name": null,
+        "s3_bucket_aws_account_id": null,
+        "s3_bucket_region": null,
+        "start_page": 88,
+        "live_at": "2025-01-24T15:09:03.424Z",
+        "steps": [
+          {
+            "id": 88,
+            "position": 1,
+            "next_step_id": 89,
+            "type": "question_page",
+            "data": {
+              "question_text": "Which is it?",
+              "hint_text": "",
+              "answer_type": "selection",
+              "is_optional": false,
+              "answer_settings": {
+                "only_one_option": "true",
+                "selection_options": [
+                  {
+                    "name": "Option 1"
+                  },
+                  {
+                    "name": "Option 2"
+                  }
+                ]
+              },
+              "page_heading": null,
+              "guidance_markdown": null,
+              "is_repeatable": false
+            },
+            "routing_conditions": [
+              {
+                "id": 101,
+                "check_page_id": 88,
+                "routing_page_id": 88,
+                "goto_page_id": null,
+                "answer_value": "Option 1",
+                "created_at": "2025-01-24T14:29:14.443Z",
+                "updated_at": "2025-01-24T14:29:14.443Z",
+                "skip_to_end": true,
+                "validation_errors": []
+              }
+            ]
+          },
+          {
+            "id": 89,
+            "position": 2,
+            "next_step_id": 90,
+            "type": "question_page",
+            "data": {
+              "question_text": "Nested selection question",
+              "hint_text": "",
+              "answer_type": "selection",
+              "is_optional": false,
+              "answer_settings": {
+                "only_one_option": "false",
+                "selection_options": [
+                  {
+                    "name": "Yes"
+                  },
+                  {
+                    "name": "No"
+                  }
+                ]
+              },
+              "page_heading": null,
+              "guidance_markdown": null,
+              "is_repeatable": false
+            },
+            "routing_conditions": []
+          },
+          {
+            "id": 90,
+            "position": 3,
+            "next_step_id": null,
+            "type": "question_page",
+            "data": {
+              "question_text": "How many times?",
+              "hint_text": "",
+              "answer_type": "number",
+              "is_optional": false,
+              "answer_settings": null,
+              "page_heading": null,
+              "guidance_markdown": null,
+              "is_repeatable": false
+            },
+            "routing_conditions": []
+          }
+        ]
+      }
+    JSON
+  end
 
   let(:req_headers) do
     {
@@ -32,7 +135,7 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v2/forms/1/live", req_headers, form.to_json, 200
+      mock.get "/api/v2/forms/21/live", req_headers, json, 200
     end
 
     allow(ReferenceNumberService).to receive(:generate).and_return(reference)
@@ -45,17 +148,10 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
     when_i_fill_in_the_question
     and_i_click_on_continue
 
-    then_i_should_see_the_optional_question
-    and_i_click_on_continue
-
-    then_i_should_see_the_routing_question
-    and_i_fill_out_the_routing_question
-    and_i_click_on_continue
-
     then_i_should_see_the_check_your_answers_page
     when_i_opt_out_of_email_confirmation
 
-    # We freeze time so we can test the value of the submission timestamp
+    # # We freeze time so we can test the value of the submission timestamp
     freeze_time do
       and_i_submit_my_form
       then_an_email_submission_should_have_been_sent
@@ -66,38 +162,24 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
   end
 
   def when_i_visit_the_form_start_page
-    visit form_path(mode: "form", form_id: 1, form_slug: "fill-in-this-form")
+    visit form_path(mode: "form", form_id: 21, form_slug: "a-form-which-breaks-csvs")
     expect_page_to_have_no_axe_errors(page)
   end
 
   def then_i_should_see_the_first_question
-    expect(page.find("h1")).to have_text question_text
+    expect(page.find("h1")).to have_text "Which is it?"
   end
 
   def when_i_fill_in_the_question
-    fill_in question_text, with: answer_text
+    choose "Option 1"
   end
 
   def and_i_click_on_continue
     click_button "Continue"
   end
 
-  def then_i_should_see_the_optional_question
-    expect(page.find("h1")).to have_text "An optional question?"
-  end
-
-  def then_i_should_see_the_routing_question
-    expect(page.find("h1")).to have_text "A routing question?"
-  end
-
-  def and_i_fill_out_the_routing_question
-    choose "Option 1"
-  end
-
   def then_i_should_see_the_check_your_answers_page
     expect(page.find("h1")).to have_text "Check your answers before submitting your form"
-    expect(page).to have_text question_text
-    expect(page).to have_text answer_text
     expect_page_to_have_no_axe_errors(page)
   end
 
@@ -106,22 +188,24 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
   end
 
   def and_i_submit_my_form
-    click_on "Submit"
+    click_on "Agree and submit"
   end
 
   def then_an_email_submission_should_have_been_sent
+    expect(ActionMailer::Base.deliveries.first).to be_present
+
     delivered_email = ActionMailer::Base.deliveries.first
 
     expected_content = [
-      ["Reference", "Submitted at", question_text, "An optional question?", "A routing question?", "a question skipped through routing"],
-      [reference, formatted_timestamp, answer_text, "", "Option 1", ""],
+      ["Reference", "Submitted at", "Which is it?", "Nested selection question", "How many times?"],
+      [reference, formatted_timestamp, "Option 1", "", ""],
     ]
 
     expect(parse_email_csv(delivered_email)).to match_array(expected_content)
   end
 
   def then_my_form_should_be_submitted
-    expect(page.find("h1")).to have_text "Your form has been submitted"
+    expect(page.find("h1")).to have_text "You still need to pay"
     expect_page_to_have_no_axe_errors(page)
   end
 

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -19,11 +19,22 @@ RSpec.describe Question::Selection, type: :model do
     let(:only_one_option) { "false" }
     let(:is_optional) { false }
 
-    before do
-      question.selection = []
-    end
-
     it_behaves_like "a question model"
+
+    context "when created without attriibutes" do
+      it "returns invalid" do
+        expect(question).not_to be_valid
+        expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.checkbox_blank"))
+      end
+
+      it "shows as a blank string" do
+        expect(question.show_answer).to eq ""
+      end
+
+      it "returns a hash with an blank value for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
+      end
+    end
 
     context "when selection is blank" do
       before do


### PR DESCRIPTION
### Fix the issue which prevented the CSV including all questions in

Trello card: <!-- link -->

This is a draft PR which fixed the [CSV issue which caused an incident for a particular form when released](https://github.com/alphagov/forms-runner/pull/1155).

When deployed, an exception was thrown when creating the CSV. This happened because the form contained a checkbox question which was skipped due to routing.

The CSV generator asked the checkbox question to produce an answer. A blank string should have been produced but it failed when trying to access a method which didn't exist on nil.

This PR adds unit tests and changes the selection question type to stop it happening.

It also adds a very basic feature tests which uses a form which triggers the issue.

I don't think the feature tests should be written with a JSON literal like this, it was a WIP.

This PR isn't finished and needs more work:
- to verify the issue is fixed for more form types
- sort the test out. 

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
