### PR TITLE
Add background job to send queue metrics

### DIFF
--- a/app/jobs/delete_submissions_job.rb
+++ b/app/jobs/delete_submissions_job.rb
@@ -1,5 +1,5 @@
 class DeleteSubmissionsJob < ApplicationJob
-  queue_as :default
+  queue_as :background
 
   def perform(*_args)
     CloudWatchService.log_job_started(self.class.name)

--- a/app/jobs/queue_metrics_job.rb
+++ b/app/jobs/queue_metrics_job.rb
@@ -1,0 +1,10 @@
+class QueueMetricsJob < ApplicationJob
+  queue_as :metrics
+
+  SUBMISSIONS_QUEUE_NAME = "submissions".freeze
+
+  def perform(*_args)
+    submissions_queue_length = SolidQueue::Queue.find_by_name(SUBMISSIONS_QUEUE_NAME).size
+    CloudWatchService.log_queue_length(SUBMISSIONS_QUEUE_NAME, submissions_queue_length)
+  end
+end

--- a/app/jobs/send_submission_job.rb
+++ b/app/jobs/send_submission_job.rb
@@ -1,5 +1,5 @@
 class SendSubmissionJob < ApplicationJob
-  queue_as :default
+  queue_as :submissions
 
   # this translates to approximately 4.5 hours of retrying in total
   TOTAL_ATTEMPTS = 10

--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -140,6 +140,26 @@ class CloudWatchService
     )
   end
 
+  def self.log_queue_length(queue_name, length)
+    return unless Settings.cloudwatch_metrics_enabled
+
+    cloudwatch_client.put_metric_data(
+      namespace: JOBS_METRICS_NAMESPACE,
+      metric_data: [
+        {
+          metric_name: "QueueLength",
+          dimensions: [
+            environment_dimension,
+            service_name_dimension,
+            queue_name_dimension(queue_name),
+          ],
+          value: length,
+          unit: "Count",
+        },
+      ],
+    )
+  end
+
   def self.old_form_metrics_namespace
     "forms/#{Settings.forms_env}".downcase
   end
@@ -169,6 +189,13 @@ class CloudWatchService
     {
       name: "JobName",
       value: job_name,
+    }
+  end
+
+  def self.queue_name_dimension(queue_name)
+    {
+      name: "QueueName",
+      value: queue_name,
     }
   end
 

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -3,7 +3,8 @@ default: &default
     - polling_interval: 1
       batch_size: 500
   workers:
-    - queues: "*"
+    # jobs on the metrics queue will be run before jobs on any other queue
+    - queues: ["metrics", "*"]
       threads: 3
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
       polling_interval: 0.1

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -2,7 +2,13 @@ production:
   delete_submissions_job:
     class: DeleteSubmissionsJob
     schedule: every hour
+  queue_metrics_job:
+    class: QueueMetricsJob
+    schedule: every minute
 development:
   delete_submissions_job:
     class: DeleteSubmissionsJob
+    schedule: every minute
+  queue_metrics_job:
+    class: QueueMetricsJob
     schedule: every minute

--- a/spec/jobs/queue_metrics_job_spec.rb
+++ b/spec/jobs/queue_metrics_job_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe QueueMetricsJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:submission_queue_length) { 4 }
+
+  before do
+    allow(CloudWatchService).to receive(:log_queue_length)
+
+    mock_queue = instance_double(SolidQueue::Queue, size: submission_queue_length)
+    allow(SolidQueue::Queue).to receive(:find_by_name).and_return(mock_queue)
+
+    described_class.perform_later
+    perform_enqueued_jobs
+  end
+
+  it "sends submission queue length to CloudWatch" do
+    expect(CloudWatchService).to have_received(:log_queue_length).with("submissions", submission_queue_length)
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/sSfVKcbD/2143-set-up-monitoring-and-observability-for-ses-file-upload-submissions

This PR:

* Assigns all jobs to named queues.
* Adds a job to send a metric for the length of the submissions queue to CloudWatch. This job runs as the highest priority to ensure we are sending regular metrics.

I did consider adding a separate worker for running background jobs so these would not block sending submissions if there was a bug that caused them to be long-running. However, we run a minimum of 6 forms-runner ECS tasks on production so it is unlikely we'd run into capacity issues. We have alerts that will tell us if we're struggling to keep up with demand.

## Testing

I've tested this by connecting my local environment to the AWS dev account:

![Screenshot 2025-03-18 at 13 12 23](https://github.com/user-attachments/assets/c32939dd-406f-459e-9bf6-096f95611752)

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
