### PR TITLE
Add remove file confirmation

### DIFF
--- a/app/components/question/file_remove_component/view.html.erb
+++ b/app/components/question/file_remove_component/view.html.erb
@@ -1,0 +1,22 @@
+<h1 class="govuk-heading-l"><%= t('forms.review_file.confirmation.title') %></h1>
+
+<p class="govuk-inset-text">
+  <%= question.original_filename %>
+</p>
+
+<%= form_with model: @remove_file_input, url: @remove_file_url, method: :delete do |form| %>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if @remove_file_input&.errors.any? %>
+        <%= form.govuk_error_summary %>
+      <% end %>
+
+      <%= form.govuk_collection_radio_buttons :remove_file,
+            @remove_file_input.values, ->(option) { option }, ->(option) { t('helpers.label.remove_file_input.options.' + "#{option}") },
+            legend: { text: t('forms.review_file.confirmation.radios_legend')},
+            inline: true  %>
+
+      <%= form.govuk_submit  %>
+    </div>
+  </div>
+<% end %>

--- a/app/components/question/file_remove_component/view.html.erb
+++ b/app/components/question/file_remove_component/view.html.erb
@@ -5,7 +5,7 @@
 </p>
 
 <%= form_with model: @remove_file_input, url: @remove_file_url, method: :delete do |form| %>
-<div class="govuk-grid-row">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if @remove_file_input&.errors.any? %>
         <%= form.govuk_error_summary %>

--- a/app/components/question/file_remove_component/view.rb
+++ b/app/components/question/file_remove_component/view.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Question::FileRemoveComponent
+  class View < Question::Base
+    def initialize(question:, extra_question_text_suffix:, remove_file_url:, remove_file_input:)
+      @remove_file_url = remove_file_url
+      @remove_file_input = remove_file_input
+      super(form_builder: nil, question:, extra_question_text_suffix:)
+    end
+  end
+end

--- a/app/components/question/file_review_component/view.html.erb
+++ b/app/components/question/file_review_component/view.html.erb
@@ -2,19 +2,15 @@
 
 <%= hint_text %>
 
-<%= govuk_table(classes: "govuk-!-margin-top-7") do |table|
-  table.with_caption(size: 'm', text: t('forms.review_file.show.table_caption'))
-  table.with_body do |body|
-    body.with_row do |row|
-      row.with_cell(text: t('forms.review_file.show.table_header'), header: true)
-      row.with_cell(text: question.original_filename)
-      row.with_cell do |cell|
-        form_with url: @remove_file_url, method: :post do |form|
-          button_content = "#{t('forms.review_file.show.remove')} <span class='govuk-visually-hidden'>#{t('forms.review_file.show.table_header')}</span>".html_safe
-          form.govuk_submit button_content, secondary: true
-        end
-      end
-    end
+<h2 class="govuk-heading-m">
+  <%= t('forms.review_file.show.table_caption') %>
+</h2>
+
+<%= govuk_summary_list do |summary_list|
+  summary_list.with_row do |row|
+    row.with_key { t('forms.review_file.show.table_header') }
+    row.with_value { question.original_filename }
+    row.with_action(text: t('forms.review_file.show.remove'), href: @remove_file_confirmation_url, visually_hidden_text: t('forms.review_file.show.table_header'))
   end
 end %>
 

--- a/app/components/question/file_review_component/view.rb
+++ b/app/components/question/file_review_component/view.rb
@@ -2,8 +2,8 @@
 
 module Question::FileReviewComponent
   class View < Question::Base
-    def initialize(question:, extra_question_text_suffix:, remove_file_url:)
-      @remove_file_url = remove_file_url
+    def initialize(question:, extra_question_text_suffix:, remove_file_confirmation_url:)
+      @remove_file_confirmation_url = remove_file_confirmation_url
       super(form_builder: nil, question:, extra_question_text_suffix:)
     end
   end

