### PR TITLE
Store submission data to handle bounced submission emails

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -39,7 +39,7 @@ module Forms
 
       submission_reference = FormSubmissionService.call(current_context:,
                                                         email_confirmation_input:,
-                                                        preview_mode: mode.preview?).submit
+                                                        is_preview: mode.preview?).submit
 
       current_context.save_submission_details(submission_reference, requested_email_confirmation)
 

--- a/app/lib/flow/context.rb
+++ b/app/lib/flow/context.rb
@@ -18,7 +18,7 @@ module Flow
     end
 
     delegate :find_or_create, :previous_step, :next_page_slug, :next_step, :can_visit?, :completed_steps, :all_steps, to: :journey
-    delegate :clear_stored_answer, :clear, :form_submitted?, to: :answer_store
+    delegate :clear_stored_answer, :clear, :form_submitted?, :answers, to: :answer_store
     delegate :save_submission_details, :get_submission_reference, :requested_email_confirmation?, :clear_submission_details, to: :confirmation_details_store
 
     def save_step(step)

--- a/app/lib/store/session_answer_store.rb
+++ b/app/lib/store/session_answer_store.rb
@@ -30,5 +30,9 @@ module Store
     def form_submitted?
       @store[ANSWERS_KEY][@form_key].nil?
     end
+
+    def answers
+      @store[ANSWERS_KEY][@form_key]
+    end
   end
 end

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -11,7 +11,7 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
       # GOV.UK Notify's templates have conditionals, but only positive
       # conditionals, so to simulate negative conditionals we add two boolean
       # flags; but they must always have opposite values!
-      test: make_notify_boolean(mailer_options.preview_mode),
+      test: make_notify_boolean(mailer_options.is_preview),
       submission_reference: mailer_options.submission_reference,
       include_payment_link: make_notify_boolean(mailer_options.payment_url.present?),
       payment_link: mailer_options.payment_url || "",

--- a/app/mailers/form_submission_mailer.rb
+++ b/app/mailers/form_submission_mailer.rb
@@ -12,8 +12,8 @@ class FormSubmissionMailer < GovukNotifyRails::Mailer
       # GOV.UK Notify's templates have conditionals, but only positive
       # conditionals, so to simulate negative conditionals we add two boolean
       # flags; but they must always have opposite values!
-      test: make_notify_boolean(mailer_options.preview_mode),
-      not_test: make_notify_boolean(!mailer_options.preview_mode),
+      test: make_notify_boolean(mailer_options.is_preview),
+      not_test: make_notify_boolean(!mailer_options.is_preview),
       submission_reference: mailer_options.submission_reference,
       include_payment_link: make_notify_boolean(mailer_options.payment_url.present?),
       csv_attached: make_notify_boolean(csv_file.present?),

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  primary_abstract_class
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,0 +1,2 @@
+class Submission < ApplicationRecord
+end

--- a/app/services/aws_ses_submission_service.rb
+++ b/app/services/aws_ses_submission_service.rb
@@ -43,6 +43,7 @@ private
                                                        files:).deliver_now
 
     CurrentLoggingAttributes.submission_email_id = mail.message_id
+    mail.message_id
   end
 
   def answer_content

--- a/app/services/aws_ses_submission_service.rb
+++ b/app/services/aws_ses_submission_service.rb
@@ -8,11 +8,11 @@ class AwsSesSubmissionService
   end
 
   def submit
-    if !@mailer_options.preview_mode && @form.submission_email.blank?
+    if !@mailer_options.is_preview && @form.submission_email.blank?
       raise StandardError, "Form id(#{@form.id}) is missing a submission email address"
     end
 
-    if @form.submission_email.blank? && @mailer_options.preview_mode
+    if @form.submission_email.blank? && @mailer_options.is_preview
       Rails.logger.info "Skipping sending submission email for preview submission, as the submission email address has not been set"
       return
     end

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -5,14 +5,14 @@ class FormSubmissionService
     end
   end
 
-  MailerOptions = Data.define(:title, :preview_mode, :timestamp, :submission_reference, :payment_url)
+  MailerOptions = Data.define(:title, :is_preview, :timestamp, :submission_reference, :payment_url)
 
