### PR TITLE
Fix back link on file removal confirmation page

### DIFF
--- a/app/controllers/forms/review_file_controller.rb
+++ b/app/controllers/forms/review_file_controller.rb
@@ -12,8 +12,7 @@ module Forms
       @remove_file_input = RemoveFileInput.new(remove_file_input_params)
 
       if @remove_file_input.invalid?
-        back_link(@step.page_slug)
-        @remove_file_url = remove_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
+        setup_confirmation
         return render :confirmation, status: :unprocessable_entity
       end
 
@@ -31,8 +30,7 @@ module Forms
     end
 
     def confirmation
-      back_link(@step.page_slug)
-      @remove_file_url = remove_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
+      setup_confirmation
       @remove_file_input = RemoveFileInput.new
     end
 
@@ -54,6 +52,11 @@ module Forms
       end
 
       form_page_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug)
+    end
+
+    def setup_confirmation
+      back_link(@step.page_slug)
+      @remove_file_url = remove_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
     end
   end
 end

--- a/app/controllers/forms/review_file_controller.rb
+++ b/app/controllers/forms/review_file_controller.rb
@@ -55,7 +55,7 @@ module Forms
     end
 
     def setup_confirmation
-      back_link(@step.page_slug)
+      @back_link = review_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
       @remove_file_url = remove_file_path(form_id: @step.form_id, form_slug: @step.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
     end
   end

--- a/spec/requests/forms/review_file_controller_spec.rb
+++ b/spec/requests/forms/review_file_controller_spec.rb
@@ -78,6 +78,10 @@ RSpec.describe Forms::ReviewFileController, type: :request do
         it "displays the uploaded filename" do
           expect(response.body).to include(uploaded_filename)
         end
+
+        it "displays a back link to the file upload page" do
+          expect(response.body).to include(form_page_path(mode:, form_id: form_data.id, form_slug: form_data.form_slug, page_slug: file_upload_step.id))
+        end
       end
 
       context "when a file has not been uploaded" do
@@ -128,6 +132,10 @@ RSpec.describe Forms::ReviewFileController, type: :request do
         it "displays an error" do
           rendered = Capybara.string(response.body)
           expect(rendered).to have_css(".govuk-error-summary")
+        end
+
+        it "displays a back link to the review file page" do
+          expect(response.body).to include(review_file_path(form_data.id, form_data.form_slug, page_slug, changing_existing_answer:))
         end
       end
 
@@ -267,6 +275,10 @@ RSpec.describe Forms::ReviewFileController, type: :request do
 
         it "displays the uploaded filename" do
           expect(response.body).to include(uploaded_filename)
+        end
+
+        it "displays a back link to the review file page" do
+          expect(response.body).to include(review_file_path(form_data.id, form_data.form_slug, page_slug, changing_existing_answer:))
         end
       end
 


### PR DESCRIPTION
### What problem does this pull request solve?

The back link on the file removal confirmation page previously linked to the upload file page, when it should link to the review file page. This PR fixes this. I've also added a `setup_confirmation` method to reduce code duplication.

Trello card: https://trello.com/c/mfhj3ufe

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
