### PR TITLE
Attachment sent status

### DIFF
--- a/app/controllers/submission_status_controller.rb
+++ b/app/controllers/submission_status_controller.rb
@@ -1,0 +1,15 @@
+class SubmissionStatusController < ApplicationController
+  def status
+    if Submission.emailed?(submission_params[:reference])
+      head :no_content
+    else
+      head :not_found
+    end
+  end
+
+private
+
+  def submission_params
+    params.permit(:reference)
+  end
+end

--- a/app/controllers/submission_status_controller.rb
+++ b/app/controllers/submission_status_controller.rb
@@ -1,4 +1,5 @@
 class SubmissionStatusController < ApplicationController
+  before_action :authenticate_client
   def status
     if Submission.emailed?(submission_params[:reference])
       head :no_content
@@ -8,6 +9,12 @@ class SubmissionStatusController < ApplicationController
   end
 
 private
+
+  def authenticate_client
+    authenticate_or_request_with_http_token do |token, _options|
+      ActiveSupport::SecurityUtils.secure_compare(token, Settings.submission_status_api[:secret])
+    end
+  end
 
   def submission_params
     params.permit(:reference)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -9,6 +9,11 @@ class Submission < ApplicationRecord
     @form ||= get_form
   end
 
+  def self.emailed?(reference)
+    submission = Submission.find_by(reference: reference)
+    submission.mail_message_id.present? if submission.present?
+  end
+
 private
 
   def mode_object

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   get "/help/cookies" => "application#cookies", as: :cookies
 
   get "/security.txt" => redirect("https://vdp.cabinetoffice.gov.uk/.well-known/security.txt")
+  get "/submission" => "submission_status#status", as: :status
   get "/.well-known/security.txt" => redirect("https://vdp.cabinetoffice.gov.uk/.well-known/security.txt")
 
   scope "/:mode", mode: /preview-draft|preview-archived|preview-live|form/ do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,6 +24,9 @@ sentry:
   environment: local
   filter_mask: "[Filtered (client-side)]"
 
+submission_status_api:
+  secret: changeme
+
 aws:
   s3_submission_iam_role_arn: changeme
   file_upload_s3_bucket_name: changeme

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -6,4 +6,7 @@ ses_submission_email:
   from_email_address: "local-test@dev.forms.service.gov.uk"
   reply_to_email_address: "local-test@dev.forms.service.gov.uk"
 
+submission_status_api:
+  secret: test_token
+
 retain_submissions_for_seconds: 60

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -6,6 +6,9 @@ ses_submission_email:
   from_email_address: govuk_forms@example.com
   reply_to_email_address: no-reply@example.com
 
+submission_status_api:
+  secret: test_token
+
 file_upload:
   poll_scan_status_wait_milliseconds: 50
   poll_scan_status_max_attempts: 2

--- a/spec/controllers/submission_status_controller_spec.rb
+++ b/spec/controllers/submission_status_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe SubmissionStatusController do
+  describe "#status" do
+    context "when a submission has been emailed" do
+      it "returns a 204 status" do
+        submission = Submission.create!(reference: "123", mail_message_id: "456")
+
+        get :status, params: { reference: submission.reference }
+
+        expect(response).to have_http_status :no_content
+      end
+    end
+
+    context "when a submission has not been emailed" do
+      it "returns a 404 status" do
+        submission = Submission.create!(reference: "789")
+
+        get :status, params: { reference: submission.reference }
+
+        expect(response).to have_http_status :not_found
+      end
+    end
+
+    context "when a submission does not exist" do
+      it "returns a 404 status" do
+        get :status, params: { reference: "999" }
+
+        expect(response).to have_http_status :not_found
+      end
+    end
+  end
+end

--- a/spec/controllers/submission_status_controller_spec.rb
+++ b/spec/controllers/submission_status_controller_spec.rb
@@ -2,32 +2,62 @@ require "rails_helper"
 
 RSpec.describe SubmissionStatusController do
   describe "#status" do
-    context "when a submission has been emailed" do
-      it "returns a 204 status" do
-        submission = Submission.create!(reference: "123", mail_message_id: "456")
+    context "when authorization token is included in request" do
+      let(:token) { "test_token" }
 
-        get :status, params: { reference: submission.reference }
+      before do
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
 
-        expect(response).to have_http_status :no_content
+      context "when a submission has been emailed" do
+        it "returns a 204 status" do
+          submission = Submission.create!(reference: "123", mail_message_id: "456")
+
+          get :status, params: { reference: submission.reference }
+
+          expect(response).to have_http_status :no_content
+        end
+      end
+
+      context "when a submission has not been emailed" do
+        it "returns a 404 status" do
+          submission = Submission.create!(reference: "789")
+
+          get :status, params: { reference: submission.reference }
+
+          expect(response).to have_http_status :not_found
+        end
+      end
+
+      context "when a submission does not exist" do
+        it "returns a 404 status" do
+          get :status, params: { reference: "999" }
+
+          expect(response).to have_http_status :not_found
+        end
       end
     end
 
-    context "when a submission has not been emailed" do
-      it "returns a 404 status" do
-        submission = Submission.create!(reference: "789")
+    context "when no authorization token is included in request" do
+      it "returns a 401 status" do
+        get :status, params: { reference: "123" }
 
-        get :status, params: { reference: submission.reference }
-
-        expect(response).to have_http_status :not_found
+        expect(response).to have_http_status :unauthorized
       end
     end
+  end
 
-    context "when a submission does not exist" do
-      it "returns a 404 status" do
-        get :status, params: { reference: "999" }
+  context "when authorization token is invalid" do
+    let(:token) { "bad_token" }
 
-        expect(response).to have_http_status :not_found
-      end
+    before do
+      request.headers["Authorization"] = "Bearer #{token}"
+    end
+
+    it "returns a 401 status" do
+      get :status, params: { reference: "123" }
+
+      expect(response).to have_http_status :unauthorized
     end
   end
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Submission do
+  describe "#emailed?" do
+    context "when the submission has a mail_message_id" do
+      it "returns true" do
+        described_class.create!(reference: "123", mail_message_id: "456")
+
+        expect(described_class).to be_emailed("123")
+      end
+    end
+
+    context "when there is a submission but no mail_message_id" do
+      it "returns false" do
+        described_class.create!(reference: "789")
+
+        expect(described_class).not_to be_emailed("789")
+      end
+    end
+
+    context "when there is no submission" do
+      it "returns false" do
+        expect(described_class).not_to be_emailed("999")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ZKseq4XJ/2157-add-e2e-test-for-sending-file-as-an-email-attachment

## What

Adds an endpoint that returns if a submission was emailed (via SES) for a given reference.

## Why

As part of e2e testing of File Upload. We have no way of checking that the email with attachment was sent from the e2e testing point of view. 

Having a way to check the status of submissions could also feed into monitoring.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
