### PR TITLE
Enable starting the Rails server using the AWS IAM role for forms-runner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem "aws-sdk-cloudwatch"
 gem "aws-sdk-codepipeline", "~> 1.93"
 gem "aws-sdk-s3"
 gem "aws-sdk-sesv2"
+gem "aws-sdk-sts"
 
 # For sending submissions as CSV
 gem "csv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,9 @@ GEM
     aws-sdk-sesv2 (1.69.0)
       aws-sdk-core (~> 3, >= 3.216.0)
       aws-sigv4 (~> 1.5)
+    aws-sdk-sts (1.11.0)
+      aws-sdk-core (~> 3, >= 3.110.0)
+      aws-sigv4 (~> 1.1)
     aws-sigv4 (1.11.0)
       aws-eventstream (~> 1, >= 1.0.2)
     axe-core-api (4.10.2)
@@ -474,6 +477,7 @@ DEPENDENCIES
   aws-sdk-codepipeline (~> 1.93)
   aws-sdk-s3
   aws-sdk-sesv2
+  aws-sdk-sts
   axe-core-rspec
   bootsnap
   brakeman (~> 7.0)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ npm run dev
 
 You will also need to run the [forms-api service](https://github.com/alphagov/forms-api), as this app needs the API to create and access forms.
 
+#### Getting AWS credentials
+
+If you have access to the `readonly` role in the development environment can start the Rails server, locally, with the same set of permissions in use in the development AWS account. This allows you to test features like file upload to AWS S3 and sending emails via AWS SES.
+
+1. Assume the `readonly` role in the development AWS account:
+    ```
+    gds aws forms-dev-readonly --shell
+    ```
+2. Start the Rails server with the `ASSUME_DEV_IAM_ROLE` environment variable
+    ```
+    ASSUME_DEV_IAM_ROLE=true ./bin/rails server
+    ```
+
 ## Development tools
 
 ### Running the tests

--- a/config/initializers/aws_role_usage.rb
+++ b/config/initializers/aws_role_usage.rb
@@ -1,0 +1,31 @@
+arn_matching_expr = /arn:aws:sts::498160065950:assumed-role\/[a-z0-9.]+-readonly\/\d+/
+
+err_msg = <<~MSG
+  You must have assumed the readonly role in the development account
+  before assuming the forms-runner role in development account.
+
+  gds aws forms-dev-readonly --shell
+MSG
+
+if Rails.env.development? && ENV["ASSUME_DEV_IAM_ROLE"]
+  begin
+    sts = Aws::STS::Client.new
+    caller_ident = sts.get_caller_identity
+
+    unless arn_matching_expr.match(caller_ident.arn)
+      raise StandardError, err_msg
+    end
+
+    assumed_role = sts.assume_role({
+      role_arn: "arn:aws:iam::498160065950:role/dev-forms-runner-ecs-task",
+      role_session_name: "#{ENV['USER']}-forms-runner-local",
+    })
+
+    ENV["AWS_ACCESS_KEY_ID"] = assumed_role.credentials.access_key_id
+    ENV["AWS_SECRET_ACCESS_KEY"] = assumed_role.credentials.secret_access_key
+    ENV["AWS_SESSION_TOKEN"] = assumed_role.credentials.session_token
+    ENV["AWS_SESSION_EXPIRATION"] = assumed_role.credentials.expiration.iso8601
+  rescue Aws::Errors::MissingCredentialsError, Aws::Sigv4::Errors::MissingCredentialsError
+    raise StandardError, err_msg
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/l4CIGYi2/596-help-ft-team-1-test-upload-email-locally

In Amazon ECS, forms-runner has credentials for an IAM role that grants it permission to do things like upload files to S3 and send emails via AWS SES. Doing these things locally requires the same set of permissions.

To attain those permissions, developers can now assume the same role as is used by Amazon ECS in the development account by starting the Rails server with the ASSUME_DEV_IAM_ROLE environment variable.

### Things to consider when reviewing

I've not been able to test this much beyond starting the server successfully, so I'd appreciate if somebody with a working `forms-runner` setup could give it a quick prod.

I'm reasonably sure it's all correct from seeing the server start up correctly. Setting environment variables is all that's required to make everything else work.
