### PR TITLE
Support optional file questions in csv

### DIFF
--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -41,7 +41,7 @@ module Question
     end
 
     def show_answer_in_csv
-      return nil if original_filename.blank?
+      return Hash[question_text, nil] if original_filename.blank?
 
       { question_text => name_with_filename_suffix }
     end

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -158,18 +158,37 @@ RSpec.describe Question::File, type: :model do
 
   describe "#show_answer_in_email" do
     let(:original_filename) { Faker::File.file_name(dir: "", directory_separator: "") }
-    let(:attributes) { { original_filename: } }
+    let(:attributes) { { original_filename:, filename_suffix: } }
+    let(:filename_suffix) { "" }
 
-    it "returns the original_filename" do
-      expect(question.show_answer_in_email).to eq I18n.t("mailer.submission.file_attached", filename: question.name_with_filename_suffix)
+    context "when the original_filename is blank" do
+      let(:original_filename) { nil }
+
+      it "returns a nil value" do
+        expect(question.show_answer_in_email).to be_nil
+      end
+
+      context "when the file has a suffix set" do
+        let(:filename_suffix) { "_1" }
+
+        it "returns a nil value" do
+          expect(question.show_answer_in_email).to be_nil
+        end
+      end
     end
 
-    context "when the file has a suffix set" do
-      let(:attributes) { { original_filename:, filename_suffix: } }
-      let(:filename_suffix) { "_1" }
-
-      it "returns the filename with a suffix" do
+    context "when the original_filename has a value" do
+      it "returns the original_filename" do
         expect(question.show_answer_in_email).to eq I18n.t("mailer.submission.file_attached", filename: question.name_with_filename_suffix)
+      end
+
+      context "when the file has a suffix set" do
+        let(:attributes) { { original_filename:, filename_suffix: } }
+        let(:filename_suffix) { "_1" }
+
+        it "returns the filename with a suffix" do
+          expect(question.show_answer_in_email).to eq I18n.t("mailer.submission.file_attached", filename: question.name_with_filename_suffix)
+        end
       end
     end
   end

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -175,19 +175,39 @@ RSpec.describe Question::File, type: :model do
   end
 
   describe "#show_answer_in_csv" do
+    let(:attributes) { { original_filename:, filename_suffix: } }
     let(:original_filename) { Faker::File.file_name(dir: "", directory_separator: "") }
-    let(:attributes) { { original_filename: } }
+    let(:filename_suffix) { "" }
 
-    it "returns the original_filename" do
-      expect(question.show_answer_in_csv).to eq({ question.question_text => question.name_with_filename_suffix })
+    context "when the original_filename is blank" do
+      let(:original_filename) { nil }
+
+      it "returns a hash with the question text and a nil value" do
+        expect(question.show_answer_in_csv).to eq({ question.question_text => nil })
+      end
+
+      context "when the file has a suffix set" do
+        let(:filename_suffix) { "_1" }
+
+        it "returns a hash with the question text and a nil value" do
+          expect(question.show_answer_in_csv).to eq({ question.question_text => nil })
+        end
+      end
     end
 
-    context "when the file has a suffix set" do
-      let(:attributes) { { original_filename:, filename_suffix: } }
-      let(:filename_suffix) { "_1" }
+    context "when the original_filename has a value" do
+      let(:original_filename) { Faker::File.file_name(dir: "", directory_separator: "") }
 
-      it "returns the filename with a suffix" do
+      it "returns the original_filename" do
         expect(question.show_answer_in_csv).to eq({ question.question_text => question.name_with_filename_suffix })
+      end
+
+      context "when the file has a suffix set" do
+        let(:filename_suffix) { "_1" }
+
+        it "returns the filename with a suffix" do
+          expect(question.show_answer_in_csv).to eq({ question.question_text => question.name_with_filename_suffix })
+        end
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/dKAbc0DS/2156-handle-multiple-files-uploaded-with-the-same-name

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
The change in #1253 meant that when a user left a file input blank, the CSV generation would break (because it expects a hash but the code was returning `nil`).

This PR updates it and adds some missing tests that would've caught the issue sooner.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