--- a/app/controllers/forms/review_file_controller.rb
+++ b/app/controllers/forms/review_file_controller.rb
@@ -4,7 +4,7 @@ module Forms
 
     def show
       back_link(@step.page_slug)
-      @remove_file_url = remove_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
+      @remove_file_confirmation_url = remove_file_confirmation_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
       @continue_url = review_file_continue_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
     end
 

--- a/app/controllers/forms/review_file_controller.rb
+++ b/app/controllers/forms/review_file_controller.rb
@@ -19,6 +19,13 @@ module Forms
       redirect_to next_page
     end
 
+    def confirmation
+      back_link(@step.page_slug)
+      @remove_file_url = remove_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
+      @remove_file_input = RemoveFileInput.new
+      # @continue_url = review_file_continue_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
+    end
+
   private
 
     def redirect_if_not_answered_file_question

--- a/app/input_objects/remove_file_input.rb
+++ b/app/input_objects/remove_file_input.rb
@@ -1,0 +1,18 @@
+class RemoveFileInput
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :remove_file
+
+  RADIO_OPTIONS = { yes: "yes", no: "no" }.freeze
+
+  validates :remove_file, presence: true, inclusion: { in: RADIO_OPTIONS.values }
+
+  def remove_file?
+    remove_file == RADIO_OPTIONS[:yes]
+  end
+
+  def values
+    RADIO_OPTIONS.keys
+  end
+end

--- a/app/views/forms/review_file/confirmation.html.erb
+++ b/app/views/forms/review_file/confirmation.html.erb
@@ -1,0 +1,15 @@
+<% set_page_title("#{t('forms.review_file.confirmation.title')} - #{form_title(form_name: @current_context.form.name, page_name: @step.question.question_text, mode: @mode, error: @step.question&.errors&.any?)}") %>
+
+<% content_for :back_link do %>
+  <% if @back_link.present? %>
+    <%= link_to "Back", @back_link, class: "govuk-back-link" %>
+  <% end %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render Question::FileRemoveComponent::View.new(question: @step.question, extra_question_text_suffix: hidden_text_mode(@mode).html_safe, remove_file_url: @remove_file_url, remove_file_input: @remove_file_input ) %>
+
+    <%= render SupportDetailsComponent::View.new(@support_details) %>
+  </div>
+</div>

--- a/app/views/forms/review_file/show.html.erb
+++ b/app/views/forms/review_file/show.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render Question::FileReviewComponent::View.new(question: @step.question, extra_question_text_suffix: hidden_text_mode(@mode).html_safe, remove_file_url: @remove_file_url ) %>
+    <%= render Question::FileReviewComponent::View.new(question: @step.question, extra_question_text_suffix: hidden_text_mode(@mode).html_safe, remove_file_confirmation_url: @remove_file_confirmation_url ) %>
 
     <%= form_with model: @step.question, url: @continue_url, scope: :question, method: :post do |form| %>
       <%= form.govuk_submit %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,10 @@ en:
           attributes:
             remove_answer:
               blank: You must select an option
+        remove_file_input:
+          attributes:
+            remove_file:
+              blank: You must select an option
   autocomplete:
     prompt: Select an answer
   banner:
@@ -160,6 +164,9 @@ en:
         phone_number_radios_legend: Are you sure you want to remove this phone number?
         short_answer_legend: Are you sure you want to remove ‘%{answer_text}’?
     review_file:
+      confirmation:
+        radios_legend: Are you sure you want to remove your file?
+        title: Remove your file
       show:
         remove: Remove
         remove_file_guidance: You can remove this file if you need to upload a different one.
@@ -180,6 +187,10 @@ en:
           send_email: 'Yes'
           skip_confirmation: 'No'
       remove_answer_input:
+        options:
+          'no': 'No'
+          'yes': 'Yes'
+      remove_file_input:
         options:
           'no': 'No'
           'yes': 'Yes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,9 @@ Rails.application.routes.draw do
       post "/:page_slug/review-file" => "forms/review_file#continue",
            as: :review_file_continue,
            constraints: page_constraints
