### PR TITLE
Add number suffix to identical file names

### DIFF
--- a/app/lib/flow/journey.rb
+++ b/app/lib/flow/journey.rb
@@ -24,6 +24,8 @@ module Flow
       @form = form
       @step_factory = StepFactory.new(form:)
       @completed_steps = generate_completed_steps
+
+      populate_file_suffixes
     end
 
     def find_or_create(page_slug)
@@ -64,6 +66,14 @@ module Flow
       completed_steps
               .select { |step| step.question.is_a?(Question::File) && step.question.file_uploaded? }
               .map(&:question)
+    end
+
+    def populate_file_suffixes
+      completed_file_upload_questions.each_with_index do |question, index|
+        count = completed_file_upload_questions.take(index).filter { it.original_filename == question.original_filename }.count
+
+        question.filename_suffix = count.zero? ? "" : "_#{count}"
+      end
     end
 
   private

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -28,6 +28,7 @@ module Question
       # .odt:
       "application/vnd.oasis.opendocument.text",
     ].freeze
+    FILE_MAX_FILENAME_LENGTH = 255
 
     def show_answer
       original_filename
@@ -41,7 +42,10 @@ module Question
 
     def name_with_filename_suffix
       extension = ::File.extname(original_filename)
-      base_name = ::File.basename(original_filename, extension)
+
+      base_name_max_length = FILE_MAX_FILENAME_LENGTH - extension.length - filename_suffix.length
+
+      base_name = ::File.basename(original_filename, extension).truncate(base_name_max_length, omission: "")
 
       "#{base_name}#{filename_suffix}#{extension}"
     end

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -28,7 +28,7 @@ module Question
       # .odt:
       "application/vnd.oasis.opendocument.text",
     ].freeze
-    FILE_MAX_FILENAME_LENGTH = 255
+    FILE_MAX_FILENAME_LENGTH = 100
 
     def show_answer
       original_filename

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -5,6 +5,7 @@ module Question
     attribute :file
     attribute :original_filename
     attribute :uploaded_file_key
+    attribute :filename_suffix, default: ""
     validates :file, presence: true, unless: :is_optional?
     validate :validate_file_size
     validate :validate_file_extension
@@ -35,7 +36,14 @@ module Question
     def show_answer_in_email
       return nil if original_filename.blank?
 
-      I18n.t("mailer.submission.file_attached", filename: original_filename)
+      I18n.t("mailer.submission.file_attached", filename: name_with_filename_suffix)
+    end
+
+    def name_with_filename_suffix
+      extension = ::File.extname(original_filename)
+      base_name = ::File.basename(original_filename, extension)
+
+      "#{base_name}#{filename_suffix}#{extension}"
     end
 
     def before_save

--- a/app/services/aws_ses_submission_service.rb
+++ b/app/services/aws_ses_submission_service.rb
@@ -52,7 +52,7 @@ private
 
   def uploaded_files_in_answers
     @journey.completed_file_upload_questions
-            .map { |question| [question.original_filename, question.file_from_s3] }
+            .map { |question| [question.name_with_filename_suffix, question.file_from_s3] }
             .to_h
   end
 

--- a/spec/factories/models/question/file.rb
+++ b/spec/factories/models/question/file.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     uploaded_file_key { nil }
 
     trait :with_uploaded_file do
-      original_filename { Faker::File.file_name(ext: "txt") }
+      original_filename { Faker::File.file_name(dir: "", directory_separator: "", ext: "txt") }
       uploaded_file_key { Faker::Alphanumeric.alphanumeric }
     end
 

--- a/spec/lib/flow/journey_spec.rb
+++ b/spec/lib/flow/journey_spec.rb
@@ -208,6 +208,37 @@ RSpec.describe Flow::Journey do
           expect(journey.completed_steps.to_json).to eq [first_step_in_journey].to_json
         end
       end
+
+      context "when there are multiple files with the same name" do
+        let(:first_page_in_form) { build(:page, answer_type: "file", id: 1, next_page: 2) }
+        let(:second_page_in_form) { build(:page, answer_type: "file", id: 2, next_page: 3) }
+        let(:third_page_in_form) { build(:page, answer_type: "file", id: 3, next_page: 4) }
+        let(:fourth_page_in_form) { build(:page, answer_type: "file", id: 4) }
+        let(:pages_data) { [first_page_in_form, second_page_in_form, third_page_in_form, fourth_page_in_form] }
+        let(:store) do
+          {
+            answers: {
+              "2" =>
+                {
+                  "1" => { uploaded_file_key: "key1", original_filename: "file1", filename_suffix: "" },
+                  "2" => { uploaded_file_key: "key2", original_filename: "a different filename", filename_suffix: "" },
+                  "3" => { uploaded_file_key: "key3", original_filename: "file1", filename_suffix: "" },
+                  "4" => { uploaded_file_key: "key4", original_filename: "file1", filename_suffix: "" },
+                },
+            },
+          }
+        end
+
+        it "does not add a numerical suffix to the first instance of a filename" do
+          expect(journey.all_steps[0].question.filename_suffix).to eq("")
+          expect(journey.all_steps[1].question.filename_suffix).to eq("")
+        end
+
+        it "adds a numerical suffix to any files with duplicate filenames" do
+          expect(journey.all_steps[2].question.filename_suffix).to eq("_1")
+          expect(journey.all_steps[3].question.filename_suffix).to eq("_2")
+        end
+      end
     end
 
     context "when answers are loaded from the database" do

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -179,28 +179,28 @@ RSpec.describe Question::File, type: :model do
 
     let(:original_filename) { "#{file_basename}#{file_extension}" }
     let(:filename_suffix) { "" }