-  def initialize(current_context:, email_confirmation_input:, preview_mode:)
+  def initialize(current_context:, email_confirmation_input:, is_preview:)
     @current_context = current_context
     @form = current_context.form
     @email_confirmation_input = email_confirmation_input
     @requested_email_confirmation = @email_confirmation_input.send_confirmation == "send_email"
-    @preview_mode = preview_mode
+    @is_preview = is_preview
     @timestamp = submission_timestamp
     @submission_reference = ReferenceNumberService.generate
 
@@ -34,7 +34,7 @@ private
     submit_using_form_submission_type
     LogEventService.log_submit(@current_context,
                                requested_email_confirmation: @requested_email_confirmation,
-                               preview: @preview_mode,
+                               preview: @is_preview,
                                submission_type: @form.submission_type)
   end
 
@@ -77,7 +77,7 @@ private
       form: @form,
       timestamp: @timestamp,
       submission_reference: @submission_reference,
-      preview_mode: @preview_mode,
+      is_preview: @is_preview,
     )
   end
 
@@ -90,7 +90,7 @@ private
   end
 
   def submit_via_aws_ses
-    submission = Submission.new(reference: @submission_reference, form_id: @form.id, answers: @current_context.answers, is_preview: @preview_mode)
+    submission = Submission.new(reference: @submission_reference, form_id: @form.id, answers: @current_context.answers, is_preview: @is_preview)
     submission.mail_message_id = aws_ses_submission_service.submit
     submission.save!
   end
@@ -140,7 +140,7 @@ private
 
   def mailer_options
     MailerOptions.new(title: form_title,
-                      preview_mode: @preview_mode,
+                      is_preview: @is_preview,
                       timestamp: @timestamp,
                       submission_reference: @submission_reference,
                       payment_url: @form.payment_url_with_reference(@submission_reference))

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -40,7 +40,7 @@ private
 
   def submit_using_form_submission_type
     return s3_submission_service.submit if @form.submission_type == "s3"
-    return aws_ses_submission_service.submit if @form.has_file_upload_question?
+    return submit_via_aws_ses if @form.has_file_upload_question?
 
     notify_submission_service.submit
   end
@@ -87,6 +87,12 @@ private
       form: @form,
       mailer_options:,
     )
+  end
+
+  def submit_via_aws_ses
+    submission = Submission.new(reference: @submission_reference, form_id: @form.id, answers: @current_context.answers, is_preview: @preview_mode)
+    submission.mail_message_id = aws_ses_submission_service.submit
+    submission.save!
   end
 
   def form_title

--- a/app/services/notify_submission_service.rb
+++ b/app/services/notify_submission_service.rb
@@ -7,11 +7,11 @@ class NotifySubmissionService
   end
 
   def submit
-    if !@mailer_options.preview_mode && @form.submission_email.blank?
+    if !@mailer_options.is_preview && @form.submission_email.blank?
       raise StandardError, "Form id(#{@form.id}) is missing a submission email address"
     end
 
-    if @form.submission_email.blank? && @mailer_options.preview_mode
+    if @form.submission_email.blank? && @mailer_options.is_preview
       Rails.logger.info "Skipping sending submission email for preview submission, as the submission email address has not been set"
       return
     end

--- a/app/services/s3_submission_service.rb
+++ b/app/services/s3_submission_service.rb
@@ -2,12 +2,12 @@ class S3SubmissionService
   def initialize(journey:, form:,
                  timestamp:,
                  submission_reference:,
-                 preview_mode:)
+                 is_preview:)
     @journey = journey
     @form = form
     @timestamp = timestamp
     @submission_reference = submission_reference
-    @preview_mode = preview_mode
+    @is_preview = is_preview
   end
 
   def submit
@@ -61,7 +61,7 @@ private
   end
 
   def key_name
