### PR TITLE
Retain bounced submissions

### DIFF
--- a/app/jobs/delete_submissions_job.rb
+++ b/app/jobs/delete_submissions_job.rb
@@ -8,6 +8,7 @@ class DeleteSubmissionsJob < ApplicationJob
     delete_submissions_updated_before_time = Settings.retain_submissions_for_seconds.seconds.ago
     submissions_to_delete = Submission.where(updated_at: ..delete_submissions_updated_before_time)
                                       .where.not(mail_message_id: nil)
+                                      .where.not(mail_status: "bounced")
 
     submissions_to_delete.find_each { |submission| delete_submission_data(submission) }
   end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
     end
     mode { "live" }
     form_document { build :v2_form_document }
+    mail_status { "pending" }
 
     trait :sent do
       mail_message_id { Faker::Alphanumeric.alphanumeric }

--- a/spec/jobs/delete_submissions_job_spec.rb
+++ b/spec/jobs/delete_submissions_job_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
            form_document: form_without_file_upload,
            updated_at: 6.days.ago
   end
+  let!(:bounced_submission) do
+    create :submission,
+           :sent,
+           reference: "BOUNCED",
+           form_id: form_without_file_upload.id,
+           form_document: form_without_file_upload,
+           updated_at: 7.days.ago,
+           mail_status: "bounced"
+  end
   let!(:unsent_submission) { create :submission, reference: "UNSENT", updated_at: 7.days.ago }
 
   let(:output) { StringIO.new }
@@ -96,6 +105,11 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
     it "does not destroy the submission that hasn't been sent" do
       perform_enqueued_jobs
       expect(Submission.exists?(unsent_submission.id)).to be true
+    end
+
+    it "does not destroy the submission that bounced" do
+      perform_enqueued_jobs
+      expect(Submission.exists?(bounced_submission.id)).to be true
     end
 
     it "logs deletion" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/Qf0gkFUE

This amends the DeleteSubmissionsJob to prevent deletion of submissions where the `mail_status` has been set to "bounced". This will allow us to replay bounced submissions later, once the delivery issues have been resolved.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
