### PR TITLE
Add suffix to filename in CSV

### DIFF
--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -40,6 +40,12 @@ module Question
       I18n.t("mailer.submission.file_attached", filename: name_with_filename_suffix)
     end
 
+    def show_answer_in_csv
+      return nil if original_filename.blank?
+
+      { question_text => name_with_filename_suffix }
+    end
+
     def name_with_filename_suffix
       extension = ::File.extname(original_filename)
 

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -174,6 +174,24 @@ RSpec.describe Question::File, type: :model do
     end
   end
 
+  describe "#show_answer_in_csv" do
+    let(:original_filename) { Faker::File.file_name(dir: "", directory_separator: "") }
+    let(:attributes) { { original_filename: } }
+
+    it "returns the original_filename" do
+      expect(question.show_answer_in_csv).to eq({ question.question_text => question.name_with_filename_suffix })
+    end
+
+    context "when the file has a suffix set" do
+      let(:attributes) { { original_filename:, filename_suffix: } }
+      let(:filename_suffix) { "_1" }
+
+      it "returns the filename with a suffix" do
+        expect(question.show_answer_in_csv).to eq({ question.question_text => question.name_with_filename_suffix })
+      end
+    end
+  end
+
   describe "name_with_filename_suffix" do
     let(:file_extension) { ".txt" }
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/dKAbc0DS/2156-handle-multiple-files-uploaded-with-the-same-name

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Uses the filename suffixes added in https://github.com/alphagov/forms-runner/pull/1252 in the CSV data as well as the email.

This was omitted from the original PR (thanks @stephencdaly for spotting!)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
