### PR TITLE
Add plain text part to submission email

### DIFF
--- a/app/lib/ses_email_formatter.rb
+++ b/app/lib/ses_email_formatter.rb
@@ -3,7 +3,7 @@ class SesEmailFormatter
 
   class FormattingError < StandardError; end
 
-  def build_question_answers_section(completed_steps)
+  def build_question_answers_section_html(completed_steps)
     completed_steps.map { |page|
       [prep_question_title(page),
        prep_answer_text(page)].join

--- a/app/lib/ses_email_formatter.rb
+++ b/app/lib/ses_email_formatter.rb
@@ -18,6 +18,8 @@ class SesEmailFormatter
     }.join(H_RULE_PLAIN_TEXT)
   end
 
+private
+
   def prep_question_title_html(page)
     "<h2>#{remove_heading_hashes(prep_question_title_plain_text(page))}</h2>"
   end

--- a/app/lib/ses_email_formatter.rb
+++ b/app/lib/ses_email_formatter.rb
@@ -21,7 +21,7 @@ class SesEmailFormatter
 private
 
   def prep_question_title_html(page)
-    "<h2>#{remove_heading_hashes(prep_question_title_plain_text(page))}</h2>"
+    "<h2>#{prep_question_title_plain_text(page)}</h2>"
   end
 
   def prep_answer_text_html(page)
@@ -31,7 +31,7 @@ private
   end
 
   def prep_question_title_plain_text(page)
-    "## #{page.question_text}"
+    page.question_text
   end
 
   def prep_answer_text_plain_text(page)
@@ -51,10 +51,6 @@ private
 
   def normalize_whitespace(text)
     text.strip.gsub(/\r\n?/, "\n").split(/\n\n+/).map(&:strip).join("\n\n")
-  end
-
-  def remove_heading_hashes(text)
-    text.gsub("## ", "")
   end
 
   def convert_newlines_to_html(text)

--- a/app/lib/ses_email_formatter.rb
+++ b/app/lib/ses_email_formatter.rb
@@ -1,20 +1,28 @@
 class SesEmailFormatter
   H_RULE = '<hr style="border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;">'.freeze
+  H_RULE_PLAIN_TEXT = "\n\n---\n\n".freeze
 
   class FormattingError < StandardError; end
 
   def build_question_answers_section_html(completed_steps)
     completed_steps.map { |page|
-      [prep_question_title(page),
-       prep_answer_text(page)].join
+      [prep_question_title_html(page),
+       prep_answer_text_html(page)].join
     }.join(H_RULE)
   end
 
-  def prep_question_title(page)
+  def build_question_answers_section_plain_text(completed_steps)
+    completed_steps.map { |page|
+      [prep_question_title_plain_text(page),
+       prep_answer_text_plain_text(page)].join("\n\n")
+    }.join(H_RULE_PLAIN_TEXT)
+  end
+
+  def prep_question_title_html(page)
     "<h2>#{page.question_text}</h2>"
   end
 
-  def prep_answer_text(page)
+  def prep_answer_text_html(page)
     answer = page.show_answer_in_email
 
     return "<p>[This question was skipped]</p>" if answer.blank?
@@ -24,13 +32,34 @@ class SesEmailFormatter
     raise FormattingError, "could not format answer for question page #{page.id}"
   end
 
+  def prep_question_title_plain_text(page)
+    "## #{page.question_text}"
+  end
+
+  def prep_answer_text_plain_text(page)
+    answer = page.show_answer_in_email
+
+    return "[This question was skipped]" if answer.blank?
+
+    sanitize_plain_text(answer)
+  end
+
   def sanitize(text)
     # TODO: we'll want to do more sanitizing on the answer text
     text
       .then { normalize_whitespace _1 }
   end
 
+  def sanitize_plain_text(text)
+    text
+      .then { normalize_whitespace_plain_text _1 }
+  end
+
   def normalize_whitespace(text)
     text.strip.gsub(/\r\n?/, "<br/>").split(/\n\n+/).map(&:strip).join("<br/><br/>")
+  end
+
+  def normalize_whitespace_plain_text(text)
+    text.strip.gsub(/\r\n?/, "\n").split(/\n\n+/).map(&:strip).join("\n\n")
   end
 end

--- a/app/mailers/aws_ses_form_submission_mailer.rb
+++ b/app/mailers/aws_ses_form_submission_mailer.rb
@@ -3,8 +3,8 @@ class AwsSesFormSubmissionMailer < ApplicationMailer
           reply_to: Settings.ses_submission_email.reply_to_email_address,
           delivery_method: Rails.configuration.x.aws_ses_form_submission_mailer["delivery_method"]
 
-  def submission_email(answer_content:, submission_email_address:, mailer_options:, files:)
-    @answer_content = answer_content
+  def submission_email(answer_content_html:, submission_email_address:, mailer_options:, files:)
+    @answer_content_html = answer_content_html
     @mailer_options = mailer_options
     @subject = I18n.t("mailer.submission.subject", form_title: mailer_options.title, reference: mailer_options.submission_reference)
 

--- a/app/mailers/aws_ses_form_submission_mailer.rb
+++ b/app/mailers/aws_ses_form_submission_mailer.rb
@@ -3,8 +3,9 @@ class AwsSesFormSubmissionMailer < ApplicationMailer
           reply_to: Settings.ses_submission_email.reply_to_email_address,
           delivery_method: Rails.configuration.x.aws_ses_form_submission_mailer["delivery_method"]
 
-  def submission_email(answer_content_html:, submission_email_address:, mailer_options:, files:)
+  def submission_email(answer_content_html:, answer_content_plain_text:, submission_email_address:, mailer_options:, files:)
     @answer_content_html = answer_content_html
+    @answer_content_plain_text = answer_content_plain_text
     @mailer_options = mailer_options
     @subject = I18n.t("mailer.submission.subject", form_title: mailer_options.title, reference: mailer_options.submission_reference)
 

