### PR TITLE
Move the FileRemoveComponent error summary

### DIFF
--- a/app/components/question/file_remove_component/view.html.erb
+++ b/app/components/question/file_remove_component/view.html.erb
@@ -1,8 +1,3 @@
-<h1 class="govuk-heading-l"><%= t('forms.remove_file.show.title') %></h1>
-
-<p class="govuk-inset-text">
-  <%= question.original_filename %>
-</p>
 
 <%= form_with model: @remove_input, url: @remove_file_url, method: :delete do |form| %>
   <div class="govuk-grid-row">
@@ -10,6 +5,12 @@
       <% if @remove_input&.errors.any? %>
         <%= form.govuk_error_summary %>
       <% end %>
+
+      <h1 class="govuk-heading-l"><%= t('forms.remove_file.show.title') %></h1>
+
+      <p class="govuk-inset-text">
+        <%= question.original_filename %>
+      </p>
 
       <%= form.govuk_collection_radio_buttons :remove,
             @remove_input.values, ->(option) { option }, ->(option) { t('helpers.label.remove_input.options.' + "#{option}") },


### PR DESCRIPTION
### What problem does this pull request solve?

Move the error summary of the FileRemoveComponent to the top, so that it appears above the h1 in accordance with the design system.

Trello card: https://trello.com/c/mfhj3ufe

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
