### PR TITLE
Add return statements to PageController#show

### DIFF
--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -8,8 +8,8 @@ module Forms
     end
 
     def show
-      redirect_to form_page_path(@step.form_id, @step.form_slug, current_context.next_page_slug) unless current_context.can_visit?(@step.page_slug)
-      redirect_to review_file_page if answered_file_question?
+      return redirect_to form_page_path(@step.form_id, @step.form_slug, current_context.next_page_slug) unless current_context.can_visit?(@step.page_slug)
+      return redirect_to review_file_page if answered_file_question?
 
       back_link(@step.page_slug)
       setup_instance_vars_for_view


### PR DESCRIPTION
### What problem does this pull request solve?

Fixes `AbstractController::DoubleRenderError` Sentry alert.

@DavidBiddle suggested the root cause of the error:

- visit a repeatable step without filling out the previous questions
- the show action in PageController runs
- [this line](https://github.com/alphagov/forms-runner/blob/e57f658217be19b8a7dc68375eb2f45d162399ed/app/controllers/forms/page_controller.rb#L11) sets up a redirect to the first page in the form, but the action still continues
- the next line calls answered_file_question? , which calls step.question , which errors out on [this line](https://github.com/alphagov/forms-runner/blob/e57f658217be19b8a7dc68375eb2f45d162399ed/app/models/repeatable_step.rb#L49)
- that exception is caught by [this rescue statement](https://github.com/alphagov/forms-runner/blob/e57f658217be19b8a7dc68375eb2f45d162399ed/app/controllers/forms/base_controller.rb#L10) which calls render, causing the DoubleRenderError in Sentry

He also suggested a solution to add a `return` to where we `redirect_to` so the method exits appropriately.

I paired with @chao-xian to make sure I understood the Ruby correctly.