+      get "/:page_slug/remove-file" => "forms/review_file#confirmation",
+          as: :remove_file_confirmation,
+          constraints: page_constraints
       post "/:page_slug/remove-file" => "forms/review_file#delete",
            as: :remove_file,
            constraints: page_constraints

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,9 +49,9 @@ Rails.application.routes.draw do
       get "/:page_slug/remove-file" => "forms/review_file#confirmation",
           as: :remove_file_confirmation,
           constraints: page_constraints
-      post "/:page_slug/remove-file" => "forms/review_file#delete",
-           as: :remove_file,
-           constraints: page_constraints
+      delete "/:page_slug/remove-file" => "forms/review_file#delete",
+             as: :remove_file,
+             constraints: page_constraints
 
       get "/:page_slug/(/:answer_index)/change" => "forms/page#show",
           as: :form_change_answer,

--- a/spec/components/question/file_remove_component/file_remove_component_preview.rb
+++ b/spec/components/question/file_remove_component/file_remove_component_preview.rb
@@ -1,0 +1,18 @@
+class Question::FileRemoveComponent::FileRemoveComponentPreview < ViewComponent::Preview
+  def file_remove
+    question = OpenStruct.new(answer_type: "file",
+                              original_filename: "a_file.png",
+                              question_text_with_optional_suffix: "Upload your photo",
+                              answer_settings: nil)
+    render(Question::FileRemoveComponent::View.new(question:, extra_question_text_suffix: "", remove_file_url: "/remove_file", remove_file_input: RemoveFileInput.new))
+  end
+
+  def file_remove_with_hint
+    question = OpenStruct.new(answer_type: "file",
+                              original_filename: "a_file.png",
+                              question_text_with_optional_suffix: "Upload your photo",
+                              hint_text: "Make sure your face is clearly visible",
+                              answer_settings: nil)
+    render(Question::FileRemoveComponent::View.new(question:, extra_question_text_suffix: "", remove_file_url: "/remove_file", remove_file_input: RemoveFileInput.new))
+  end
+end

--- a/spec/components/question/file_remove_component/view_spec.rb
+++ b/spec/components/question/file_remove_component/view_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Question::FileRemoveComponent::View, type: :component do
+  let(:question_page) { build :page, answer_type: "file" }
+  let(:is_optional) { false }
+  let(:question_text) { "Upload a file" }
+  let(:page_heading) { nil }
+  let(:hint_text) { nil }
+  let(:question) { build :file, :with_uploaded_file, question_text:, is_optional:, page_heading:, hint_text: }
+  let(:extra_question_text_suffix) { nil }
+  let(:remove_file_url) { "/remove_file" }
+
+  before do
+    render_inline(described_class.new(question:, extra_question_text_suffix:, remove_file_url:, remove_file_input: RemoveFileInput.new))
+  end
+
+  it "renders the correct h1" do
+    expect(page.find("h1")).to have_text(I18n.t("forms.review_file.confirmation.title"))
+  end
+
+  it "renders the original file name" do
+    expect(page).to have_content(question.original_filename)
+  end
+
+  it "renders radio buttons to confirm removal" do
+    expect(page).to have_css("form[action='#{remove_file_url}'][method='post']")
+    expect(page).to have_css("fieldset", text: I18n.t("forms.review_file.confirmation.radios_legend"))
+    expect(page).to have_field("Yes", type: :radio)
+    expect(page).to have_field("No", type: :radio)
+  end
+
+  it "has a button continue with file removal" do
+    within(page.find("form[action='#{remove_file_url}'][method='post']")) do
+      expect(page).to have_button("Continue")
+    end
+  end
+end

--- a/spec/components/question/file_review_component/file_review_component_preview.rb
+++ b/spec/components/question/file_review_component/file_review_component_preview.rb
@@ -4,7 +4,7 @@ class Question::FileReviewComponent::FileReviewComponentPreview < ViewComponent:
                               original_filename: "a_file.png",
                               question_text_with_optional_suffix: "Upload your photo",
                               answer_settings: nil)
