### PR TITLE
Include page heading in Check Your Answers rows for file upload questions

### DIFF
--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -53,11 +53,11 @@ module Forms
   private
 
     def page_to_row(page)
-      question_name = page.question.question_text_with_optional_suffix
+      question_name = page.question.question_text_for_check_your_answers
       {
-        key: { text: question_name },
+        key: { text: helpers.sanitize(question_name) },
         value: { text: page.show_answer },
-        actions: [{ href: change_link(page), visually_hidden_text: question_name }],
+        actions: [{ href: change_link(page), visually_hidden_text: helpers.strip_tags(question_name) }],
       }
     end
 

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -59,7 +59,7 @@ module Forms
                       form_change_answer_path(page.form_id, page.form_slug, page.page_id)
                     end
 
-      question_name = helpers.question_text_with_optional_suffix_inc_mode(page, @mode)
+      question_name = page.question.question_text_with_optional_suffix
       {
         key: { text: question_name },
         value: { text: page.show_answer },

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -53,18 +53,18 @@ module Forms
   private
 
     def page_to_row(page)
-      change_link = if page.repeatable? && page.show_answer.present?
-                      change_add_another_answer_path(page.form_id, page.form_slug, page.page_id)
-                    else
-                      form_change_answer_path(page.form_id, page.form_slug, page.page_id)
-                    end
-
       question_name = page.question.question_text_with_optional_suffix
       {
         key: { text: question_name },
         value: { text: page.show_answer },
-        actions: [{ href: change_link, visually_hidden_text: question_name }],
+        actions: [{ href: change_link(page), visually_hidden_text: question_name }],
       }
+    end
+
+    def change_link(page)
+      return change_add_another_answer_path(page.form_id, page.form_slug, page.page_id) if page.repeatable? && page.show_answer.present?
+
+      form_change_answer_path(page.form_id, page.form_slug, page.page_id)
     end
 
     def check_your_answers_rows

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,12 +23,6 @@ module ApplicationHelper
     "#{t('page_titles.error_prefix') if error}#{page_name}#{mode_string} - #{form_name}"
   end
 
-  def question_text_with_optional_suffix_inc_mode(page, mode)
-    mode_string = hidden_text_mode(mode)
-
-    [CGI.escapeHTML(page.question.question_text_with_optional_suffix), mode_string].compact_blank.join(" ").html_safe
-  end
-
   def hidden_text_mode(mode)
     return "" unless mode.preview?
 

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -93,6 +93,13 @@ module Question
       uploaded_file_key.present?
     end
 
+    def question_text_for_check_your_answers
+      return question_text_with_optional_suffix if page_heading.blank?
+
+      caption = tag.span(page_heading, class: %w[govuk-caption-m govuk-!-margin-bottom-1])
+      [caption, question_text_with_optional_suffix].join(" ")
+    end
+
   private
 
     def validate_file_size

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -58,5 +58,12 @@ module Question
 
       "#{question_text} #{I18n.t('page.optional')}"
     end
+
+    def question_text_for_check_your_answers
+      return question_text_with_optional_suffix if page_heading.blank?
+      return question_text_with_optional_suffix unless is_a?(Question::File)
+
+      "<span class=\"govuk-caption-m govuk-!-margin-bottom-1\">#{page_heading}</span> #{question_text_with_optional_suffix}"
+    end
   end
 end

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -61,11 +61,7 @@ module Question
     end
 
     def question_text_for_check_your_answers
-      return question_text_with_optional_suffix if page_heading.blank?
-      return question_text_with_optional_suffix unless is_a?(Question::File)
-
-      caption = tag.span(page_heading, class: %w[govuk-caption-m govuk-!-margin-bottom-1])
-      [caption, question_text_with_optional_suffix].join(" ")
+      question_text_with_optional_suffix
     end
   end
 end

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -4,6 +4,7 @@ module Question
     include ActiveModel::Validations
     include ActiveModel::Serialization
     include ActiveModel::Attributes
+    include ActionView::Helpers::TagHelper
 
     attr_accessor :question_text, :hint_text, :answer_settings, :is_optional, :page_heading, :guidance_markdown
 
@@ -63,7 +64,8 @@ module Question
       return question_text_with_optional_suffix if page_heading.blank?
       return question_text_with_optional_suffix unless is_a?(Question::File)
 
-      "<span class=\"govuk-caption-m govuk-!-margin-bottom-1\">#{page_heading}</span> #{question_text_with_optional_suffix}"
+      caption = tag.span(page_heading, class: %w[govuk-caption-m govuk-!-margin-bottom-1])
+      [caption, question_text_with_optional_suffix].join(" ")
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -25,23 +25,6 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "#question_text_with_optional_suffix_inc_mode" do
-    it "renders the question text followed by the mode the page is viewed in" do
-      page = OpenStruct.new(question: OpenStruct.new(question_text_with_optional_suffix: "What is your name?"))
-      allow(helper).to receive(:hidden_text_mode).and_return("<span>PREVIEWING MODE</span>")
-      expect(helper.question_text_with_optional_suffix_inc_mode(page, "mode")).to eq("What is your name? <span>PREVIEWING MODE</span>")
-    end
-
-    context "with unsafe question text" do
-      it "returns the escaped title but doesn't escape the trusted suffix" do
-        page = OpenStruct.new(question: OpenStruct.new(question_text_with_optional_suffix: "What is your name? <script>alert(\"Hi\")</script>"))
-        allow(helper).to receive(:hidden_text_mode).and_return("<span>not escaped</span>")
-        expected_output = "What is your name? &lt;script&gt;alert(&quot;Hi&quot;)&lt;/script&gt; <span>not escaped</span>"
-        expect(helper.question_text_with_optional_suffix_inc_mode(page, "")).to eq(expected_output)
-      end
-    end
-  end
-
   describe "#hidden_text_mode" do
     let(:mode) { OpenStruct.new(preview?: false) }
 

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Forms::CheckYourAnswersController, type: :request do
+  include Capybara::RSpecMatchers
+
   let(:timestamp_of_request) { Time.utc(2022, 12, 14, 10, 0o0, 0o0) }
 
   let(:form_data) do
@@ -308,6 +310,58 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
             expect(response.body)
               .to include(form_change_answer_path(2, form_data.form_slug, 3))
           end
+        end
+      end
+
+      context "when the form has a file question with a heading" do
+        let(:page_heading) { Faker::Lorem.sentence }
+        let(:store) do
+          {
+            answers: {
+              "2" => {
+                "1" => {
+                  "original_filename" => "file.txt",
+                  "uploaded_file_key" => "some_file_key",
+                },
+              },
+            },
+          }
+        end
+
+        let(:steps_data) do
+          [
+            {
+              id: 1,
+              position: 1,
+              type: "question_page",
+              data: {
+                answer_type: "file",
+                is_optional: nil,
+                page_heading:,
+                question_text: "Question one",
+              },
+            },
+          ]
+        end
+
+        it "returns 'ok' status code" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "Displays a back link to the last page of the form" do
+          expect(response.body).to include(form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1))
+        end
+
+        it "Returns the correct X-Robots-Tag header" do
+          expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
+        end
+
+        it "Contains a change link for each page" do
+          expect(response.body).to include(form_change_answer_path(2, form_data.form_slug, 1))
+        end
+
+        it "Contains the guidance page heading in a caption" do
+          expect(response.body).to have_css("span.govuk-caption-m", text: page_heading)
         end
       end
     end

