### PR TITLE
Fix Solid Queue db configuration for development

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -31,7 +31,7 @@ development:
   queue:
     <<: *primary_development
     database: forms_runner_development_queue
-    migrations_path: db/queue_migrate
+    migrations_paths: db/queue_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".


### PR DESCRIPTION
### What problem does this pull request solve?

Ensure only migrations in the `db/queue_migrate` directory are run on the Solid Queue database for the development environment by correcting the `migrations_paths` key in the configuration.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