-    render(Question::FileReviewComponent::View.new(question:, extra_question_text_suffix: "", remove_file_url: "/remove_file"))
+    render(Question::FileReviewComponent::View.new(question:, extra_question_text_suffix: "", remove_file_confirmation_url: "/remove_file_confirmation"))
   end
 
   def file_review_with_hint
@@ -13,6 +13,6 @@ class Question::FileReviewComponent::FileReviewComponentPreview < ViewComponent:
                               question_text_with_optional_suffix: "Upload your photo",
                               hint_text: "Make sure your face is clearly visible",
                               answer_settings: nil)
-    render(Question::FileReviewComponent::View.new(question:, extra_question_text_suffix: "", remove_file_url: "/remove_file"))
+    render(Question::FileReviewComponent::View.new(question:, extra_question_text_suffix: "", remove_file_confirmation_url: "/remove_file_confirmation"))
   end
 end

--- a/spec/components/question/file_review_component/view_spec.rb
+++ b/spec/components/question/file_review_component/view_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe Question::FileReviewComponent::View, type: :component do
   let(:hint_text) { nil }
   let(:question) { build :file, :with_uploaded_file, question_text:, is_optional:, page_heading:, hint_text: }
   let(:extra_question_text_suffix) { nil }
-  let(:remove_file_url) { "/remove_file" }
+  let(:remove_file_confirmation_url) { "/remove_file_confirmation" }
 
   before do
-    render_inline(described_class.new(question:, extra_question_text_suffix:, remove_file_url:))
+    render_inline(described_class.new(question:, extra_question_text_suffix:, remove_file_confirmation_url:))
   end
 
   it "renders the question text as a h1" do
@@ -36,17 +36,12 @@ RSpec.describe Question::FileReviewComponent::View, type: :component do
     expect(page).to have_content(question.original_filename)
   end
 
-  it "has a button to delete the file" do
-    within(page.find("form[action='#{remove_file_url}'][method='post']")) do
-      expect(page).to have_button("Remove")
-      expect(page).to have_css("button span.hidden-text", text: t("forms.review_file.show.hidden_text"))
-    end
+  it "has a link to the file removal confirmation page" do
+    expect(page).to have_link(I18n.t("forms.review_file.show.remove"), href: remove_file_confirmation_url)
   end
 
-  it "the button to delete the file has hidden text" do
-    within(page.find("form[action='#{remove_file_url}'][method='post']")) do
-      expect(page).to have_css("button span.hidden-text", text: t("forms.review_file.show.hidden_text"))
-    end
+  it "the link to the file removal confirmation page has hidden text" do
+    expect(page).to have_css(".govuk-visually-hidden", text: I18n.t("forms.review_file.show.table_header"))
   end
 
   context "when there is an extra suffix to be added to the heading" do

--- a/spec/input_objects/remove_file_input_spec.rb
+++ b/spec/input_objects/remove_file_input_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe RemoveFileInput do
+  let(:input) { described_class.new({ remove_file: "yes" }) }
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      expect(input).to be_valid
+    end
+
+    it "is not valid without remove_file" do
+      input.remove_file = nil
+      expect(input).not_to be_valid
+      expect(input.errors[:remove_file]).to include(I18n.t("activemodel.errors.models.remove_file_input.attributes.remove_file.blank"))
+    end
+
+    it "is not valid with an invalid remove_file" do
+      input.remove_file = "invalid"
+      expect(input).not_to be_valid
+      expect(input.errors[:remove_file]).to include("is not included in the list")
+    end
+
+    it 'is valid with "no" as remove_file' do
+      input.remove_file = "no"
+      expect(input).to be_valid
+    end
+  end
+
+  describe "#remove_file?" do
+    it 'returns true when remove_file is "yes"' do
+      input = described_class.new(remove_file: "yes")
+      expect(input.remove_file?).to be true
+    end
+
+    it 'returns false when remove_file is "no"' do
+      input = described_class.new(remove_file: "no")
+      expect(input.remove_file?).to be false
+    end
+  end
+
+  describe "#values" do
+    it "returns an array of valid values" do
+      input = described_class.new
+      expect(input.values).to eq(%i[yes no])
+    end
+  end
+
+  describe "RADIO_OPTIONS" do
+    it "has the correct values" do
+      expect(described_class::RADIO_OPTIONS).to eq({ yes: "yes", no: "no" })
+    end
+
+    it "is frozen" do
+      expect(described_class::RADIO_OPTIONS).to be_frozen
+    end
+  end
+end