--- a/app/services/aws_ses_submission_service.rb
+++ b/app/services/aws_ses_submission_service.rb
@@ -52,7 +52,7 @@ private
   end
 
   def answer_content_plain_text
-    SesEmailFormatter.new.build_question_answers_section_html(@journey.completed_steps)
+    SesEmailFormatter.new.build_question_answers_section_plain_text(@journey.completed_steps)
   end
 
   def uploaded_files_in_answers

--- a/app/services/aws_ses_submission_service.rb
+++ b/app/services/aws_ses_submission_service.rb
@@ -37,7 +37,8 @@ private
   end
 
   def deliver_submission_email(files)
-    mail = AwsSesFormSubmissionMailer.submission_email(answer_content_html: answer_content_html,
+    mail = AwsSesFormSubmissionMailer.submission_email(answer_content_html:,
+                                                       answer_content_plain_text:,
                                                        submission_email_address: @form.submission_email,
                                                        mailer_options: @mailer_options,
                                                        files:).deliver_now
@@ -47,6 +48,10 @@ private
   end
 
   def answer_content_html
+    SesEmailFormatter.new.build_question_answers_section_html(@journey.completed_steps)
+  end
+
+  def answer_content_plain_text
     SesEmailFormatter.new.build_question_answers_section_html(@journey.completed_steps)
   end
 

--- a/app/services/aws_ses_submission_service.rb
+++ b/app/services/aws_ses_submission_service.rb
@@ -37,7 +37,7 @@ private
   end
 
   def deliver_submission_email(files)
-    mail = AwsSesFormSubmissionMailer.submission_email(answer_content:,
+    mail = AwsSesFormSubmissionMailer.submission_email(answer_content_html: answer_content_html,
                                                        submission_email_address: @form.submission_email,
                                                        mailer_options: @mailer_options,
                                                        files:).deliver_now
@@ -46,8 +46,8 @@ private
     mail.message_id
   end
 
-  def answer_content
-    SesEmailFormatter.new.build_question_answers_section(@journey.completed_steps)
+  def answer_content_html
+    SesEmailFormatter.new.build_question_answers_section_html(@journey.completed_steps)
   end
 
   def uploaded_files_in_answers

--- a/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
@@ -13,7 +13,7 @@
 
 <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
 
-<%= @answer_content.html_safe %>
+<%= @answer_content_html.html_safe %>
 
 <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
 

--- a/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
@@ -22,6 +22,6 @@
     padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;"
 >
   <h2><%= I18n.t("mailer.submission.cannot_reply.heading") %></h2>
-  <%= I18n.t("mailer.submission.cannot_reply.contact_form_filler").html_safe %>
-  <%= I18n.t("mailer.submission.cannot_reply.contact_forms_team").html_safe %>
+  <%= I18n.t("mailer.submission.cannot_reply.contact_form_filler_html").html_safe %>
+  <%= I18n.t("mailer.submission.cannot_reply.contact_forms_team_html").html_safe %>
 </div>

--- a/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
@@ -12,7 +12,7 @@
 
 ---
 
-## <%= I18n.t("mailer.submission.cannot_reply.heading") %>
+<%= I18n.t("mailer.submission.cannot_reply.heading") %>
 
 <%= I18n.t("mailer.submission.cannot_reply.contact_form_filler_plain") %>
 <%= I18n.t("mailer.submission.cannot_reply.contact_forms_team_plain") %>

--- a/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
@@ -8,7 +8,7 @@
 
 ---
 
-<%= @answer_content_html %>
+<%= @answer_content_plain_text %>
 
 ---
 

--- a/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
@@ -1,0 +1,18 @@
+<%= I18n.t("mailer.submission.title", title: @mailer_options.title) %>
+
+<%= I18n.t("mailer.submission.time", time: @mailer_options.timestamp.strftime("%l:%M%P").strip, date: @mailer_options.timestamp.strftime("%-d %B %Y") ) %>
+
+<%= I18n.t("mailer.submission.reference", submission_reference: @mailer_options.submission_reference) %>
+
+<%= I18n.t("mailer.submission.check_before_using") %>
+
+---
+
+<%= @answer_content %>
+
+---
+
+## <%= I18n.t("mailer.submission.cannot_reply.heading") %>
+
+<%= I18n.t("mailer.submission.cannot_reply.contact_form_filler") %>
+<%= I18n.t("mailer.submission.cannot_reply.contact_forms_team") %>

--- a/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
@@ -8,7 +8,7 @@
 
 ---
 
-<%= @answer_content %>
+<%= @answer_content_html %>
 
 ---
 

--- a/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
@@ -14,5 +14,5 @@
 
 ## <%= I18n.t("mailer.submission.cannot_reply.heading") %>
 
-<%= I18n.t("mailer.submission.cannot_reply.contact_form_filler") %>
-<%= I18n.t("mailer.submission.cannot_reply.contact_forms_team") %>
+<%= I18n.t("mailer.submission.cannot_reply.contact_form_filler_plain") %>
+<%= I18n.t("mailer.submission.cannot_reply.contact_forms_team_plain") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,8 +193,10 @@ en:
   mailer:
     submission:
       cannot_reply:
-        contact_form_filler: "<p>If you need to contact the person who completed this form, you’ll need to contact them directly.</p>"
-        contact_forms_team: <p>If you’re experiencing a technical issue with this form, <a href="https://www.forms.service.gov.uk/support">contact the GOV.​UK Forms team</a> with details of the issue and the form it relates to.</p>
+        contact_form_filler_html: "<p>If you need to contact the person who completed this form, you’ll need to contact them directly.</p>"
+        contact_form_filler_plain: If you need to contact the person who completed this form, you’ll need to contact them directly.
+        contact_forms_team_html: <p>If you’re experiencing a technical issue with this form, <a href="https://www.forms.service.gov.uk/support">contact the GOV.​UK Forms team</a> with details of the issue and the form it relates to.</p>
+        contact_forms_team_plain: If you’re experiencing a technical issue with this form, contact the GOV.​UK Forms team (https://www.forms.service.gov.uk/support) with details of the issue and the form it relates to.
         heading: You cannot reply to this email
       check_before_using: Check that this data looks safe before you use it
       file_attached: "%{filename} (attached to this email)"

--- a/spec/features/fill_in_file_upload_question_spec.rb
+++ b/spec/features/fill_in_file_upload_question_spec.rb
@@ -135,7 +135,7 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
 
     delivered_email = ActionMailer::Base.deliveries.first
 
-    expect(delivered_email.body.parts.find { |p| p.content_type.match(/html/) }.body.raw_source).to match(/a-file.txt/)
+    expect(delivered_email.html_part.body.raw_source).to match(/a-file.txt/)
   end
 
   def then_i_see_an_error_message_that_the_file_contains_a_virus

--- a/spec/lib/notify_template_formatter_spec.rb
+++ b/spec/lib/notify_template_formatter_spec.rb
@@ -1,76 +1,74 @@
 require "rails_helper"
 
 RSpec.describe NotifyTemplateFormatter, type: :model do
-  describe "NotifyTemplateBodyFilter" do
-    subject(:notify_template_formatter) { described_class.new }
+  subject(:notify_template_formatter) { described_class.new }
 
-    describe "#build_question_answers_section" do
-      let(:completed_steps) { [step] }
+  describe "#build_question_answers_section" do
+    let(:completed_steps) { [step] }
 
-      let(:step) { instance_double(Step, { id: 99, question_text: "What is the meaning of life?", show_answer_in_email: "42" }) }
+    let(:step) { instance_double(Step, { id: 99, question_text: "What is the meaning of life?", show_answer_in_email: "42" }) }
 
-      it "returns combined title and answer" do
-        expect(notify_template_formatter.build_question_answers_section(completed_steps)).to eq "# What is the meaning of life?\n42\n"
-      end
+    it "returns combined title and answer" do
+      expect(notify_template_formatter.build_question_answers_section(completed_steps)).to eq "# What is the meaning of life?\n42\n"
+    end
 
-      context "when there is more than one step" do
-        let(:completed_steps) { [step, step] }
+    context "when there is more than one step" do
+      let(:completed_steps) { [step, step] }
 
-        it "contains a horizontal rule between each step" do
-          expect(notify_template_formatter.build_question_answers_section(completed_steps)).to include "\n\n---\n\n"
-        end
-      end
-
-      context "when there is an error formatting an answer" do
-        before do
-          allow(step).to receive(:show_answer_in_email).and_raise(NoMethodError, "undefined method 'strip' for an instance of Array")
-        end
-
-        it "raises an error with the page id" do
-          expect {
-            notify_template_formatter.build_question_answers_section(completed_steps)
-          }.to raise_error(NotifyTemplateFormatter::FormattingError, "could not format answer for question page 99")
-        end
+      it "contains a horizontal rule between each step" do
+        expect(notify_template_formatter.build_question_answers_section(completed_steps)).to include "\n\n---\n\n"
       end
     end
 
-    describe "#prep_question_title" do
-      it "returns markdown heading on its own line" do
-        ["Hello", "3.4 Question", "-23.4 Negative headings", "\n\n # 4.5.6"].each do |title|
-          page = instance_double(Step, question_text: title)
-          expect(notify_template_formatter.prep_question_title(page)).to eq "# #{title}\n"
-        end
+    context "when there is an error formatting an answer" do
+      before do
+        allow(step).to receive(:show_answer_in_email).and_raise(NoMethodError, "undefined method 'strip' for an instance of Array")
+      end
+
+      it "raises an error with the page id" do
+        expect {
+          notify_template_formatter.build_question_answers_section(completed_steps)
+        }.to raise_error(NotifyTemplateFormatter::FormattingError, "could not format answer for question page 99")
+      end
+    end
+  end
+
+  describe "#prep_question_title" do
+    it "returns markdown heading on its own line" do
+      ["Hello", "3.4 Question", "-23.4 Negative headings", "\n\n # 4.5.6"].each do |title|
+        page = instance_double(Step, question_text: title)
+        expect(notify_template_formatter.prep_question_title(page)).to eq "# #{title}\n"
+      end
+    end
+  end
+
+  describe "#prep_answer_text" do
+    it "returns escaped answer" do
+      [
+        { input: "Hello", output: "Hello" },
+        { input: "3.4 Question", output: "3\\.4 Question" },
+        { input: "-23.4 answer", output: "\\-23\\.4 answer" },
+        { input: "4.5.6", output: "4\\.5\\.6" },
+        { input: "\n\n# Test \n\n## Test 2", output: "\\# Test\n\n\\#\\# Test 2" },
+        { input: "\n\n```# Test 3\n\n## Test 4", output: "\\`\\`\\`\\# Test 3\n\n\\#\\# Test 4" }, # escapes ```
+        { input: "\n\n\n\n\n```# Test \n\n\n\n\n\n## Test 3\n\n\n\n", output: "\\`\\`\\`\\# Test\n\n\\#\\# Test 3" },
+        { input: "test https://example.org # more text 19.5\n\nA new paragraph.", output: "test https://example.org \\# more text 19\\.5\n\nA new paragraph\\." },
+        { input: "test https://example.org # more text 19.5\n\nA new paragraph.\n\n# another link http://gov.uk", output: "test https://example.org \\# more text 19\\.5\n\nA new paragraph\\.\n\n\\# another link http://gov.uk" },
+        { input: "not a title\n====", output: "not a title\n\\_\\_\\_\\_" },
+        { input: "a normal sentence: 10 = 5 + 5", output: "a normal sentence: 10 = 5 \\+ 5" },
+        { input: "    paragraph 1\n\n\n\n\n\n\n\n\n\n\n\n\n Another Paragraph with trailing space     \n\n\n\n\n", output: "paragraph 1\n\nAnother Paragraph with trailing space" },
+
+      ].each do |test_case|
+        page = instance_double(Step, show_answer_in_email: test_case[:input])
+        expect(notify_template_formatter.prep_answer_text(page)).to eq test_case[:output]
       end
     end
 
-    describe "#prep_answer_text" do
-      it "returns escaped answer" do
-        [
-          { input: "Hello", output: "Hello" },
-          { input: "3.4 Question", output: "3\\.4 Question" },
-          { input: "-23.4 answer", output: "\\-23\\.4 answer" },
-          { input: "4.5.6", output: "4\\.5\\.6" },
-          { input: "\n\n# Test \n\n## Test 2", output: "\\# Test\n\n\\#\\# Test 2" },
-          { input: "\n\n```# Test 3\n\n## Test 4", output: "\\`\\`\\`\\# Test 3\n\n\\#\\# Test 4" }, # escapes ```
-          { input: "\n\n\n\n\n```# Test \n\n\n\n\n\n## Test 3\n\n\n\n", output: "\\`\\`\\`\\# Test\n\n\\#\\# Test 3" },
-          { input: "test https://example.org # more text 19.5\n\nA new paragraph.", output: "test https://example.org \\# more text 19\\.5\n\nA new paragraph\\." },
-          { input: "test https://example.org # more text 19.5\n\nA new paragraph.\n\n# another link http://gov.uk", output: "test https://example.org \\# more text 19\\.5\n\nA new paragraph\\.\n\n\\# another link http://gov.uk" },
-          { input: "not a title\n====", output: "not a title\n\\_\\_\\_\\_" },
-          { input: "a normal sentence: 10 = 5 + 5", output: "a normal sentence: 10 = 5 \\+ 5" },
-          { input: "    paragraph 1\n\n\n\n\n\n\n\n\n\n\n\n\n Another Paragraph with trailing space     \n\n\n\n\n", output: "paragraph 1\n\nAnother Paragraph with trailing space" },
+    context "when answer is blank i.e skipped" do
+      let(:page) { instance_double(Step, show_answer_in_email: "") }
 
-        ].each do |test_case|
-          page = instance_double(Step, show_answer_in_email: test_case[:input])
-          expect(notify_template_formatter.prep_answer_text(page)).to eq test_case[:output]
-        end
-      end
-
-      context "when answer is blank i.e skipped" do
-        let(:page) { instance_double(Step, show_answer_in_email: "") }
-
-        it "returns the blank answer text" do
-          expect(notify_template_formatter.prep_answer_text(page)).to eq "\\[This question was skipped\\]"
-        end
+      it "returns the blank answer text" do
+        expect(notify_template_formatter.prep_answer_text(page)).to eq "\\[This question was skipped\\]"
       end
     end
   end

--- a/spec/lib/ses_email_formatter_spec.rb
+++ b/spec/lib/ses_email_formatter_spec.rb
@@ -132,5 +132,18 @@ RSpec.describe SesEmailFormatter do
         end
       end
     end
+
+    context "when there is an error formatting an answer" do
+      before do
+        text_step.page.id = 99
+        allow(text_step).to receive(:show_answer_in_email).and_raise(NoMethodError, "undefined method 'strip' for an instance of Array")
+      end
+
+      it "raises an error with the page id" do
+        expect {
+          described_class.new.build_question_answers_section_plain_text(completed_steps)
+        }.to raise_error(SesEmailFormatter::FormattingError, "could not format answer for question page 99")
+      end
+    end
   end
 end

--- a/spec/lib/ses_email_formatter_spec.rb
+++ b/spec/lib/ses_email_formatter_spec.rb
@@ -73,4 +73,64 @@ RSpec.describe SesEmailFormatter do
       end
     end
   end
+
+  describe "#build_question_answers_section_plain_text" do
+    let(:text_question) { build :text, question_text: "What is the meaning of life?", text: "42" }
+    let(:text_step) { build :step, question: text_question }
+    let(:name_question) { build :first_middle_last_name_question, question_text: "What is your name?" }
+    let(:name_step) { build :step, question: name_question }
+    let(:completed_steps) { [text_step] }
+
+    context "when there is one step" do
+      it "returns question and and answer HTML" do
+        question_answers = described_class.new.build_question_answers_section_plain_text(completed_steps)
+        expect(question_answers).to eq("## What is the meaning of life?\n\n42")
+      end
+    end
+
+    context "when the answer has multiple attributes" do
+      let(:completed_steps) { [name_step] }
+
+      it "inserts line breaks between answer attributes" do
+        question_answers = described_class.new.build_question_answers_section_plain_text(completed_steps)
+        expect(question_answers).to eq("## What is your name?\n\nFirst name: #{name_question.first_name}\n\nLast name: #{name_question.last_name}")
+      end
+    end
+
+    context "when the answer is blank i.e. skipped" do
+      let(:text_question) { build :text, question_text: "What is the meaning of life?", text: nil }
+      let(:completed_steps) { [text_step] }
+
+      it "returns the blank answer text" do
+        question_answers = described_class.new.build_question_answers_section_plain_text(completed_steps)
+        expect(question_answers).to eq("## What is the meaning of life?\n\n[This question was skipped]")
+      end
+    end
+
+    context "when there is more than one step" do
+      let(:completed_steps) { [text_step, name_step] }
+
+      it "returns all question an answers separated by a horizontal rule" do
+        question_answers = described_class.new.build_question_answers_section_plain_text(completed_steps)
+        expect(question_answers).to eq("## What is the meaning of life?\n\n42\n\n---\n\n## What is your name?\n\nFirst name: #{name_question.first_name}\n\nLast name: #{name_question.last_name}")
+      end
+    end
+
+    context "when there are special characters in the answer" do
+      let(:completed_steps) { [text_step] }
+
+      it "returns the sanitized answer" do
+        [
+          { input: "\n\nTest\n\nTest 2", output: "Test\n\nTest 2" },
+          { input: "    paragraph 1\n\n\n\n\n\n\n\n\n\n\n\n\n Another Paragraph with trailing space     \n\n\n\n\n", output: "paragraph 1\n\nAnother Paragraph with trailing space" },
+
+        ].each do |test_case|
+          text_question.text = test_case[:input]
+
+          question_answers = described_class.new.build_question_answers_section_plain_text(completed_steps)
+          expect(question_answers).to eq("## What is the meaning of life?\n\n#{test_case[:output]}")
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/ses_email_formatter_spec.rb
+++ b/spec/lib/ses_email_formatter_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe SesEmailFormatter do
-  describe "#build_question_answers_section" do
+  describe "#build_question_answers_section_html" do
     let(:text_question) { build :text, question_text: "What is the meaning of life?", text: "42" }
     let(:text_step) { build :step, question: text_question }
     let(:name_question) { build :first_middle_last_name_question, question_text: "What is your name?" }
@@ -10,7 +10,7 @@ RSpec.describe SesEmailFormatter do
 
     context "when there is one step" do
       it "returns question and and answer HTML" do
-        question_answers = described_class.new.build_question_answers_section(completed_steps)
+        question_answers = described_class.new.build_question_answers_section_html(completed_steps)
         expect(question_answers).to eq("<h2>What is the meaning of life?</h2><p>42</p>")
       end
     end
@@ -19,7 +19,7 @@ RSpec.describe SesEmailFormatter do
       let(:completed_steps) { [name_step] }
 
       it "inserts line breaks between answer attributes" do
-        question_answers = described_class.new.build_question_answers_section(completed_steps)
+        question_answers = described_class.new.build_question_answers_section_html(completed_steps)
         expect(question_answers).to eq("<h2>What is your name?</h2><p>First name: #{name_question.first_name}<br/><br/>Last name: #{name_question.last_name}</p>")
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe SesEmailFormatter do
       let(:completed_steps) { [text_step] }
 
       it "returns the blank answer text" do
-        question_answers = described_class.new.build_question_answers_section(completed_steps)
+        question_answers = described_class.new.build_question_answers_section_html(completed_steps)
         expect(question_answers).to eq("<h2>What is the meaning of life?</h2><p>[This question was skipped]</p>")
       end
     end
@@ -38,7 +38,7 @@ RSpec.describe SesEmailFormatter do
       let(:completed_steps) { [text_step, name_step] }
 
       it "returns all question an answers separated by a horizontal rule" do
-        question_answers = described_class.new.build_question_answers_section(completed_steps)
+        question_answers = described_class.new.build_question_answers_section_html(completed_steps)
         expect(question_answers).to eq("<h2>What is the meaning of life?</h2><p>42</p><hr style=\"border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;\"><h2>What is your name?</h2><p>First name: #{name_question.first_name}<br/><br/>Last name: #{name_question.last_name}</p>")
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe SesEmailFormatter do
         ].each do |test_case|
           text_question.text = test_case[:input]
 
-          question_answers = described_class.new.build_question_answers_section(completed_steps)
+          question_answers = described_class.new.build_question_answers_section_html(completed_steps)
           expect(question_answers).to eq("<h2>What is the meaning of life?</h2><p>#{test_case[:output]}</p>")
         end
       end
@@ -68,7 +68,7 @@ RSpec.describe SesEmailFormatter do
 
       it "raises an error with the page id" do
         expect {
-          described_class.new.build_question_answers_section(completed_steps)
+          described_class.new.build_question_answers_section_html(completed_steps)
         }.to raise_error(SesEmailFormatter::FormattingError, "could not format answer for question page 99")
       end
     end

--- a/spec/lib/ses_email_formatter_spec.rb
+++ b/spec/lib/ses_email_formatter_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe SesEmailFormatter do
     context "when there is one step" do
       it "returns question and and answer HTML" do
         question_answers = described_class.new.build_question_answers_section_plain_text(completed_steps)
-        expect(question_answers).to eq("## What is the meaning of life?\n\n42")
+        expect(question_answers).to eq("What is the meaning of life?\n\n42")
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe SesEmailFormatter do
 
       it "inserts line breaks between answer attributes" do
         question_answers = described_class.new.build_question_answers_section_plain_text(completed_steps)
-        expect(question_answers).to eq("## What is your name?\n\nFirst name: #{name_question.first_name}\n\nLast name: #{name_question.last_name}")
+        expect(question_answers).to eq("What is your name?\n\nFirst name: #{name_question.first_name}\n\nLast name: #{name_question.last_name}")
       end
     end
 
@@ -103,7 +103,7 @@ RSpec.describe SesEmailFormatter do
 
       it "returns the blank answer text" do
         question_answers = described_class.new.build_question_answers_section_plain_text(completed_steps)
-        expect(question_answers).to eq("## What is the meaning of life?\n\n[This question was skipped]")
+        expect(question_answers).to eq("What is the meaning of life?\n\n[This question was skipped]")
       end
     end
 
@@ -112,7 +112,7 @@ RSpec.describe SesEmailFormatter do
 
       it "returns all question an answers separated by a horizontal rule" do
         question_answers = described_class.new.build_question_answers_section_plain_text(completed_steps)
-        expect(question_answers).to eq("## What is the meaning of life?\n\n42\n\n---\n\n## What is your name?\n\nFirst name: #{name_question.first_name}\n\nLast name: #{name_question.last_name}")
+        expect(question_answers).to eq("What is the meaning of life?\n\n42\n\n---\n\nWhat is your name?\n\nFirst name: #{name_question.first_name}\n\nLast name: #{name_question.last_name}")
       end
     end
 
@@ -128,7 +128,7 @@ RSpec.describe SesEmailFormatter do
           text_question.text = test_case[:input]
 
           question_answers = described_class.new.build_question_answers_section_plain_text(completed_steps)
-          expect(question_answers).to eq("## What is the meaning of life?\n\n#{test_case[:output]}")
+          expect(question_answers).to eq("What is the meaning of life?\n\n#{test_case[:output]}")
         end
       end
     end

--- a/spec/mailers/aws_ses_form_submission_mailer_preview.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_preview.rb
@@ -1,6 +1,6 @@
 class AwsSesFormSubmissionMailerPreview < ActionMailer::Preview
   def submission_email
-    AwsSesFormSubmissionMailer.submission_email(answer_content: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
+    AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
                                                 submission_email_address: "testing@gov.uk",
                                                 mailer_options: FormSubmissionService::MailerOptions.new(title: "Form 1",
                                                                                                          is_preview: false,

--- a/spec/mailers/aws_ses_form_submission_mailer_preview.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_preview.rb
@@ -1,6 +1,7 @@
 class AwsSesFormSubmissionMailerPreview < ActionMailer::Preview
   def submission_email
     AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
+                                                answer_content_plain_text: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
                                                 submission_email_address: "testing@gov.uk",
                                                 mailer_options: FormSubmissionService::MailerOptions.new(title: "Form 1",
                                                                                                          is_preview: false,

--- a/spec/mailers/aws_ses_form_submission_mailer_preview.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_preview.rb
@@ -1,7 +1,7 @@
 class AwsSesFormSubmissionMailerPreview < ActionMailer::Preview
   def submission_email
     AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
-                                                answer_content_plain_text: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
+                                                answer_content_plain_text: "## What's your email address?\n\nforms@example.gov.uk",
                                                 submission_email_address: "testing@gov.uk",
                                                 mailer_options: FormSubmissionService::MailerOptions.new(title: "Form 1",
                                                                                                          is_preview: false,

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe AwsSesFormSubmissionMailer, type: :mailer do
-  let(:mail) { described_class.submission_email(answer_content:, submission_email_address:, mailer_options:, files:) }
+  let(:mail) { described_class.submission_email(answer_content_html:, submission_email_address:, mailer_options:, files:) }
   let(:title) { "Form 1" }
-  let(:answer_content) { "My question: My answer" }
+  let(:answer_content_html) { "My question: My answer" }
   let(:is_preview) { false }
   let(:submission_email_address) { "testing@gov.uk" }
   let(:files) { {} }
@@ -34,7 +34,7 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
       end
 
       it "includes the answers" do
-        expect(part.body).to match(answer_content)
+        expect(part.body).to match(answer_content_html)
       end
 
       it "includes the form title text" do
@@ -86,7 +86,7 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
       let(:part) { mail.text_part }
 
       it "includes the answers" do
-        expect(part.body).to match(answer_content)
+        expect(part.body).to match(answer_content_html)
       end
 
       it "includes the form title text" do

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -26,53 +26,109 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
       expect(mail.subject).to eq("Form submission: #{title} - reference: #{submission_reference}")
     end
 
-    it "has a link to GOV.UK" do
-      expect(mail.body).to have_link("GOV.UK", href: "https://www.gov.uk")
-    end
+    context "when looking at the html part" do
+      let(:part) { mail.html_part }
 
-    it "includes the answers" do
-      expect(mail.body).to match(answer_content)
-    end
+      it "has a link to GOV.UK" do
+        expect(part.body).to have_link("GOV.UK", href: "https://www.gov.uk")
+      end
 
-    it "includes the form title text" do
-      expect(mail.body).to have_css("p", text: I18n.t("mailer.submission.title", title:))
-    end
+      it "includes the answers" do
+        expect(part.body).to match(answer_content)
+      end
 
-    it "includes text about the submission time" do
-      expect(mail.body).to have_css("p", text: I18n.t("mailer.submission.time", time: submission_timestamp.strftime("%l:%M%P").strip, date: submission_timestamp.strftime("%-d %B %Y")))
-    end
+      it "includes the form title text" do
+        expect(part.body).to have_css("p", text: I18n.t("mailer.submission.title", title:))
+      end
 
-    it "includes the submission reference" do
-      expect(mail.body).to have_css("p", text: I18n.t("mailer.submission.reference", submission_reference:))
-    end
+      it "includes text about the submission time" do
+        expect(part.body).to have_css("p", text: I18n.t("mailer.submission.time", time: submission_timestamp.strftime("%l:%M%P").strip, date: submission_timestamp.strftime("%-d %B %Y")))
+      end
 
-    it "includes text about checking the answers" do
-      expect(mail.body).to have_css("p", text: I18n.t("mailer.submission.check_before_using"))
-    end
+      it "includes the submission reference" do
+        expect(part.body).to have_css("p", text: I18n.t("mailer.submission.reference", submission_reference:))
+      end
 
-    it "includes the warning about not replying" do
-      expect(mail.body).to have_css("h2", text: I18n.t("mailer.submission.cannot_reply.heading"))
-      expect(mail.body).to include(I18n.t("mailer.submission.cannot_reply.contact_form_filler"))
-      expect(mail.body).to include(I18n.t("mailer.submission.cannot_reply.contact_forms_team"))
-    end
+      it "includes text about checking the answers" do
+        expect(part.body).to have_css("p", text: I18n.t("mailer.submission.check_before_using"))
+      end
 
-    describe "submission date/time" do
-      context "with a time in BST" do
-        let(:timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0) }
+      it "includes the warning about not replying" do
+        expect(part.body).to have_css("h2", text: I18n.t("mailer.submission.cannot_reply.heading"))
+        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_form_filler"))
+        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_forms_team"))
+      end
 
-        it "includes the date and time the user submitted the form" do
-          travel_to timestamp do
-            expect(mail.body).to match("This form was submitted at 9:00am on 14 September 2022")
+      describe "submission date/time" do
+        context "with a time in BST" do
+          let(:timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0) }
+
+          it "includes the date and time the user submitted the form" do
+            travel_to timestamp do
+              expect(part.body).to match("This form was submitted at 9:00am on 14 September 2022")
+            end
+          end
+        end
+
+        context "with a time in GMT" do
+          let(:timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
+
+          it "includes the date and time the user submitted the form" do
+            travel_to timestamp do
+              expect(part.body).to match("This form was submitted at 1:00pm on 14 December 2022")
+            end
           end
         end
       end
+    end
 
-      context "with a time in GMT" do
-        let(:timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
+    context "when looking at the plaintext part" do
+      let(:part) { mail.text_part }
 
-        it "includes the date and time the user submitted the form" do
-          travel_to timestamp do
-            expect(mail.body).to match("This form was submitted at 1:00pm on 14 December 2022")
+      it "includes the answers" do
+        expect(part.body).to match(answer_content)
+      end
+
+      it "includes the form title text" do
+        expect(part.body).to have_text(I18n.t("mailer.submission.title", title:))
+      end
+
+      it "includes text about the submission time" do
+        expect(part.body).to have_text(I18n.t("mailer.submission.time", time: submission_timestamp.strftime("%l:%M%P").strip, date: submission_timestamp.strftime("%-d %B %Y")))
+      end
+
+      it "includes the submission reference" do
+        expect(part.body).to have_text(I18n.t("mailer.submission.reference", submission_reference:))
+      end
+
+      it "includes text about checking the answers" do
+        expect(part.body).to have_text(I18n.t("mailer.submission.check_before_using"))
+      end
+
+      it "includes the warning about not replying" do
+        expect(part.body).to have_text(I18n.t("mailer.submission.cannot_reply.heading"))
+        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_form_filler"))
+        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_forms_team"))
+      end
+
+      describe "submission date/time" do
+        context "with a time in BST" do
+          let(:timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0) }
+
+          it "includes the date and time the user submitted the form" do
+            travel_to timestamp do
+              expect(part.body).to match("This form was submitted at 9:00am on 14 September 2022")
+            end
+          end
+        end
+
+        context "with a time in GMT" do
+          let(:timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
+
+          it "includes the date and time the user submitted the form" do
+            travel_to timestamp do
+              expect(part.body).to match("This form was submitted at 1:00pm on 14 December 2022")
+            end
           end
         end
       end

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 describe AwsSesFormSubmissionMailer, type: :mailer do
-  let(:mail) { described_class.submission_email(answer_content_html:, submission_email_address:, mailer_options:, files:) }
+  let(:mail) { described_class.submission_email(answer_content_html:, answer_content_plain_text:, submission_email_address:, mailer_options:, files:) }
   let(:title) { "Form 1" }
   let(:answer_content_html) { "My question: My answer" }
+  let(:answer_content_plain_text) { "My question: My answer" }
   let(:is_preview) { false }
   let(:submission_email_address) { "testing@gov.uk" }
   let(:files) { {} }
@@ -86,7 +87,7 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
       let(:part) { mail.text_part }
 
       it "includes the answers" do
-        expect(part.body).to match(answer_content_html)
+        expect(part.body).to match(answer_content_plain_text)
       end
 
       it "includes the form title text" do

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -55,8 +55,8 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
 
       it "includes the warning about not replying" do
         expect(part.body).to have_css("h2", text: I18n.t("mailer.submission.cannot_reply.heading"))
-        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_form_filler"))
-        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_forms_team"))
+        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_form_filler_html"))
+        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_forms_team_html"))
       end
 
       describe "submission date/time" do
@@ -107,8 +107,8 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
 
       it "includes the warning about not replying" do
         expect(part.body).to have_text(I18n.t("mailer.submission.cannot_reply.heading"))
-        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_form_filler"))
-        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_forms_team"))
+        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_form_filler_plain"))
+        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_forms_team_plain"))
       end
 
       describe "submission date/time" do

--- a/spec/services/aws_ses_submission_service_spec.rb
+++ b/spec/services/aws_ses_submission_service_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe AwsSesSubmissionService do
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
             { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
+              answer_content_plain_text: "<h2>What is the meaning of life?</h2><p>42</p>",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
               files: {} },
@@ -102,6 +103,7 @@ RSpec.describe AwsSesSubmissionService do
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
             { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
+              answer_content_plain_text: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
               files: { question.name_with_filename_suffix => file_content } },
@@ -138,6 +140,7 @@ RSpec.describe AwsSesSubmissionService do
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
             { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
+              answer_content_plain_text: "<h2>What is the meaning of life?</h2><p>42</p>",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
               files: { "govuk_forms_form_#{form.id}_#{submission_reference}.csv" => expected_csv_content } },
@@ -167,6 +170,7 @@ RSpec.describe AwsSesSubmissionService do
 
               expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
                 { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
+                  answer_content_plain_text: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
                   submission_email_address: submission_email,
                   mailer_options: instance_of(FormSubmissionService::MailerOptions),
                   files: {
@@ -192,6 +196,7 @@ RSpec.describe AwsSesSubmissionService do
 
             expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
               { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
+                answer_content_plain_text: "<h2>What is the meaning of life?</h2><p>42</p>",
                 submission_email_address: submission_email,
                 mailer_options: instance_of(FormSubmissionService::MailerOptions),
                 files: {} },

--- a/spec/services/aws_ses_submission_service_spec.rb
+++ b/spec/services/aws_ses_submission_service_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe AwsSesSubmissionService do
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
             { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
-              answer_content_plain_text: "<h2>What is the meaning of life?</h2><p>42</p>",
+              answer_content_plain_text: "## What is the meaning of life?\n\n42",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
               files: {} },
@@ -103,7 +103,7 @@ RSpec.describe AwsSesSubmissionService do
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
             { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
-              answer_content_plain_text: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
+              answer_content_plain_text: "## #{question.question_text}\n\n#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
               files: { question.name_with_filename_suffix => file_content } },
@@ -140,7 +140,7 @@ RSpec.describe AwsSesSubmissionService do
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
             { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
-              answer_content_plain_text: "<h2>What is the meaning of life?</h2><p>42</p>",
+              answer_content_plain_text: "## What is the meaning of life?\n\n42",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
               files: { "govuk_forms_form_#{form.id}_#{submission_reference}.csv" => expected_csv_content } },
@@ -170,7 +170,7 @@ RSpec.describe AwsSesSubmissionService do
 
               expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
                 { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
-                  answer_content_plain_text: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
+                  answer_content_plain_text: "## #{question.question_text}\n\n#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}",
                   submission_email_address: submission_email,
                   mailer_options: instance_of(FormSubmissionService::MailerOptions),
                   files: {
@@ -196,7 +196,7 @@ RSpec.describe AwsSesSubmissionService do
 
             expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
               { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
-                answer_content_plain_text: "<h2>What is the meaning of life?</h2><p>42</p>",
+                answer_content_plain_text: "## What is the meaning of life?\n\n42",
                 submission_email_address: submission_email,
                 mailer_options: instance_of(FormSubmissionService::MailerOptions),
                 files: {} },

--- a/spec/services/aws_ses_submission_service_spec.rb
+++ b/spec/services/aws_ses_submission_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe AwsSesSubmissionService do
           service.submit
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-            { answer_content: "<h2>What is the meaning of life?</h2><p>42</p>",
+            { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
               files: {} },
@@ -101,7 +101,7 @@ RSpec.describe AwsSesSubmissionService do
           service.submit
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-            { answer_content: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
+            { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
               files: { question.name_with_filename_suffix => file_content } },
@@ -137,7 +137,7 @@ RSpec.describe AwsSesSubmissionService do
           expected_csv_content = "Reference,Submitted at,What is the meaning of life?\n#{submission_reference},2022-09-14T08:00:00Z,42\n"
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-            { answer_content: "<h2>What is the meaning of life?</h2><p>42</p>",
+            { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
               files: { "govuk_forms_form_#{form.id}_#{submission_reference}.csv" => expected_csv_content } },
@@ -166,7 +166,7 @@ RSpec.describe AwsSesSubmissionService do
               expected_csv_content = "Reference,Submitted at,#{question.question_text}\n#{submission_reference},2022-09-14T08:00:00Z,#{question.name_with_filename_suffix}\n"
 
               expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-                { answer_content: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
+                { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
                   submission_email_address: submission_email,
                   mailer_options: instance_of(FormSubmissionService::MailerOptions),
                   files: {
@@ -191,7 +191,7 @@ RSpec.describe AwsSesSubmissionService do
             service.submit
 
             expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-              { answer_content: "<h2>What is the meaning of life?</h2><p>42</p>",
+              { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
                 submission_email_address: submission_email,
                 mailer_options: instance_of(FormSubmissionService::MailerOptions),
                 files: {} },

--- a/spec/services/aws_ses_submission_service_spec.rb
+++ b/spec/services/aws_ses_submission_service_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe AwsSesSubmissionService do
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
             { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
-              answer_content_plain_text: "## What is the meaning of life?\n\n42",
+              answer_content_plain_text: "What is the meaning of life?\n\n42",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
               files: {} },
@@ -103,7 +103,7 @@ RSpec.describe AwsSesSubmissionService do
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
             { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
-              answer_content_plain_text: "## #{question.question_text}\n\n#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}",
+              answer_content_plain_text: "#{question.question_text}\n\n#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
               files: { question.name_with_filename_suffix => file_content } },
@@ -140,7 +140,7 @@ RSpec.describe AwsSesSubmissionService do
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
             { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
-              answer_content_plain_text: "## What is the meaning of life?\n\n42",
+              answer_content_plain_text: "What is the meaning of life?\n\n42",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
               files: { "govuk_forms_form_#{form.id}_#{submission_reference}.csv" => expected_csv_content } },
@@ -170,7 +170,7 @@ RSpec.describe AwsSesSubmissionService do
 
               expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
                 { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
-                  answer_content_plain_text: "## #{question.question_text}\n\n#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}",
+                  answer_content_plain_text: "#{question.question_text}\n\n#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}",
                   submission_email_address: submission_email,
                   mailer_options: instance_of(FormSubmissionService::MailerOptions),
                   files: {
@@ -196,7 +196,7 @@ RSpec.describe AwsSesSubmissionService do
 
             expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
               { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
-                answer_content_plain_text: "## What is the meaning of life?\n\n42",
+                answer_content_plain_text: "What is the meaning of life?\n\n42",
                 submission_email_address: submission_email,
                 mailer_options: instance_of(FormSubmissionService::MailerOptions),
                 files: {} },


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/2DMKRjiO/2170-include-plain-text-version-for-emails-sent-using-ses

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Updates the SES mailer template with a plaintext template, so that the email will be a multipart email with HTML and plaintext parts.

### Testing instructions
You can use the mailer preview (http://localhost:3001/rails/mailers/aws_ses_form_submission_mailer/submission_email) to see how the email should look in HTML and plaintext forms.

If running the product in a local AWS shell, you can see the real thing by submitting a file upload form. In Gmail you can then use '[Show original](https://support.google.com/mail/answer/29436?hl=en-GB#zippy=)' to check whether you can see the plaintext content in the email code.

The content should look something like this:

```
This is a completed “Form 1” form.

This form was submitted at 3:28pm on 24 March 2025

GOV.​UK Forms reference number: JCHF7487

Check that this data looks safe before you use it

---

## Upload your file

image.jpg (attached to this email)

---

## You cannot reply to this email

If you need to contact the person who completed this form, you’ll need to contact them directly.
If you’re experiencing a technical issue with this form, contact the GOV.​UK Forms team (https://www.forms.service.gov.uk/support) with details of the issue and the form it relates to.
```

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
