### PR TITLE
Log more information about S3 operations

### DIFF
--- a/app/lib/file_upload_logger.rb
+++ b/app/lib/file_upload_logger.rb
@@ -1,0 +1,11 @@
+class FileUploadLogger
+  S3_OBJECT_KEY_FIELD = :s3_object_key
+
+  def self.log_s3_operation(object_key, message, additional_context = {})
+    Rails.logger.info(message, additional_context.merge({ S3_OBJECT_KEY_FIELD => object_key }))
+  end
+
+  def self.log_s3_operation_error(object_key, message, additional_context = {})
+    Rails.logger.error(message, additional_context.merge({ S3_OBJECT_KEY_FIELD => object_key }))
+  end
+end

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -43,7 +43,7 @@ module Question
       key = file_upload_s3_key(tempfile)
       FileUploadS3Service.new.upload_to_s3(tempfile, key)
 
-      Rails.logger.info("Uploaded file to S3 for file upload question", {
+      FileUploadLogger.log_s3_operation(key, "Uploaded file to S3 for file upload question", {
         file_size_in_bytes: file.size,
         file_type: file.content_type,
       })

--- a/app/models/question/file/virus_scan.rb
+++ b/app/models/question/file/virus_scan.rb
@@ -14,6 +14,6 @@ module Question::File::VirusScan
     errors.add(:file, :scan_failure)
   rescue Question::FileUploadS3Service::PollForScanResultTimeoutError
     errors.add(:file, :scan_failure)
-    Rails.logger.error "Timed out polling for GuardDuty scan status for uploaded file"
+    FileUploadLogger.log_s3_operation_error(key, "Timed out polling for GuardDuty scan status for uploaded file")
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

It's useful to log the S3 object key when we log operations on files uploaded for a file upload question so that we can link together operations on the object during is lifecycle if we ever need to track what happened to an object.

Additionally, log when a file is deleted from S3 or retrieved to be attached in an email so we have greater visibility over the object lifecycle.

Added `FileUploadLogger` to ensure that we always log these operations with the `s3_object_key` field.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
