### PR TITLE
Change dash in error message to be em dash

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,7 +47,7 @@ en:
               blank: Select a file
               contains_virus: The selected file contains a virus
               disallowed_type: The selected file must be a CSV, DOC, DOCX, JPEG, JPG, JSON, ODT, PDF, PNG, RTF, TXT, or XLSX
-              scan_failure: The selected file could not be uploaded - try again
+              scan_failure: The selected file could not be uploaded — try again
               too_big: The selected file must be smaller than 7MB
         question/name:
           attributes:

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Question::File, type: :model do
           let(:scan_status) { "FAILURE" }
 
           it "does adds a contains_virus error" do
-            expect(question.errors[:file]).to include "The selected file could not be uploaded - try again"
+            expect(question.errors[:file]).to include "The selected file could not be uploaded — try again"
           end
         end
       end
@@ -110,7 +110,7 @@ RSpec.describe Question::File, type: :model do
         let(:scan_status) { nil }
 
         it "adds a contains_virus error" do
-          expect(question.errors[:file]).to include "The selected file could not be uploaded - try again"
+          expect(question.errors[:file]).to include "The selected file could not be uploaded — try again"
         end
 
         it "logs an error" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/VmHYY9jo/2091-scan-files-that-are-uploaded

Em dash is appropriate in this context.

![Screenshot 2025-02-04 at 16 37 48](https://github.com/user-attachments/assets/f4879b55-2cb0-415f-b6d3-ab74fb078963)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
