### PR TITLE
Update content around file type validation

### DIFF
--- a/app/components/question/file_component/view.html.erb
+++ b/app/components/question/file_component/view.html.erb
@@ -9,5 +9,3 @@
                                   },
                                   accept: Question::File::FILE_TYPES.join(", ")
 %>
-
-<p class="govuk-body govuk-!-margin-bottom-8"><%= t("question/file.your_file_must_be_smaller_than")%></p>

--- a/app/views/forms/page/show.html.erb
+++ b/app/views/forms/page/show.html.erb
@@ -19,6 +19,13 @@
       <%= render view_component.new(form_builder: form, question: @step.question, extra_question_text_suffix: hidden_text_mode(@mode).html_safe) %>
 
       <%= form.govuk_submit %>
+
+    <% end %>
+
+    <% if @step.question.instance_of? Question::File %>
+      <%= govuk_details(summary_text: t("question/file.file_types.summary")) do %>
+        <% t("question/file.file_types.body_html") %>
+      <% end %>
     <% end %>
 
     <%= render SupportDetailsComponent::View.new(@support_details) %>

--- a/app/views/forms/page/show.html.erb
+++ b/app/views/forms/page/show.html.erb
@@ -23,8 +23,8 @@
     <% end %>
 
     <% if @step.question.instance_of? Question::File %>
-      <%= govuk_details(summary_text: t("question/file.file_types.summary")) do %>
-        <% t("question/file.file_types.body_html") %>
+      <%= govuk_details(summary_text: t("question/file.file_requirements.summary")) do %>
+        <% t("question/file.file_requirements.body_html") %>
       <% end %>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,6 +200,18 @@ en:
     heading: This is a preview of this form. Do not enter personal information.
     title: Important
   question/file:
+    file_types:
+      body_html: |
+        <p>You can upload the following file types:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>CSV (.csv)</li>
+          <li>image (.jpeg, .jpg, .png)</li>
+          <li>Microsoft Excel Spreadsheet (.xlsx)</li>
+          <li>Microsoft Word Document (.doc, .docx)</li>
+          <li>PDF (.pdf)</li>
+          <li>text (.json, .odt, .rtf, .txt)</li>
+        </ul>
+      summary: What files can I upload?
     your_file_must_be_smaller_than: Your file must be smaller than 7MB.
   question/name:
     label:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,7 +200,7 @@ en:
     heading: This is a preview of this form. Do not enter personal information.
     title: Important
   question/file:
-    file_types:
+    file_requirements:
       body_html: |
         <p>You can upload the following file types:</p>
         <ul class="govuk-list govuk-list--bullet">
@@ -211,8 +211,8 @@ en:
           <li>PDF (.pdf)</li>
           <li>text (.json, .odt, .rtf, .txt)</li>
         </ul>
+        <p>Your file must be smaller than 7MB.</p>
       summary: What files can I upload?
-    your_file_must_be_smaller_than: Your file must be smaller than 7MB.
   question/name:
     label:
       first_name: First name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,7 +45,7 @@ en:
           attributes:
             file:
               blank: Select a file
-              disallowed_type: The selected file must be a CSV, JPEG, JPG, PNG, XLSX, DOC, DOCX, PDF, JSON, ODT, RTF or TXT
+              disallowed_type: The selected file must be a CSV, DOC, DOCX, JPEG, JPG, JSON, ODT, PDF, PNG, RTF, TXT, or XLSX
               too_big: The selected file must be smaller than 7MB
         question/name:
           attributes:

--- a/spec/views/forms/page/show.html.erb_spec.rb
+++ b/spec/views/forms/page/show.html.erb_spec.rb
@@ -22,15 +22,15 @@ describe "forms/check_your_answers/show.html.erb" do
   end
 
   it "does not display the file upload help text" do
-    expect(rendered).not_to have_text(I18n.t("question/file.file_types.summary"))
+    expect(rendered).not_to have_text(I18n.t("question/file.file_requirements.summary"))
   end
 
   context "when the question asks for a file" do
     let(:question) { build :file }
 
     it "displays the file upload help text" do
-      expect(rendered).to have_text(I18n.t("question/file.file_types.summary"))
-      expect(rendered).to include(I18n.t("question/file.file_types.body_html"))
+      expect(rendered).to have_text(I18n.t("question/file.file_requirements.summary"))
+      expect(rendered).to include(I18n.t("question/file.file_requirements.body_html"))
     end
   end
 end

--- a/spec/views/forms/page/show.html.erb_spec.rb
+++ b/spec/views/forms/page/show.html.erb_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "forms/check_your_answers/show.html.erb" do
+  let(:form) { build :form, :with_support, id: 1 }
+  let(:support_details) { OpenStruct.new(email: form.support_email) }
+  let(:question) { build :full_name_question }
+  let(:step) { build :step, question: question }
+  let(:context) { OpenStruct.new(form:) }
+
+  before do
+    assign(:current_context, context)
+    assign(:mode, OpenStruct.new(preview_draft?: false, preview_archived?: false, preview_live?: false))
+    assign(:step, step)
+    assign(:save_url, "/save")
+    assign(:support_details, support_details)
+
+    render template: "forms/page/show"
+  end
+
+  it "displays the help link" do
+    expect(rendered).to have_text(I18n.t("support_details.get_help_with_this_form"))
+  end
+
+  it "does not display the file upload help text" do
+    expect(rendered).not_to have_text(I18n.t("question/file.file_types.summary"))
+  end
+
+  context "when the question asks for a file" do
+    let(:question) { build :file }
+
+    it "displays the file upload help text" do
+      expect(rendered).to have_text(I18n.t("question/file.file_types.summary"))
+      expect(rendered).to include(I18n.t("question/file.file_types.body_html"))
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/Nr7OQkk2/2092-limit-the-file-types-that-can-be-uploaded

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Makes some tweaks to the content we show to form fillers on file upload questions:

- alphabetises the list of file types in the validation message
- adds some new guidance around what file types the user can supply
- puts the new guidance and the existing guidance on file size together in one details component

### Screenshots
#### Before
![The upload page with a validation error. The error reads 'The selected file must be a CSV, JPEG, JPG, PNG, XLSX, DOC, DOCX, PDF, JSON, ODT, RTF or TXT'. Below the input there is guidance that says 'Your file must be smaller than 7MB.'](https://github.com/user-attachments/assets/6d0c2ed9-4012-46cb-a27f-48714faab152)

#### After
![The upload page with a validation error. The error reads 'The selected file must be a CSV, DOC, DOCX, JPEG, JPG, JSON, ODT, PDF, PNG, RTF, TXT, or XLSX'. The guidance under the input is gone. There is a new details component under the submit button with summary 'What files can I upload?' and content 'You can upload the following file types: CSV (.csv), image (.jpeg, .jpg, .png), Microsoft Excel Spreadsheet (.xlsx), Microsoft Word Document (.doc, .docx), PDF (.pdf), text (.json, .odt, .rtf, .txt).Your file must be smaller than 7MB.'](https://github.com/user-attachments/assets/0b4d9b69-1e5a-4061-836a-37cd7fc9fb8c)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
