### PR TITLE
Delete submissions after 7 days

### DIFF
--- a/app/jobs/delete_submissions_job.rb
+++ b/app/jobs/delete_submissions_job.rb
@@ -1,0 +1,34 @@
+class DeleteSubmissionsJob < ApplicationJob
+  queue_as :default
+
+  def perform(*_args)
+    delete_submissions_updated_before_time = Settings.retain_submissions_for_seconds.seconds.ago
+    submissions_to_delete = Submission.where(updated_at: ..delete_submissions_updated_before_time)
+                            .where.not(mail_message_id: nil)
+
+    submissions_to_delete.find_each { |submission| delete_submission_data(submission) }
+  end
+
+  def delete_submission_data(submission)
+    files = submission.journey.completed_file_upload_questions
+    files.each(&:delete_from_s3)
+    submission.destroy!
+    log_submission_deleted(submission)
+  rescue StandardError => e
+    Rails.logger.warn("Error deleting submission - #{e.class.name}: #{e.message}", {
+      form_id: submission.form_id,
+      submission_reference: submission.reference,
+      job_id:,
+    })
+    Sentry.capture_exception(e)
+  end
+
+  def log_submission_deleted(submission)
+    EventLogger.log_form_event("submission_deleted", {
+      submission_reference: submission.reference,
+      form_id: submission.form.id,
+      form_name: submission.form.name,
+      job_id:,
+    })
+  end
+end

--- a/app/jobs/send_submission_job.rb
+++ b/app/jobs/send_submission_job.rb
@@ -7,24 +7,16 @@ class SendSubmissionJob < ApplicationJob
   retry_on Aws::SESV2::Errors::ServiceError, wait: :polynomially_longer, attempts: TOTAL_ATTEMPTS
 
   def perform(submission)
-    mode = Mode.new(submission.mode)
-
-    form = Api::V1::FormSnapshotRepository.find_with_mode(id: submission.form_id, mode:)
-
-    answer_store = Store::DatabaseAnswerStore.new(submission.answers)
-
-    journey = Flow::Journey.new(answer_store:, form:)
-
-    # TODO: we can refactor how we do this - just getting it working
+    form = submission.form
     mailer_options = FormSubmissionService::MailerOptions.new(title: form.name,
-                                                              is_preview: mode.preview?,
+                                                              is_preview: submission.preview?,
                                                               timestamp: submission.created_at,
                                                               submission_reference: submission.reference,
                                                               payment_url: form.payment_url_with_reference(submission.reference))
 
     message_id = AwsSesSubmissionService.new(
-      journey:,
-      form:,
+      journey: submission.journey,
+      form: form,
       mailer_options:,
     ).submit
 

--- a/app/lib/flow/journey.rb
+++ b/app/lib/flow/journey.rb
@@ -60,6 +60,12 @@ module Flow
       @form.pages.map { |page| find_or_create(page.id.to_s) }
     end
 
+    def completed_file_upload_questions
+      completed_steps
+              .select { |step| step.question.is_a?(Question::File) && step.question.file_uploaded? }
+              .map(&:question)
+    end
+
   private
 
     def step_is_completed?(question_page_step)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,2 +1,21 @@
 class Submission < ApplicationRecord
+  delegate :preview?, to: :mode_object
+
+  def journey
+    @journey ||= Flow::Journey.new(answer_store:, form:)
+  end
+
+  def form
+    @form ||= Api::V1::FormSnapshotRepository.find_with_mode(id: form_id, mode: mode_object)
+  end
+
+private
+
+  def mode_object
+    Mode.new(mode)
+  end
+
+  def answer_store
+    Store::DatabaseAnswerStore.new(answers)
+  end
 end

--- a/app/services/aws_ses_submission_service.rb
+++ b/app/services/aws_ses_submission_service.rb
@@ -51,9 +51,8 @@ private
   end
 
   def uploaded_files_in_answers
-    @journey.completed_steps
-            .select { |step| step.question.is_a?(Question::File) && step.question.file_uploaded? }
-            .map { |step| [step.question.original_filename, step.question.file_from_s3] }
+    @journey.completed_file_upload_questions
+            .map { |question| [question.original_filename, question.file_from_s3] }
             .to_h
   end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,35 +22,16 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
-  <<: *default
-  database: forms_runner_development
-
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user running Rails.
-  username: postgres
-
-  # The password associated with the postgres role (username).
-  password: postgres
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
+  primary: &primary_development
+    <<: *default
+    database: forms_runner_development
+    username: postgres
+    password: postgres
+    host: localhost
+  queue:
+    <<: *primary_development
+    database: forms_runner_development_queue
+    migrations_path: db/queue_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,6 +52,10 @@ Rails.application.configure do
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 
+  # Uncomment the lines below to use Solid Queue as Active Job adapter locally. Then start Solid Queue using ./bin/jobs
+  # config.active_job.queue_adapter = :solid_queue
+  # config.solid_queue.connects_to = { database: { writing: :queue } }
+
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true
 

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,10 +1,8 @@
-# production:
-#   periodic_cleanup:
-#     class: CleanSoftDeletedRecordsJob
-#     queue: background
-#     args: [ 1000, { batch_size: 500 } ]
-#     schedule: every hour
-#   periodic_command:
-#     command: "SoftDeletedRecord.due.delete_all"
-#     priority: 2
-#     schedule: at 5am every day
+production:
+  delete_submissions_job:
+    class: DeleteSubmissionsJob
+    schedule: every hour
+development:
+  delete_submissions_job:
+    class: DeleteSubmissionsJob
+    schedule: every minute

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,6 +37,8 @@ file_upload:
   poll_scan_status_wait_milliseconds: 500
   poll_scan_status_max_attempts: 20
 