--- a/spec/support/shared_examples/question_models.rb
+++ b/spec/support/shared_examples/question_models.rb
@@ -51,4 +51,34 @@ RSpec.shared_examples "a question model" do |_parameter|
       end
     end
   end
+
+  describe "#question_text_for_check_your_answers" do
+    let(:is_optional?) { false }
+
+    before do
+      question.question_text = Faker::Lorem.question
+      question.page_heading = page_heading
+      allow(question).to receive(:is_optional?).and_return(is_optional?)
+    end
+
+    context "when page has no guidance" do
+      let(:page_heading) { nil }
+
+      it "returns the question text with optional suffix" do
+        expect(question.question_text_for_check_your_answers).to eq(question.question_text_with_optional_suffix)
+      end
+    end
+
+    context "when page has guidance" do
+      let(:page_heading) { Faker::Lorem.sentence }
+
+      it "returns the question text with optional suffix and prepends a span with the page heading to file questions" do
+        if question.is_a?(Question::File)
+          expect(question.question_text_for_check_your_answers).to eq("<span class=\"govuk-caption-m govuk-!-margin-bottom-1\">#{question.page_heading}</span> #{question.question_text_with_optional_suffix}")
+        else
+          expect(question.question_text_for_check_your_answers).to eq(question.question_text_with_optional_suffix)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/wMIZWtPX/2160-include-page-heading-in-cya-page-when-guidance-is-present

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Adds a caption with the page heading to the Check Your Answers page when the question has guidance.

At the moment this will only show for File questions, but if we're happy with this we can apply t to all questions with guidance in future.


### Screenshots
#### Before
![A Check your answers summary list with two 'Upload your file (optional)' keys and one 'What is your date of birth' key](https://github.com/user-attachments/assets/a80b6863-f381-4bbb-9327-b0ba5d31e68c)

#### After
![The same Check your answers summary list, but one of the file upload keys now has a caption above it saying 'Driving Licence' and the other has a caption saying 'passport'](https://github.com/user-attachments/assets/d541c410-38f7-4cfb-a53f-4d5885913582)


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