--- a/spec/requests/forms/review_file_controller_spec.rb
+++ b/spec/requests/forms/review_file_controller_spec.rb
@@ -114,53 +114,86 @@ RSpec.describe Forms::ReviewFileController, type: :request do
     end
   end
 
-  describe "#remove" do
+  describe "#delete" do
     let(:mock_s3_client) { Aws::S3::Client.new(stub_responses: true) }
+    let(:remove_file) { "yes" }
 
     before do
       allow(Aws::S3::Client).to receive(:new).and_return(mock_s3_client)
       allow(mock_s3_client).to receive(:delete_object)
-      post remove_file_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug:, changing_existing_answer:)
+      delete remove_file_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug:, changing_existing_answer:, remove_file_input: { remove_file: })
     end
 
     context "when the question is a file upload question" do
       let(:page_slug) { file_upload_step.id.to_s }
 
-      context "when a file has been uploaded" do
-        it "deletes the file from S3" do
-          expect(mock_s3_client).to have_received(:delete_object)
+      context "when the input object validation fails" do
+        let(:remove_file) { "invalid" }
+
+        it "renders the confirmation page with 422 status" do
+          expect(response).to render_template("forms/review_file/confirmation")
+          expect(response).to have_http_status :unprocessable_entity
         end
 
-        it "removes the answer from the session" do
-          expect(store[:answers][form_data.id.to_s]).not_to have_key page_slug
+        it "displays an error" do
+          rendered = Capybara.string(response.body)
+          expect(rendered).to have_css(".govuk-error-summary")
+        end
+      end
+
+      context "when the user has confirmed they want to remove their file" do
+        context "when a file has been uploaded" do
+          it "deletes the file from S3" do
+            expect(mock_s3_client).to have_received(:delete_object)
+          end
+
+          it "removes the answer from the session" do
+            expect(store[:answers][form_data.id.to_s]).not_to have_key page_slug
+          end
+
+          it "redirects to the show page route" do
+            expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, page_slug)
+          end
+
+          it "displays a success banner" do
+            expect(flash[:success]).to eq(I18n.t("banner.success.file_removed"))
+          end
+
+          context "when changing an existing answer" do
+            let(:changing_existing_answer) { true }
+
+            it "redirects to the change answer route" do
+              expect(response).to redirect_to form_change_answer_path(form_data.id, form_data.form_slug, page_slug)
+            end
+          end
         end
 
-        it "redirects to the show page route" do
-          expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, page_slug)
-        end
+        context "when a file has not been uploaded" do
+          let(:uploaded_file_key) { nil }
 
-        it "displays a success banner" do
-          expect(flash[:success]).to eq(I18n.t("banner.success.file_removed"))
-        end
+          it "does not remove the answer from the session" do
+            expect(store[:answers][form_data.id.to_s]).to have_key page_slug
+          end
 
-        context "when changing an existing answer" do
-          let(:changing_existing_answer) { true }
-
-          it "redirects to the change answer route" do
-            expect(response).to redirect_to form_change_answer_path(form_data.id, form_data.form_slug, page_slug)
+          it "redirects to the show page route" do
+            expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, page_slug)
           end
         end
       end
 