+retain_submissions_for_seconds: 604800 # 7 days
+
 maintenance_mode:
   # When set to true, All pages will render 'Maintenance mode' message
   enabled: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -5,3 +5,5 @@ aws:
 ses_submission_email:
   from_email_address: "local-test@dev.forms.service.gov.uk"
   reply_to_email_address: "local-test@dev.forms.service.gov.uk"
+
+retain_submissions_for_seconds: 60

--- a/db/migrate/20250303163133_add_index_on_updated_at_to_submissions.rb
+++ b/db/migrate/20250303163133_add_index_on_updated_at_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddIndexOnUpdatedAtToSubmissions < ActiveRecord::Migration[8.0]
+  def change
+    add_index :submissions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_25_161333) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_03_163133) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,5 +22,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_25_161333) do
     t.integer "form_id"
     t.jsonb "answers"
     t.string "mode"
+    t.index ["updated_at"], name: "index_submissions_on_updated_at"
   end
 end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
       }
     end
     mode { "live" }
+
+    trait :sent do
+      mail_message_id { Faker::Alphanumeric.alphanumeric }
+    end
   end
 end

--- a/spec/jobs/delete_submissions_job_spec.rb
+++ b/spec/jobs/delete_submissions_job_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+RSpec.describe DeleteSubmissionsJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:form_with_file_upload) { build :v2_form_document, id: 1, steps: file_upload_steps, start_page: 1 }
+  let(:form_without_file_upload) { build :v2_form_document, id: 2, steps: [text_step], start_page: text_step.id }
+  let(:file_upload_steps) do
+    [
+      build(:v2_question_page_step, answer_type: "file", id: 1, next_step_id: 2),
+      build(:v2_question_page_step, answer_type: "file", id: 2),
+    ]
+  end
+  let(:text_step) { build(:v2_question_page_step, :with_text_settings, id: 3) }
+  let(:req_headers) do
+    {
+      "X-API-Token" => Settings.forms_api.auth_key,
+      "Accept" => "application/json",
+    }
+  end
+
+  let(:file_upload_s3_service_spy) { instance_double(Question::FileUploadS3Service) }
+
+  let(:form_with_file_upload_answers) do
+    {
+      "1" => { uploaded_file_key: "key1" },
+      "2" => { uploaded_file_key: "key2" },
+    }
+  end
+
+  let!(:sent_submission_updated_8_days_ago) { create :submission, :sent, reference: "SENT8DAYS", form_id: form_with_file_upload.id, updated_at: 8.days.ago, answers: form_with_file_upload_answers }
+  let!(:sent_submission_updated_7_days_ago) { create :submission, :sent, reference: "SENT7DAYS", form_id: form_without_file_upload.id, updated_at: 7.days.ago }
+  let!(:sent_submission_updated_6_days_ago) { create :submission, :sent, reference: "SENT6DAYS", form_id: form_without_file_upload.id, updated_at: 6.days.ago }
+  let!(:unsent_submission) { create :submission, reference: "UNSENT", updated_at: 7.days.ago }
+
+  before do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/api/v2/forms/#{form_with_file_upload.id}/live", req_headers, form_with_file_upload.to_json, 200
+      mock.get "/api/v2/forms/#{form_without_file_upload.id}/live", req_headers, form_without_file_upload.to_json, 200
+    end
+
+    allow(Question::FileUploadS3Service).to receive(:new).and_return(file_upload_s3_service_spy)
+
+    described_class.perform_later
+  end
+
+  context "when deleting uploaded files is successful" do
+    before do
+      allow(file_upload_s3_service_spy).to receive(:delete_from_s3)
+      allow(EventLogger).to receive(:log_form_event)
+    end
+
+    it "deletes the files from S3" do
+      perform_enqueued_jobs
+      expect(file_upload_s3_service_spy).to have_received(:delete_from_s3).with("key1").once
+      expect(file_upload_s3_service_spy).to have_received(:delete_from_s3).with("key2").once
+    end
+
+    it "destroys the sent submissions updated more than 7 days ago" do
+      expect { perform_enqueued_jobs }.to change(Submission, :count).by(-2)
+      expect(Submission.exists?(sent_submission_updated_8_days_ago.id)).to be false
+      expect(Submission.exists?(sent_submission_updated_7_days_ago.id)).to be false
+    end
+
+    it "does not destroy the sent submission updated more recently than 7 days ago" do
+      perform_enqueued_jobs
+      expect(Submission.exists?(sent_submission_updated_6_days_ago.id)).to be true
+    end
+
+    it "does not destroy the submission that hasn't been sent" do
+      perform_enqueued_jobs
+      expect(Submission.exists?(unsent_submission.id)).to be true
+    end
+
+    it "logs deletion" do
+      perform_enqueued_jobs
+      expect(EventLogger).to have_received(:log_form_event).once.with("submission_deleted", {
+        submission_reference: "SENT8DAYS", form_id: form_with_file_upload.id, form_name: form_with_file_upload.name, job_id: anything
+      })
+      expect(EventLogger).to have_received(:log_form_event).once.with("submission_deleted", {
+        submission_reference: "SENT7DAYS", form_id: form_without_file_upload.id, form_name: form_without_file_upload.name, job_id: anything
+      })
+    end
+  end
+
+  context "when deleting uploaded files fails" do
+    before do
+      allow(file_upload_s3_service_spy).to receive(:delete_from_s3).and_raise(StandardError, "Test error")
+      allow(Rails.logger).to receive(:warn).at_least(:once)
+      allow(Sentry).to receive(:capture_exception)
+    end
+
+    it "logs at warn level" do
+      perform_enqueued_jobs
+      expect(Rails.logger).to have_received(:warn).with("Error deleting submission - StandardError: Test error", {
+        form_id: form_with_file_upload.id,
+        submission_reference: sent_submission_updated_8_days_ago.reference,
+        job_id: anything,
+      })
+    end
+
+    it "sends error to Sentry" do
+      perform_enqueued_jobs
+      expect(Sentry).to have_received(:capture_exception)
+    end
+
+    it "does not destroy the submission that errored" do
+      perform_enqueued_jobs
+      expect(Submission.exists?(sent_submission_updated_8_days_ago.id)).to be true
+    end
+
+    it "continues to delete the next submission" do
+      expect { perform_enqueued_jobs }.to change(Submission, :count).by(-1)
+      expect(Submission.exists?(sent_submission_updated_7_days_ago.id)).to be false
+    end
+  end
+end