-    folder = @preview_mode ? "test_form_submissions" : "form_submissions"
+    folder = @is_preview ? "test_form_submissions" : "form_submissions"
     formatted_timestamp = @timestamp.utc.strftime("%Y%m%dT%H%M%SZ")
     "#{folder}/#{@form.id}/#{formatted_timestamp}_#{@submission_reference}.csv"
   end

--- a/db/migrate/20250219163804_add_initial_columns_to_submissions.rb
+++ b/db/migrate/20250219163804_add_initial_columns_to_submissions.rb
@@ -1,0 +1,11 @@
+class AddInitialColumnsToSubmissions < ActiveRecord::Migration[8.0]
+  def change
+    change_table :submissions, bulk: true do |t|
+      t.string :reference
+      t.string :mail_message_id
+      t.integer :form_id
+      t.jsonb :answers
+      t.boolean :is_preview
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_12_141200) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_19_163804) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "submissions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "reference"
+    t.string "mail_message_id"
+    t.integer "form_id"
+    t.jsonb "answers"
+    t.boolean "is_preview"
   end
 end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :submission do
+  end
+end

--- a/spec/lib/store/session_answer_store_spec.rb
+++ b/spec/lib/store/session_answer_store_spec.rb
@@ -65,6 +65,35 @@ RSpec.describe Store::SessionAnswerStore do
     expect(answer_store.get_stored_answer(other_form_step)).to eq("test2 answer")
   end
 
+  describe "#answers" do
+    let(:form_answers) do
+      {
+        "1" => {
+          selection: "Option 1",
+        },
+        "2" => {
+          text: "Example text",
+        },
+      }
+    end
+    let(:store) do
+      {
+        answers: {
+          form_id.to_s => form_answers,
+          "2" => {
+            "3" => {
+              selection: "Option 2",
+            },
+          },
+        },
+      }
+    end
+
+    it "returns all answers for a form" do
+      expect(answer_store.answers).to eq form_answers
+    end
+  end
+
   describe "#form_submitted?" do
     let(:store) { { answers: { form_id.to_s => nil } } }
 

--- a/spec/lib/store/session_answer_store_spec.rb
+++ b/spec/lib/store/session_answer_store_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Store::SessionAnswerStore do
 
   let(:store) { {} }
   let(:form_id) { 1 }
-  let(:step) { OpenStruct.new({ page_id: "5", form_id: }) }
-  let(:other_form_step) { OpenStruct.new({ page_id: "1", form_id: 2 }) }
+  let(:step) { OpenStruct.new({ page_id: "5" }) }
+  let(:other_step) { OpenStruct.new({ page_id: "1" }) }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
   let(:requested_email_confirmation) { true }
 
@@ -27,42 +27,57 @@ RSpec.describe Store::SessionAnswerStore do
     expect(result).to eq("test answer")
   end
 
-  it "clears a single answer for a step" do
-    answer_store.save_step(step, "test answer")
-    expect(answer_store.get_stored_answer(step)).to eq("test answer")
-    answer_store.clear_stored_answer(step)
-    expect(answer_store.get_stored_answer(step)).to be_nil
-  end
+  describe "#clear_stored_answer" do
+    before do
+      answer_store.save_step(step, "test answer")
+    end
 
-  it "does not error if removing a step which doesn't exist in the store" do
-    answer_store.save_step(step, "test answer")
-    answer_store.clear_stored_answer(other_form_step)
-    expect(answer_store.get_stored_answer(step)).to eq("test answer")
+    it "clears a single answer for a step" do
+      expect(answer_store.get_stored_answer(step)).to eq("test answer")
+      answer_store.clear_stored_answer(step)
+      expect(answer_store.get_stored_answer(step)).to be_nil
+    end
+
+    it "does not error if removing a step which doesn't exist in the store" do
+      answer_store.clear_stored_answer(other_step)
+      expect(answer_store.get_stored_answer(step)).to eq("test answer")
+    end
   end
 
   describe "#clear" do
-    it "clears the session for a form" do
+    let(:other_form_id) { 9 }
+
+    before do
       answer_store.save_step(step, "test answer")
+    end
+
+    it "clears the session for a form" do
       answer_store.clear
       expect(answer_store.get_stored_answer(step)).to be_nil
     end
 
     it "doesn't change other forms" do
