### PR TITLE
Log an error when file upload key is not found in S3

### DIFF
--- a/app/services/question/file_upload_s3_service.rb
+++ b/app/services/question/file_upload_s3_service.rb
@@ -26,6 +26,9 @@ class Question::FileUploadS3Service
     }).body.read
     FileUploadLogger.log_s3_operation(key, "Retrieved uploaded file from S3")
     file
+  rescue Aws::S3::Errors::NoSuchKey
+    FileUploadLogger.log_s3_operation_error(key, "Object with key does not exist in S3")
+    raise
   end
 
   def delete_from_s3(key)


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ZzVCrkDn/2115-test-policy-on-the-s3-buckets-that-clear-up-files-after-30-days

Log at error level with the logging context field `s3_object_key` when a `NoSuchKey` error is raised by the request to get an object from S3. This will allow us to find out the key for the file that was not found to help us diagnose the cause of this error.

Re-raise the error, which will cause the user to see a generic technical difficulties page, and the error will be sent to Sentry.

We only expect this error to be raised when a user has managed to keep the same form filling session open for 30 days and our lifecycle rules for the S3 bucket have deleted the file.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