-      context "when a file has not been uploaded" do
-        let(:uploaded_file_key) { nil }
+      context "when the user has not confirmed they want to remove their file" do
+        let(:remove_file) { "no" }
+
+        it "does not delete the file from S3" do
+          expect(mock_s3_client).not_to have_received(:delete_object)
+        end
 
         it "does not remove the answer from the session" do
           expect(store[:answers][form_data.id.to_s]).to have_key page_slug
         end
 
-        it "redirects to the show page route" do
-          expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, page_slug)
+        it "redirects to the review file page route" do
+          expect(response).to redirect_to review_file_path(form_data.id, form_data.form_slug, page_slug, changing_existing_answer:)
         end
       end
     end

--- a/spec/requests/forms/review_file_controller_spec.rb
+++ b/spec/requests/forms/review_file_controller_spec.rb
@@ -78,22 +78,6 @@ RSpec.describe Forms::ReviewFileController, type: :request do
         it "displays the uploaded filename" do
           expect(response.body).to include(uploaded_filename)
         end
-
-        context "when changing an existing answer" do
-          let(:changing_existing_answer) { true }
-
-          it "includes the changing_existing_answer query parameter for the remove file URL" do
-            rendered = Capybara.string(response.body)
-            expected_url = remove_file_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug:, changing_existing_answer:)
-            expect(rendered).to have_css("form[action='#{expected_url}'][method='post']")
-          end
-
-          it "includes the changing_existing_answer query parameter for the continue URL" do
-            rendered = Capybara.string(response.body)
-            expected_url = review_file_continue_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug:, changing_existing_answer:)
-            expect(rendered).to have_css("form[action='#{expected_url}'][method='post']")
-          end
-        end
       end
 
       context "when a file has not been uploaded" do
@@ -102,6 +86,12 @@ RSpec.describe Forms::ReviewFileController, type: :request do
         it "redirects to the show page route" do
           expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, page_slug)
         end
+      end
+
+      it "includes the changing_existing_answer query parameter for the continue URL" do
+        rendered = Capybara.string(response.body)
+        expected_url = review_file_continue_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug:, changing_existing_answer:)
+        expect(rendered).to have_css("form[action='#{expected_url}'][method='post']")
       end
     end
 
@@ -249,6 +239,52 @@ RSpec.describe Forms::ReviewFileController, type: :request do
 
         it "redirects to the show page route" do
           expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, page_slug)
+        end
+      end
+    end
+
+    context "when the question isn't a file upload question" do
+      let(:page_slug) { text_question_step.id }
+
+      it "redirects to the show page route" do
+        expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, page_slug)
+      end
+    end
+  end
+
+  describe "#confirmation" do
+    before do
+      get remove_file_confirmation_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug:, changing_existing_answer:)
+    end
+
+    context "when the question is a file upload question" do
+      let(:page_slug) { file_upload_step.id }
+
+      context "when a file has been uploaded" do
+        it "renders the remove file confirmation template" do
+          expect(response).to render_template("forms/review_file/confirmation")
+        end
+
+        it "displays the uploaded filename" do
+          expect(response.body).to include(uploaded_filename)
+        end
+      end
+
+      context "when a file has not been uploaded" do
+        let(:store) { {} }
+
+        it "redirects to the show page route" do
+          expect(response).to redirect_to form_page_path(form_data.id, form_data.form_slug, page_slug)
+        end
+      end
+
+      context "when changing an existing answer" do
+        let(:changing_existing_answer) { true }
+
+        it "includes the changing_existing_answer query parameter for the confirmation URL" do
+          rendered = Capybara.string(response.body)
+          expected_url = remove_file_confirmation_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug:, changing_existing_answer:)
+          expect(rendered).to have_css("form[action='#{expected_url}'][method='post']")
         end
       end
     end