-      answer_store.save_step(step, "form1 answer")
-
-      other_form_answer_store = described_class.new(store, other_form_step.form_id)
-      other_form_answer_store.save_step(other_form_step, "form2 answer")
+      other_form_answer_store = described_class.new(store, other_form_id)
+      other_form_answer_store.save_step(other_step, "other form answer")
 
       answer_store.clear
-      expect(other_form_answer_store.get_stored_answer(other_form_step)).to eq("form2 answer")
+      expect(other_form_answer_store.get_stored_answer(other_step)).to eq("other form answer")
     end
   end
 
-  it "returns the answers for a form" do
-    answer_store.save_step(step, "test answer")
-    answer_store.save_step(other_form_step, "test2 answer")
-    expect(answer_store.get_stored_answer(step)).to eq("test answer")
-    expect(answer_store.get_stored_answer(other_form_step)).to eq("test2 answer")
+  describe "#get_stored_answer" do
+    before do
+      answer_store.save_step(step, "test answer")
+      answer_store.save_step(other_step, "test2 answer")
+    end
+
+    it "returns the answer for the first step" do
+      expect(answer_store.get_stored_answer(step)).to eq("test answer")
+    end
+
+    it "returns the answer for the second step" do
+      expect(answer_store.get_stored_answer(other_step)).to eq("test2 answer")
+    end
   end
 
   describe "#answers" do

--- a/spec/mailers/aws_ses_form_submission_mailer_preview.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_preview.rb
@@ -3,7 +3,7 @@ class AwsSesFormSubmissionMailerPreview < ActionMailer::Preview
     AwsSesFormSubmissionMailer.submission_email(answer_content: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
                                                 submission_email_address: "testing@gov.uk",
                                                 mailer_options: FormSubmissionService::MailerOptions.new(title: "Form 1",
-                                                                                                         preview_mode: false,
+                                                                                                         is_preview: false,
                                                                                                          timestamp: Time.zone.now,
                                                                                                          submission_reference: Faker::Alphanumeric.alphanumeric(number: 8).upcase,
                                                                                                          payment_url: nil),

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -4,14 +4,14 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
   let(:mail) { described_class.submission_email(answer_content:, submission_email_address:, mailer_options:, files:) }
   let(:title) { "Form 1" }
   let(:answer_content) { "My question: My answer" }
-  let(:preview_mode) { false }
+  let(:is_preview) { false }
   let(:submission_email_address) { "testing@gov.uk" }
   let(:files) { {} }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
   let(:payment_url) { nil }
   let(:mailer_options) do
     FormSubmissionService::MailerOptions.new(title:,
-                                             preview_mode:,
+                                             is_preview:,
                                              timestamp: submission_timestamp,
                                              submission_reference:,
                                              payment_url:)

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -10,7 +10,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
   end
   let(:mailer_options) do
     FormSubmissionService::MailerOptions.new(title:,
-                                             preview_mode:,
+                                             is_preview:,
                                              timestamp: submission_timestamp,
                                              submission_reference:,
                                              payment_url:)
@@ -18,7 +18,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
   let(:title) { "Form 1" }
   let(:what_happens_next_markdown) { "Please wait for a response" }
   let(:support_contact_details) { "Call: 0203 222 2222" }
-  let(:preview_mode) { false }
+  let(:is_preview) { false }
   let(:confirmation_email_address) { "testing@gov.uk" }
   let(:submission_timestamp) { Time.zone.now }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
@@ -114,7 +114,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
     end
 
     context "when the submission is from preview mode" do
-      let(:preview_mode) { true }
+      let(:is_preview) { true }
 
       it "uses the preview personalisation" do
         expect(mail.govuk_notify_personalisation[:test]).to eq("yes")

--- a/spec/mailers/form_submission_mailer_spec.rb
+++ b/spec/mailers/form_submission_mailer_spec.rb
@@ -4,13 +4,13 @@ describe FormSubmissionMailer, type: :mailer do
   let(:mail) { described_class.email_confirmation_input(text_input:, notify_response_id: "for-my-ref", submission_email:, mailer_options:) }
   let(:title) { "Form 1" }
   let(:text_input) { "My question: My answer" }
-  let(:preview_mode) { false }
+  let(:is_preview) { false }
   let(:submission_email) { "testing@gov.uk" }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
   let(:payment_url) { nil }
   let(:mailer_options) do
     FormSubmissionService::MailerOptions.new(title:,
-                                             preview_mode:,
+                                             is_preview:,
                                              timestamp: submission_timestamp,
                                              submission_reference:,
                                              payment_url:)
@@ -167,7 +167,7 @@ describe FormSubmissionMailer, type: :mailer do
     end
 
     context "when the submission is from preview mode" do
-      let(:preview_mode) { true }
+      let(:is_preview) { true }
 
       it "uses the preview personalisation" do
         expect(mail.govuk_notify_personalisation[:test]).to eq("yes")

--- a/spec/services/aws_ses_submission_service_spec.rb
+++ b/spec/services/aws_ses_submission_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AwsSesSubmissionService do
   let(:journey) { instance_double(Flow::Journey, completed_steps: all_steps, all_steps:) }
   let(:question) { build :text, question_text: "What is the meaning of life?", text: "42" }
   let(:step) { build :step, question: }
-  let(:preview_mode) { false }
+  let(:is_preview) { false }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
   let(:payment_url) { nil }
   let(:submission_email) { "submissions@example.gov.uk" }
@@ -21,7 +21,7 @@ RSpec.describe AwsSesSubmissionService do
   let(:timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0) }
   let(:mailer_options) do
     FormSubmissionService::MailerOptions.new(title: form.name,
-                                             preview_mode:,
+                                             is_preview:,
                                              timestamp:,
                                              submission_reference:,
                                              payment_url:)
