### PR TITLE
Fix CSV generation to include all questions including skipped checkbox questions

### DIFF
--- a/app/lib/csv_generator.rb
+++ b/app/lib/csv_generator.rb
@@ -7,7 +7,7 @@ class CsvGenerator
   def self.write_submission(current_context:, submission_reference:, timestamp:, output_file_path:)
     headers = ["Reference", "Submitted at"]
     values = [submission_reference, timestamp.iso8601]
-    current_context.completed_steps.map do |page|
+    current_context.all_steps.map do |page|
       headers.push(*page.show_answer_in_csv.keys)
       values.push(*page.show_answer_in_csv.values)
     end

--- a/app/models/question/selection.rb
+++ b/app/models/question/selection.rb
@@ -48,6 +48,8 @@ module Question
     end
 
     def selection_without_blanks
+      return [] if selection.nil?
+
       selection.reject(&:blank?)
     end
 

--- a/spec/features/fill_in_and_submit_form_with_csv_spec.rb
+++ b/spec/features/fill_in_and_submit_form_with_csv_spec.rb
@@ -3,30 +3,16 @@ require "rails_helper"
 feature "Fill in and submit a form with a CSV submission", type: :feature do
   let(:steps) do
     [
-      build(:v2_question_page_step, :with_text_settings, id: 1, question_text:, next_step_id: 2),
-      build(:v2_question_page_step, :with_text_settings, id: 2, is_optional: true, question_text: "An optional question?", next_step_id: 3),
-      build(:v2_question_page_step, :with_selections_settings, id: 3, question_text: "A routing question?", routing_conditions: [DataStruct.new(routing_page_id: 3, check_page_id: 3, answer_value: "Option 1", goto_page_id: nil, skip_to_end: true, validation_errors: [])]),
-      build(:v2_question_page_step, :with_text_settings, id: 4, question_text: "a question skipped through routing"),
-
+      build(:v2_question_page_step, :with_selections_settings, id: 1, question_text: "A routing question", routing_conditions: [DataStruct.new(routing_page_id: 1, check_page_id: 1, answer_value: "Option 1", goto_page_id: nil, skip_to_end: true, validation_errors: [])], next_step_id: 2),
+      build(:v2_question_page_step, :with_selections_settings, only_one_option: false, id: 2, question_text: "Skipped question", next_step_id: 3),
     ]
   end
   let(:form) { build :v2_form_document, :live?, id: 1, name: "Fill in this form", steps:, start_page: steps.first.id, submission_type: "email_with_csv" }
-  let(:question_text) { Faker::Lorem.question }
-  let(:answer_text) { "Answer text" }
-
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
-
   let(:req_headers) do
     {
       "X-API-Token" => Settings.forms_api.auth_key,
       "Accept" => "application/json",
-    }
-  end
-
-  let(:post_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Content-Type" => "application/json",
     }
   end
 
@@ -36,6 +22,12 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
     end
 
     allow(ReferenceNumberService).to receive(:generate).and_return(reference)
+
+    travel_to Time.parse("2029-01-24T05:05:50+00:00")
+  end
+
+  after do
+    travel_back
   end
 
   scenario "As a form filler" do
@@ -45,24 +37,13 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
     when_i_fill_in_the_question
     and_i_click_on_continue
 
-    then_i_should_see_the_optional_question
-    and_i_click_on_continue
-
-    then_i_should_see_the_routing_question
-    and_i_fill_out_the_routing_question
-    and_i_click_on_continue
-
     then_i_should_see_the_check_your_answers_page
     when_i_opt_out_of_email_confirmation
-
-    # We freeze time so we can test the value of the submission timestamp
-    freeze_time do
-      and_i_submit_my_form
-      then_an_email_submission_should_have_been_sent
-    end
+    and_i_submit_my_form
 
     then_my_form_should_be_submitted
     and_i_should_receive_a_reference_number
+    and_an_email_submission_should_have_been_sent
   end
 
   def when_i_visit_the_form_start_page
@@ -71,33 +52,19 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
   end
 
   def then_i_should_see_the_first_question
-    expect(page.find("h1")).to have_text question_text
+    expect(page.find("h1")).to have_text "A routing question"
   end
 
   def when_i_fill_in_the_question
-    fill_in question_text, with: answer_text
+    choose "Option 1"
   end
 
   def and_i_click_on_continue
     click_button "Continue"
   end
 
-  def then_i_should_see_the_optional_question
-    expect(page.find("h1")).to have_text "An optional question?"
-  end
-
-  def then_i_should_see_the_routing_question
-    expect(page.find("h1")).to have_text "A routing question?"
-  end
-
-  def and_i_fill_out_the_routing_question
-    choose "Option 1"
-  end
-
   def then_i_should_see_the_check_your_answers_page
     expect(page.find("h1")).to have_text "Check your answers before submitting your form"
-    expect(page).to have_text question_text
-    expect(page).to have_text answer_text
     expect_page_to_have_no_axe_errors(page)
   end
 
@@ -109,12 +76,14 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
     click_on "Submit"
   end
 
-  def then_an_email_submission_should_have_been_sent
+  def and_an_email_submission_should_have_been_sent
+    expect(ActionMailer::Base.deliveries.first).to be_present
+
     delivered_email = ActionMailer::Base.deliveries.first
 
     expected_content = [
-      ["Reference", "Submitted at", question_text, "An optional question?", "A routing question?"],
-      [reference, formatted_timestamp, answer_text, "", "Option 1"],
+      ["Reference", "Submitted at", "A routing question"],
+      [reference, "2029-01-24T05:05:50+00:00", "Option 1"],
     ]
 
     expect(parse_email_csv(delivered_email)).to match_array(expected_content)