--- a/spec/views/forms/review_file/confirmation.html.erb_spec.rb
+++ b/spec/views/forms/review_file/confirmation.html.erb_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+describe "forms/review_file/confirmation.html.erb" do
+  let(:form) { build :form, :with_support, id: 1 }
+  let(:mode) { OpenStruct.new(preview_draft?: false, preview_archived?: false, preview_live?: false) }
+  let(:back_link) { "/back" }
+  let(:continue_url) { "/review_file" }
+  let(:remove_file_url) { "/remove_file" }
+  let(:question) { build :file, :with_uploaded_file }
+  let(:step) { build :step, question: }
+  let(:support_details) { OpenStruct.new({ email: "help@example.gov.uk", phone: "Call 01610123456\n\nThis line is only open on Tuesdays.", url: "https://example.gov.uk/contact", url_text: "Contact form" }) }
+  let(:remove_file_input) { RemoveFileInput.new }
+
+  before do
+    assign(:current_context, OpenStruct.new(form:))
+    assign(:mode, mode)
+    assign(:step, step)
+    assign(:back_link, back_link)
+    assign(:continue_url, continue_url)
+    assign(:remove_file_url, remove_file_url)
+    assign(:support_details, support_details)
+    assign(:remove_file_input, remove_file_input)
+
+    without_partial_double_verification do
+      allow(view).to receive(:remove_file_path).and_return("/remove_file")
+    end
+
+    render
+  end
+
+  it "has a back link" do
+    expect(view.content_for(:back_link)).to have_link("Back", href: "/back")
+  end
+
+  context "when back link not preset" do
+    let(:back_link) { "" }
+
+    it "does not set back link" do
+      expect(view.content_for(:back_link)).to be_nil
+    end
+  end
+
+  context "when there are errors" do
+    before do
+      remove_file_input.errors.add(:base, "Error message")
+    end
+
+    it "renders the error summary" do
+      render
+      expect(rendered).to have_css(".govuk-error-summary")
+    end
+  end
+
+  it "has the correct page title" do
+    expect(view.content_for(:title)).to eq "#{I18n.t('forms.review_file.confirmation.title')} - #{question.question_text} - #{form.name}"
+  end
+
+  it "has the correct heading" do
+    expect(rendered).to have_css("h1", text: I18n.t("forms.review_file.confirmation.title"))
+  end
+
+  it "displays the review file component with the uploaded file name" do
+    expect(rendered).to have_content(question.original_filename)
+  end
+
+  it "has a continue button" do
+    page = Capybara.string(rendered.html)
+    within(page.find("form[action='#{remove_file_url}'][method='post']")) do
+      expect(page).to have_button("Continue")
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/mfhj3ufe

This PR adds a confirmation page for removing an uploaded file. This allows us to use a summary list in the review file page, and better fits with patterns used elsewhere in GOV.UK Forms (e.g. add another answer). This necessitates updating the delete action in `ReviewFileController` to accept an input object and conditionally delete the file.

There are a couple of refactoring bits I'd like to do, but probably in a subsequent PR unless reviewers think it should be done in this one:
- tidying up translation names and reducing duplication
- reducing duplication in `ReviewFileController`
- refactoring remove file and remove answer input objects into a single input object used by both
- suggestions by @stephencdaly:
  - fix back link on confirmation page
  - improve confirmation action name
  - move view to remove_file directory

<details><summary>Screenshots</summary>

![Screenshot 2025-02-05 at 11 00 52](https://github.com/user-attachments/assets/a9e4b792-7c3a-44c1-8b79-b96543be76ff)
![Screenshot 2025-02-05 at 11 12 40](https://github.com/user-attachments/assets/dcba9c4b-dc47-41c1-bb5a-012e49cf24f1)
![Screenshot 2025-02-05 at 11 12 49](https://github.com/user-attachments/assets/b5f7850e-c4e5-4699-a854-18b6c60b1fcf)
![Screenshot 2025-02-05 at 11 12 56](https://github.com/user-attachments/assets/6327ec07-2c6a-4a23-9b55-f6885f758e8c)
![Screenshot 2025-02-05 at 11 13 07](https://github.com/user-attachments/assets/4f41d53b-aa3f-4411-8f4f-83599d1351cd)

</details> 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
