### PR TITLE
Add rake task to retry bounced submissions

### DIFF
--- a/app/jobs/send_submission_job.rb
+++ b/app/jobs/send_submission_job.rb
@@ -22,7 +22,7 @@ class SendSubmissionJob < ApplicationJob
       mailer_options:,
     ).submit
 
-    submission.update!(mail_message_id: message_id)
+    submission.update!(mail_message_id: message_id, mail_status: "pending")
 
     milliseconds_since_scheduled = (Time.current - scheduled_at_or_enqueued_at).in_milliseconds.round
     EventLogger.log_form_event("submission_email_sent", { milliseconds_since_scheduled: })

--- a/lib/tasks/submissions.rake
+++ b/lib/tasks/submissions.rake
@@ -1,0 +1,19 @@
+namespace :submissions do
+  desc "Retry bounced submissions"
+  task :retry_bounced_submissions, %i[form_id] => :environment do |_, args|
+    form_id = args[:form_id]
+
+    usage_message = "usage: rake submissions:retry_bounced_submissions[<form_id>]".freeze
+    abort usage_message if form_id.blank?
+
+    submissions_to_retry = Submission.where(form_id: form_id)
+                                      .where(mail_status: "bounced")
+
+    Rails.logger.info "#{submissions_to_retry.length} submissions to retry for form with ID: #{form_id}"
+
+    submissions_to_retry.each do |submission|
+      Rails.logger.info "Retrying submission with reference #{submission.reference} for form with ID: #{form_id}"
+      SendSubmissionJob.perform_later(submission)
+    end
+  end
+end

--- a/spec/jobs/send_submission_job_spec.rb
+++ b/spec/jobs/send_submission_job_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe SendSubmissionJob, type: :job do
   include ActiveJob::TestHelper
 
-  let(:submission) { create :submission, form_document: form }
+  let(:submission) { create :submission, form_document: form, mail_status: "invalid" }
   let(:form) { build(:form, id: 1, name: "Form 1") }
   let(:question) { build :text, question_text: "What is the meaning of life?", text: "42" }
   let(:step) { build :step, question: }
@@ -43,6 +43,10 @@ RSpec.describe SendSubmissionJob, type: :job do
 
     it "updates the submission message ID" do
       expect(Submission.last).to have_attributes(mail_message_id:)
+    end
+
+    it "updates the submission mail status to pending" do
+      expect(Submission.last).to have_attributes(mail_status: "pending")
     end
 
     it "sends cloudwatch metric for the submission being sent" do

--- a/spec/lib/tasks/submissions.rake_spec.rb
+++ b/spec/lib/tasks/submissions.rake_spec.rb
@@ -1,0 +1,93 @@
+require "rake"
+require "rails_helper"
+
+RSpec.describe "submissions.rake" do
+  include ActiveJob::TestHelper
+
+  before do
+    Rake.application.rake_require "tasks/submissions"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "submissions:retry_bounced_submissions" do
+    subject(:task) do
+      Rake::Task["submissions:retry_bounced_submissions"]
+        .tap(&:reenable)
+    end
+
+    let(:form_id) { 1 }
+    let(:other_form_id) { 2 }
+    let!(:bounced_submission) do
+      create :submission,
+             :sent,
+             form_id:,
+             mail_status: "bounced"
+    end
+    let!(:pending_submission) do
+      create :submission,
+             :sent,
+             form_id:,
+             mail_status: "pending"
+    end
+
+    before do
+      create :submission,
+             :sent,
+             form_id: other_form_id,
+             mail_status: "pending"
+    end
+
+    context "with valid arguments" do
+      let(:valid_args) { [form_id] }
+
+      it "logs how many submissions to retry" do
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with("1 submissions to retry for form with ID: #{form_id}")
+
+        task.invoke(*valid_args)
+      end
+
+      context "with a form ID with bounced submissions" do
+        it "logs submissions that are being retried" do
+          allow(Rails.logger).to receive(:info)
+          expect(Rails.logger).to receive(:info).with("Retrying submission with reference #{bounced_submission.reference} for form with ID: #{form_id}")
+
+          task.invoke(*valid_args)
+        end
+
+        it "enqueues bounced submissions for retrying" do
+          expect {
+            task.invoke(*valid_args)
+          }.to have_enqueued_job.with(bounced_submission)
+        end
+
+        it "does not enqueue pending submissions for retrying" do
+          expect {
+            task.invoke(*valid_args)
+          }.not_to have_enqueued_job.with(pending_submission)
+        end
+      end
+
+      context "with a form ID without bounced submissions" do
+        let(:valid_args) { [other_form_id] }
+
+        it "does not enqueue pending submissions for retrying" do
+          expect {
+            task.invoke(*valid_args)
+          }.not_to have_enqueued_job
+        end
+      end
+    end
+
+    context "with invalid arguments" do
+      let(:invalid_args) { [] }
+
+      it "aborts with a usage message" do
+        expect {
+          task.invoke(*invalid_args)
+        }.to raise_error(SystemExit)
+         .and output("usage: rake submissions:retry_bounced_submissions[<form_id>]\n").to_stderr
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Add a rake task to retry submissions sent via SES that bounced. This accepts a form id as a parameter, and will enqueue each submission for that form that has a mail status of "bounced".

Trello card: https://trello.com/c/Qf0gkFUE

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
