### PR TITLE
Update URI gem to avoid CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,7 +454,7 @@ GEM
       tzinfo (>= 1.0.0)
     uk_postcode (2.1.8)
     unicode-display_width (2.6.0)
-    uri (1.0.2)
+    uri (1.0.3)
     useragent (0.16.11)
     view_component (3.21.0)
       activesupport (>= 5.2.0, < 8.1)


### PR DESCRIPTION
Update the version of the URI gem to avoid a CVE, see https://www.cve.org/CVERecord?id=CVE-2025-27221

Done without Dependabot because it has an issue.

