### PR TITLE
Add temporary rake task to set mode on submissions

### DIFF
--- a/lib/tasks/submissions.rake
+++ b/lib/tasks/submissions.rake
@@ -1,0 +1,19 @@
+namespace :submissions do
+  desc "Update mode for submission"
+  task :update_mode, %i[submission_reference mode] => :environment do |_, args|
+    submission_reference = args[:submission_reference]
+    mode = args[:mode]
+
+    usage_message = "usage: rake submissions:update_mode[<submission_reference>, <mode>]"
+    abort usage_message if submission_reference.blank? || mode.blank?
+
+    Submission.find_by(reference: submission_reference).update!(mode: mode)
+    Rails.logger.info "Updated submission #{submission_reference} mode to #{mode}"
+  end
+
+  desc "List submissions without mode"
+  task :list_submissions_without_mode, [] => :environment do |_, _|
+    submission_references = Submission.where(mode: nil).map(&:reference).join(", ")
+    Rails.logger.info "Submissions with no mode set: #{submission_references}"
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/koB73lTl

When we first started storing submissions, we were not storing the `mode`, which is required to retrieve the form from forms-api.

This means that the DeleteSubmissionsJob is failing for these submissions. Add a temporary rake task to set the `mode` on these submissions.

Add another task to list submissions without a mode so we don't miss any.

These rake tasks can be removed as soon as these submission records are fixed.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