-    let(:maximum_file_basename_length) { 255 - filename_suffix.length - file_extension.length }
+    let(:maximum_file_basename_length) { 100 - filename_suffix.length - file_extension.length }
 
     let(:attributes) { { original_filename:, filename_suffix: } }
 
     context "when no suffix is supplied" do
-      context "when the filename and extension are less than or equal to 255 characters" do
+      context "when the filename and extension are less than or equal to 100 characters" do
         let(:file_basename) { Faker::Alphanumeric.alpha(number: maximum_file_basename_length) }
 
         it "returns the original_filename" do
           expect(question.name_with_filename_suffix).to eq original_filename
-          expect(question.name_with_filename_suffix.length).to eq 255
+          expect(question.name_with_filename_suffix.length).to eq 100
         end
       end
 
-      context "when the filename and extension are over 255 characters" do
+      context "when the filename and extension are over 100 characters" do
         let(:file_basename) { Faker::Alphanumeric.alpha(number: maximum_file_basename_length + 1) }
 
         it "returns the original_filename" do
           truncated_basename = file_basename.truncate(maximum_file_basename_length, omission: "")
           truncated_filename = "#{truncated_basename}#{file_extension}"
           expect(question.name_with_filename_suffix).to eq truncated_filename
-          expect(question.name_with_filename_suffix.length).to eq 255
+          expect(question.name_with_filename_suffix.length).to eq 100
         end
       end
     end
@@ -208,24 +208,24 @@ RSpec.describe Question::File, type: :model do
     context "when a suffix is supplied" do
       let(:filename_suffix) { "_1" }
 
-      context "when the filename, suffix and extension are less than or equal to 255 characters" do
+      context "when the filename, suffix and extension are less than or equal to 100 characters" do
         let(:file_basename) { Faker::Alphanumeric.alpha(number: maximum_file_basename_length) }
 
         it "returns the original filename with the suffix" do
           filename_with_suffix = "#{file_basename}#{filename_suffix}#{file_extension}"
           expect(question.name_with_filename_suffix).to eq filename_with_suffix
-          expect(question.name_with_filename_suffix.length).to eq 255
+          expect(question.name_with_filename_suffix.length).to eq 100
         end
       end
 
-      context "when the filename, suffix and extension are over 255 characters" do
+      context "when the filename, suffix and extension are over 100 characters" do
         let(:file_basename) { Faker::Alphanumeric.alpha(number: maximum_file_basename_length + 1) }
 
         it "returns the truncated filename with suffix" do
           truncated_basename = file_basename.truncate(maximum_file_basename_length, omission: "")
           truncated_filename_with_suffix = "#{truncated_basename}#{filename_suffix}#{file_extension}"
           expect(question.name_with_filename_suffix).to eq truncated_filename_with_suffix
-          expect(question.name_with_filename_suffix.length).to eq 255
+          expect(question.name_with_filename_suffix.length).to eq 100
         end
       end
     end

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Question::File, type: :model do
   end
 
   describe "#show_answer" do
-    let(:original_filename) { Faker::File.file_name }
+    let(:original_filename) { Faker::File.file_name(dir: "", directory_separator: "") }
 
     before do
       question.original_filename = original_filename

--- a/spec/services/aws_ses_submission_service_spec.rb
+++ b/spec/services/aws_ses_submission_service_spec.rb
@@ -101,10 +101,10 @@ RSpec.describe AwsSesSubmissionService do
           service.submit
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-            { answer_content: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.original_filename)}</p>",
+            { answer_content: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
-              files: { question.original_filename => file_content } },
+              files: { question.name_with_filename_suffix => file_content } },
           ).once
         end
       end
@@ -163,15 +163,15 @@ RSpec.describe AwsSesSubmissionService do
 
               service.submit
 
-              expected_csv_content = "Reference,Submitted at,#{question.question_text}\n#{submission_reference},2022-09-14T08:00:00Z,#{question.original_filename}\n"
+              expected_csv_content = "Reference,Submitted at,#{question.question_text}\n#{submission_reference},2022-09-14T08:00:00Z,#{question.name_with_filename_suffix}\n"
 
               expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-                { answer_content: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.original_filename)}</p>",
+                { answer_content: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
                   submission_email_address: submission_email,
                   mailer_options: instance_of(FormSubmissionService::MailerOptions),
                   files: {
                     "govuk_forms_form_#{form.id}_#{submission_reference}.csv" => expected_csv_content,
-                    question.original_filename => file_content,
+                    question.name_with_filename_suffix => file_content,
                   } },
               ).once
             end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/dKAbc0DS/2156-handle-multiple-files-uploaded-with-the-same-name

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
When more than one file with the same name has been uploaded in the same form journey, we want to disambiguate them by adding a suffix to some of them before attaching them to the SES email.

In this implementation the first file with a given name will keep the original filename, and subsequent files with the same name will be suffixed like so:
- `my_file.png`
- `my_file_1.png`
- `my_file_2.png`
- `my_file_3.png`

We currently only allow 4 files but this implementation should support any number if we increrase that in future.

This PR also includes a change to truncate filenames to 255 characters or fewer - this is the maximum filename macOS supports by default, Windows supports 256 by default and S3 allows 1024 so I think it makes sense to choose the smallest of these options. 

### Testing instructions
- Create a form with at least 2 file upload questions in your local forms-admin.
- Run the runner in an AWS shell with the IAM role assumed
- Upload files with the same name for every file question in the form (the easiest way is to use the same file every time)
- Check that the submission email includes multiple attachments, and the names are suffixed as detailed above

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
