### PR TITLE
Store form document on submission

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -4,6 +4,7 @@ class Form < ActiveResource::Base
   self.include_format_in_path = false
 
   has_many :pages
+  attr_accessor :document_json
 
   def last_page
     pages.find { |p| !p.has_next_page? }

--- a/app/services/api/v1/form_snapshot_repository.rb
+++ b/app/services/api/v1/form_snapshot_repository.rb
@@ -27,7 +27,9 @@ class Api::V1::FormSnapshotRepository
       v2_blob = v2_form_document.as_json
 
       v1_blob = converter.to_api_v1_form_snapshot(v2_blob)
-      Form.new(v1_blob, true)
+      form = Form.new(v1_blob, true)
+      form.document_json = v2_blob
+      form
     end
   end
 end

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -91,7 +91,11 @@ private
 
   def submit_via_aws_ses
     submission = Submission.create!(
-      reference: @submission_reference, form_id: @form.id, answers: @current_context.answers, mode: @mode,
+      reference: @submission_reference,
+      form_id: @form.id,
+      answers: @current_context.answers,
+      mode: @mode,
+      form_document: @form.document_json,
     )
 
     SendSubmissionJob.perform_later(submission)

--- a/db/migrate/20250310114758_add_form_document_to_submissions.rb
+++ b/db/migrate/20250310114758_add_form_document_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddFormDocumentToSubmissions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :submissions, :form_document, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_03_163133) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_10_114758) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_03_163133) do
     t.integer "form_id"
     t.jsonb "answers"
     t.string "mode"
+    t.jsonb "form_document"
     t.index ["updated_at"], name: "index_submissions_on_updated_at"
   end
 end

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     support_url { nil }
     support_url_text { nil }
     payment_url { nil }
+    document_json { build(:v2_form_document).to_h.with_indifferent_access }
 
     declaration_text { nil }
     declaration_section_completed { false }

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
       }
     end
     mode { "live" }
+    form_document { build :v2_form_document }
 
     trait :sent do
       mail_message_id { Faker::Alphanumeric.alphanumeric }

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -20,8 +20,10 @@ RSpec.describe FormSubmissionService do
           submission_email:,
           payment_url:,
           submission_type:,
-          pages:)
+          pages:,
+          document_json: form_document)
   end
+  let(:form_document) { build(:v2_form_document).to_h.with_indifferent_access }
   let(:pages) { [build(:page, id: 2, answer_type: "text")] }
   let(:submission_type) { "email" }
   let(:what_happens_next_markdown) { "We usually respond to applications within 10 working days." }
@@ -159,7 +161,8 @@ RSpec.describe FormSubmissionService do
             service.submit
           }.to change(Submission, :count).by(1)
 
-          expect(Submission.last).to have_attributes(reference:, form_id: form.id, answers: answers.deep_stringify_keys, mode: "live", mail_message_id: nil)
+          expect(Submission.last).to have_attributes(reference:, form_id: form.id, answers: answers.deep_stringify_keys,
+                                                     mode: "live", mail_message_id: nil, form_document: form_document)
         end
       end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/MK2CoKeB/2753-ensure-we-can-send-submission-emails-when-form-is-changed

Store the form document JSON blob on the submission in the database and use this when reading the form to construct the Journey for generating the submission email in the SendSubmissionJob, and for deleting uploaded files from S3 in the DeleteSubmissionsJob.

We need to do this rather than getting the form from forms-api as the form may have been updated after the submission was made, meaning that the answers may no longer match up with the questions in the most recent version of the form.

To account for submissions that currently exist without the form_document stored, read the form from forms-api if the form_document is not present. This fallback can be removed once we have automatically deleted all submissions that don't have the form_document stored.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