@@ -202,7 +202,7 @@ RSpec.describe AwsSesSubmissionService do
     end
 
     context "when form being submitted is from previewed form" do
-      let(:preview_mode) { true }
+      let(:is_preview) { true }
 
       context "when the submission email is set" do
         it "calls AwsSesFormSubmissionMailer" do

--- a/spec/services/aws_ses_submission_service_spec.rb
+++ b/spec/services/aws_ses_submission_service_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe AwsSesSubmissionService do
       allow(Settings.ses_submission_email).to receive(:from_email_address).and_return(from_email_address)
     end
 
+    shared_examples "it returns the message id" do
+      it "returns the message id" do
+        message_id = service.submit
+
+        last_email = ActionMailer::Base.deliveries.last
+        expect(message_id).to eq last_email.message_id
+      end
+    end
+
     context "when the submission type is email" do
       before do
         form.submission_type = "email"
@@ -72,6 +81,8 @@ RSpec.describe AwsSesSubmissionService do
         service.submit
         expect(CsvGenerator).not_to have_received(:write_submission)
       end
+
+      include_examples "it returns the message id"
     end
 
     context "when answers contain uploaded files" do
@@ -96,6 +107,8 @@ RSpec.describe AwsSesSubmissionService do
           ).once
         end
       end
+
+      include_examples "it returns the message id"
     end
 
     context "when the submission type is email_with_csv" do
@@ -130,6 +143,8 @@ RSpec.describe AwsSesSubmissionService do
           ).once
         end
       end
+
+      include_examples "it returns the message id"
 
       context "when submission contains a file upload question" do
         let(:question) { build :file, :with_uploaded_file }
@@ -219,6 +234,8 @@ RSpec.describe AwsSesSubmissionService do
           expect(AwsSesFormSubmissionMailer).not_to have_received(:submission_email)
         end
       end
+
+      include_examples "it returns the message id"
     end
 
     describe "validations" do

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe FormSubmissionService do
-  subject(:service) { described_class.call(current_context:, email_confirmation_input:, preview_mode:) }
+  subject(:service) { described_class.call(current_context:, email_confirmation_input:, is_preview:) }
 
-  let(:preview_mode) { false }
+  let(:is_preview) { false }
   let(:email_confirmation_input) { build :email_confirmation_input_opted_in }
 
   let(:form) do