@@ -135,10 +104,5 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
         email.govuk_notify_personalisation[:link_to_file][:file],
       ),
     )
-  end
-
-  def formatted_timestamp
-    timezone = Rails.configuration.x.submission.time_zone || "UTC"
-    Time.use_zone(timezone) { Time.zone.now.iso8601 }
   end
 end

--- a/spec/features/fill_in_and_submit_form_with_csv_spec.rb
+++ b/spec/features/fill_in_and_submit_form_with_csv_spec.rb
@@ -41,9 +41,7 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
     when_i_opt_out_of_email_confirmation
     and_i_submit_my_form
 
-    then_my_form_should_be_submitted
-    and_i_should_receive_a_reference_number
-    and_an_email_submission_should_have_been_sent
+    there_should_be_an_error_submitting
   end
 
   def when_i_visit_the_form_start_page
@@ -82,8 +80,8 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
     delivered_email = ActionMailer::Base.deliveries.first
 
     expected_content = [
-      ["Reference", "Submitted at", "A routing question"],
-      [reference, "2029-01-24T05:05:50+00:00", "Option 1"],
+      ["Reference", "Submitted at", "A routing question", "Skipped question"],
+      [reference, "2029-01-24T05:05:50+00:00", "Option 1", ""],
     ]
 
     expect(parse_email_csv(delivered_email)).to match_array(expected_content)
@@ -92,6 +90,10 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
   def then_my_form_should_be_submitted
     expect(page.find("h1")).to have_text "Your form has been submitted"
     expect_page_to_have_no_axe_errors(page)
+  end
+
+  def there_should_be_an_error_submitting
+    expect(page.find("h1")).to have_text "Sorry, we could not submit your answers"
   end
 
   def and_i_should_receive_a_reference_number

--- a/spec/features/fill_in_and_submit_form_with_csv_spec.rb
+++ b/spec/features/fill_in_and_submit_form_with_csv_spec.rb
@@ -41,7 +41,9 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
     when_i_opt_out_of_email_confirmation
     and_i_submit_my_form
 
-    there_should_be_an_error_submitting
+    then_my_form_should_be_submitted
+    and_i_should_receive_a_reference_number
+    and_an_email_submission_should_have_been_sent
   end
 
   def when_i_visit_the_form_start_page
@@ -90,10 +92,6 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
   def then_my_form_should_be_submitted
     expect(page.find("h1")).to have_text "Your form has been submitted"
     expect_page_to_have_no_axe_errors(page)
-  end
-
-  def there_should_be_an_error_submitting
-    expect(page.find("h1")).to have_text "Sorry, we could not submit your answers"
   end
 
   def and_i_should_receive_a_reference_number

--- a/spec/lib/csv_generator_spec.rb
+++ b/spec/lib/csv_generator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CsvGenerator do
   let(:name_question) { build :first_middle_last_name_question, question_text: "What is your name?" }
   let(:first_step) { build :step, question: text_question }
   let(:second_step) { build :step, question: name_question }
-  let(:current_context) { OpenStruct.new(form:, completed_steps: [first_step, second_step], support_details: OpenStruct.new(call_back_url: "http://gov.uk")) }
+  let(:current_context) { OpenStruct.new(form:, all_steps: [first_step, second_step], support_details: OpenStruct.new(call_back_url: "http://gov.uk")) }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
   let(:timestamp) do
     Time.use_zone("London") { Time.zone.local(2022, 9, 14, 8, 0o0, 0o0) }

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -19,11 +19,22 @@ RSpec.describe Question::Selection, type: :model do
     let(:only_one_option) { "false" }
     let(:is_optional) { false }
 
-    before do
-      question.selection = []
-    end
-
     it_behaves_like "a question model"
+
+    context "when created without attriibutes" do
+      it "returns invalid" do
+        expect(question).not_to be_valid
+        expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.checkbox_blank"))
+      end
+
+      it "shows as a blank string" do
+        expect(question.show_answer).to eq ""
+      end
+
+      it "returns a hash with an blank value for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
+      end
+    end
 
     context "when selection is blank" do
       before do


### PR DESCRIPTION
Trello card: https://trello.com/c/GxKKN67X/2038-implement-csv-formatting-for-routing

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This PR makes submission CSVs include headers and values for all questions in a form. It fixes an issue which caused production issues when previously enabling this feature.

See:
[The original PR which caused submissions to fail for a production form](https://github.com/alphagov/forms-runner/pull/1155)
[The PR used during the incident to revert the behaviour](https://github.com/alphagov/forms-runner/pull/1158)
[The incident document](https://docs.google.com/document/d/1M3usd9hEwpnVSnh2WP77Qf6uGak7pASfQqe5AQCIwc4/edit?tab=t.0#heading=h.p99426yo0rbv)

To prevent similar issues happening when deploying this PR the feature test for CSV generation has been adapted to cover the case.

I cloned the production form locally and tested it locally to reproduce the issue and confirm that the fix works. I then made a minimal tests case which is embedded in the feature test to show it's been fixed. The commits should be read in order and hopefully make it clear.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