--- a/spec/lib/flow/journey_spec.rb
+++ b/spec/lib/flow/journey_spec.rb
@@ -254,4 +254,34 @@ RSpec.describe Flow::Journey do
       end
     end
   end
+
+  describe "#completed_file_upload_questions" do
+    let(:first_page_in_form) { build(:page, answer_type: "file", id: 1, next_page: 2) }
+    let(:second_page_in_form) { build(:page, answer_type: "file", id: 2, next_page: 3) }
+    let(:third_page_in_form) { build(:page, answer_type: "file", id: 3, next_page: 4) }
+    let(:fourth_page_in_form) { build(:page, :with_text_settings, id: 4) }
+    let(:pages_data) { [first_page_in_form, second_page_in_form, third_page_in_form, fourth_page_in_form] }
+
+    let(:answer_store) { Store::SessionAnswerStore.new(store, form.id) }
+    let(:store) do
+      {
+        answers: {
+          "2" =>
+            {
+              "1" => { uploaded_file_key: "key1", original_filename: "file1" },
+              "2" => { original_filename: "" },
+              "3" => { uploaded_file_key: "key2", original_filename: "file2" },
+              "4" => { text: "Example text" },
+            },
+        },
+      }
+    end
+
+    it "returns the answered file upload questions" do
+      completed_file_upload_questions = journey.completed_file_upload_questions
+      expect(completed_file_upload_questions.length).to eq 2
+      expect(completed_file_upload_questions.first.uploaded_file_key).to eq "key1"
+      expect(completed_file_upload_questions.second.uploaded_file_key).to eq "key2"
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/koB73lTl/

Add a scheduled task which is run by Solid Queue to delete submission which:
* have an `updated_at` date of earlier that 7 days ago
* have a `mail_message_id` present, indicating we have successfully initialised sending the submission email

We are using the `updated_at` date so that when a submission bounces, we will delete it 7 days after the submission is re-attempted. We'll look at ensuring we don't delete bounced submissions until they've been successfully retried in a different PR.

If a submission has answered file upload questions, we delete the uploaded files from S3.

This job will be run on an hourly schedule.

If deleting a submission fails for any reason, we send the error to Sentry and continue deleting other submissions.

### Testing

To test running the recurring job locally, uncomment the lines in `development.rb` to set Solid Queue as the adapter for Active Job.

Start Solid Queue by running `ASSUME_DEV_IAM_ROLE=true ./bin/jobs` while in an AWS shell, so it is possible to delete files from the S3 bucket.

If you see errors being thrown when Solid Queue tries to run the job, look at https://github.com/rails/rails/issues/38560
I found this made it work for me:
`PGGSSENCMODE="disable" ASSUME_DEV_IAM_ROLE=true ./bin/jobs`


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