@@ -90,7 +90,7 @@ RSpec.describe FormSubmissionService do
         expect(LogEventService).to have_received(:log_submit).with(
           current_context,
           requested_email_confirmation: true,
-          preview: preview_mode,
+          preview: is_preview,
           submission_type:,
         )
       end
@@ -137,7 +137,7 @@ RSpec.describe FormSubmissionService do
             service.submit
           }.to change(Submission, :count).by(1)
 
-          expect(Submission.last).to have_attributes(reference:, form_id: form.id, answers: answers.deep_stringify_keys, is_preview: preview_mode, mail_message_id:)
+          expect(Submission.last).to have_attributes(reference:, form_id: form.id, answers: answers.deep_stringify_keys, is_preview: is_preview, mail_message_id:)
         end
       end
 
@@ -159,7 +159,7 @@ RSpec.describe FormSubmissionService do
               form:,
               timestamp: Time.zone.now,
               submission_reference: reference,
-              preview_mode:,
+              is_preview:,
             ).once
           end
         end
@@ -178,7 +178,7 @@ RSpec.describe FormSubmissionService do
       end
 
       context "when form being submitted is from previewed form" do
-        let(:preview_mode) { true }
+        let(:is_preview) { true }
 
         include_examples "logging"
       end

--- a/spec/services/notify_submission_service_spec.rb
+++ b/spec/services/notify_submission_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe NotifySubmissionService do
   let(:journey) { instance_double(Flow::Journey, completed_steps: all_steps, all_steps:) }
   let(:question) { build :text, question_text: "What is the meaning of life?", text: "42" }
   let(:step) { build :step, question: }
-  let(:preview_mode) { false }
+  let(:is_preview) { false }
   let(:notify_email_reference) { "ffffffff-submission-email" }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
   let(:payment_url) { nil }
@@ -23,7 +23,7 @@ RSpec.describe NotifySubmissionService do
   let(:timestamp) { Time.zone.now }
   let(:mailer_options) do
     FormSubmissionService::MailerOptions.new(title: form.name,
-                                             preview_mode:,
+                                             is_preview:,
                                              timestamp:,
                                              submission_reference:,
                                              payment_url:)
@@ -149,7 +149,7 @@ RSpec.describe NotifySubmissionService do
     end
 
     context "when form being submitted is from previewed form" do
-      let(:preview_mode) { true }
+      let(:is_preview) { true }
 
       context "when the submission email is set" do
         it "calls FormSubmissionMailer" do

--- a/spec/services/s3_submission_service_spec.rb
+++ b/spec/services/s3_submission_service_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe S3SubmissionService do
   subject(:service) do
-    described_class.new(journey:, form:, timestamp:, submission_reference:, preview_mode:)
+    described_class.new(journey:, form:, timestamp:, submission_reference:, is_preview:)
   end
 
   let(:file_body) { "some body/n" }
@@ -23,7 +23,7 @@ RSpec.describe S3SubmissionService do
   let(:all_steps) { [step] }
   let(:journey) { instance_double(Flow::Journey, completed_steps: all_steps, all_steps:) }
   let(:step) { build :step }
-  let(:preview_mode) { false }
+  let(:is_preview) { false }
 
   describe "#upload_submission_csv_to_s3" do
     let(:mock_credentials) { { foo: "bar" } }
@@ -75,7 +75,7 @@ RSpec.describe S3SubmissionService do
       end
 
       context "when a preview is being submitted" do
-        let(:preview_mode) { true }
+        let(:is_preview) { true }
 
         it "calls put_object with a key starting with 'test_form_submissions/'" do
           expected_timestamp = "20220914T072434Z"


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/lW3IqOhY

This PR adds a new `Submission` model, and uses it to store submission data when submission emails are sent via AWS SES. In order to enable this, we also added a method to the `SessionAnswerStore` to retrieve answers from the session.

In future, we may make all submission types asynchronous so may persist submission data for all submission types then, as opposed to just for the `AwsSesSubmissionService`.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
