### PR TITLE
Rename CloudWatch metrics to match AWS conventions

### DIFF
--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -1,11 +1,29 @@
 class CloudWatchService
   REGION = "eu-west-2".freeze
+  FORM_METRICS_NAMESPACE = "Forms".freeze
 
   def self.log_form_submission(form_id:)
     return unless Settings.cloudwatch_metrics_enabled
 
     cloudwatch_client.put_metric_data(
-      namespace: metric_namespace,
+      namespace: FORM_METRICS_NAMESPACE,
+      metric_data: [
+        {
+          metric_name: "Submitted",
+          dimensions: [
+            environment_dimension,
+            form_id_dimension(form_id),
+          ],
+          value: 1,
+          unit: "Count",
+        },
+      ],
+    )
+
+    # Stop sending this metric once we have been sending the new metric for long enough and switched over
+    # forms-admin to read the new metric
+    cloudwatch_client.put_metric_data(
+      namespace: old_form_metrics_namespace,
       metric_data: [
         {
           metric_name: "submitted",
@@ -26,7 +44,24 @@ class CloudWatchService
     return unless Settings.cloudwatch_metrics_enabled
 
     cloudwatch_client.put_metric_data(
-      namespace: metric_namespace,
+      namespace: FORM_METRICS_NAMESPACE,
+      metric_data: [
+        {
+          metric_name: "Started",
+          dimensions: [
+            environment_dimension,
+            form_id_dimension(form_id),
+          ],
+          value: 1,
+          unit: "Count",
+        },
+      ],
+    )
+
+    # Stop sending this metric once we have been sending the new metric for long enough and switched over
+    # forms-admin to read the new metric
+    cloudwatch_client.put_metric_data(
+      namespace: old_form_metrics_namespace,
       metric_data: [
         {
           metric_name: "started",
@@ -43,8 +78,22 @@ class CloudWatchService
     )
   end
 
-  def self.metric_namespace
+  def self.old_form_metrics_namespace
     "forms/#{Settings.forms_env}".downcase
+  end
+
+  def self.environment_dimension
+    {
+      name: "Environment",
+      value: Settings.forms_env.downcase,
+    }
+  end
+
+  def self.form_id_dimension(form_id)
+    {
+      name: "FormId",
+      value: form_id.to_s,
+    }
   end
 
   def self.cloudwatch_client

--- a/spec/services/cloud_watch_service_spec.rb
+++ b/spec/services/cloud_watch_service_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe CloudWatchService do
   let(:form_id) { 3 }
   let(:forms_env) { "test" }
   let(:cloudwatch_metrics_enabled) { true }
+  let(:cloudwatch_client) { Aws::CloudWatch::Client.new(stub_responses: true) }
 
   before do
     allow(Settings).to receive_messages(forms_env:, cloudwatch_metrics_enabled:)
+    allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
   end
 
   describe ".log_form_submission" do
@@ -15,9 +17,6 @@ RSpec.describe CloudWatchService do
       let(:cloudwatch_metrics_enabled) { false }
 
       it "does not call the CloudWatch client with .put_metric_data" do
-        cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
-        allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
-
         expect(cloudwatch_client).not_to receive(:put_metric_data)
 
         described_class.log_form_submission(form_id:)
@@ -25,11 +24,27 @@ RSpec.describe CloudWatchService do
     end
 
     it "calls the cloudwatch client with put_metric_data" do
-      # Stub the CloudWatch client and put_metric_data method
-      cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
-      allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
-
-      expect(cloudwatch_client).to receive(:put_metric_data).with(
+      expect(cloudwatch_client).to receive(:put_metric_data).once.with(
+        namespace: "Forms",
+        metric_data: [
+          {
+            metric_name: "Submitted",
+            dimensions: [
+              {
+                name: "Environment",
+                value: forms_env,
+              },
+              {
+                name: "FormId",
+                value: form_id.to_s,
+              },
+            ],
+            value: 1,
+            unit: "Count",
+          },
+        ],
+      )
+      expect(cloudwatch_client).to receive(:put_metric_data).once.with(
         namespace: "forms/#{forms_env}",
         metric_data: [
           {
@@ -55,9 +70,6 @@ RSpec.describe CloudWatchService do
       let(:cloudwatch_metrics_enabled) { false }
 
       it "does not call the CloudWatch client with .put_metric_data" do
-        cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
-        allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
-
         expect(cloudwatch_client).not_to receive(:put_metric_data)
 
         described_class.log_form_start(form_id:)
@@ -65,11 +77,27 @@ RSpec.describe CloudWatchService do
     end
 
     it "calls the cloudwatch client with put_metric_data" do
-      # Stub the CloudWatch client and put_metric_data method
-      cloudwatch_client = Aws::CloudWatch::Client.new(stub_responses: true)
-      allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
-
-      expect(cloudwatch_client).to receive(:put_metric_data).with(
+      expect(cloudwatch_client).to receive(:put_metric_data).once.with(
+        namespace: "Forms",
+        metric_data: [
+          {
+            metric_name: "Started",
+            dimensions: [
+              {
+                name: "Environment",
+                value: forms_env,
+              },
+              {
+                name: "FormId",
+                value: form_id.to_s,
+              },
+            ],
+            value: 1,
+            unit: "Count",
+          },
+        ],
+      )
+      expect(cloudwatch_client).to receive(:put_metric_data).once.with(
         namespace: "forms/#{forms_env}",
         metric_data: [
           {


### PR DESCRIPTION
> [!WARNING]  
> https://github.com/alphagov/forms-deploy/pull/1438 must be deployed before this is merged

### What problem does this pull request solve?

Trello card: https://trello.com/c/sSfVKcbD/2143-set-up-monitoring-and-observability-for-ses-file-upload-submissions

We're adding additional metrics to monitor the health of our background jobs, and we reviewed the naming conventions of our existing metrics as part of this.

We want to follow the AWS metrics naming conventions by making namespaces, metric names and dimension names all CamelCase.

To do this, we need to start sending new metrics with the desired names alongside the existing metrics. We can then switch over forms-admin to read the new metrics once we have been sending metrics for at least 8 days, as forms-admin only displays metrics for the previous 7 days. Once forms-admin is reading the new metrics, we can stop sending the old metrics.

For the new metrics, use the namespace name `Forms`, and add an `Environment` dimension rather than including this in the namespace.

I've added a trello ticket for switching over forms-admin to use the renamed metrics when we're ready: https://trello.com/c/yxarCr91/2770-use-new-cloudwatch-metrics-in-forms-admin

### Testing

It's possible to test this locally by running with AWS credentials following the instructions in the readme and setting the `cloudwatch_metrics_enabled` setting to true.

I've tested by deploying to dev and checking both sets of metrics were sent.

<img width="685" alt="Screenshot 2025-03-14 at 11 14 58" src="https://github.com/user-attachments/assets/e9ec7da4-1218-4d73-8df9-8cdee252db5e" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
