### PR TITLE
Use sent at date for deleting submissions

### DIFF
--- a/app/jobs/delete_submissions_job.rb
+++ b/app/jobs/delete_submissions_job.rb
@@ -5,9 +5,8 @@ class DeleteSubmissionsJob < ApplicationJob
     CloudWatchService.log_job_started(self.class.name)
     CurrentJobLoggingAttributes.job_id = job_id
 
-    delete_submissions_updated_before_time = Settings.retain_submissions_for_seconds.seconds.ago
-    submissions_to_delete = Submission.where(updated_at: ..delete_submissions_updated_before_time)
-                                      .where.not(mail_message_id: nil)
+    delete_submissions_sent_before_time = Settings.retain_submissions_for_seconds.seconds.ago
+    submissions_to_delete = Submission.where(sent_at: ..delete_submissions_sent_before_time)
                                       .where.not(mail_status: "bounced")
 
     submissions_to_delete.find_each { |submission| delete_submission_data(submission) }

--- a/app/jobs/send_submission_job.rb
+++ b/app/jobs/send_submission_job.rb
@@ -22,7 +22,11 @@ class SendSubmissionJob < ApplicationJob
       mailer_options:,
     ).submit
 
-    submission.update!(mail_message_id: message_id, mail_status: "pending")
+    submission.update!(
+      mail_message_id: message_id,
+      mail_status: "pending",
+      sent_at: Time.zone.now,
+    )
 
     milliseconds_since_scheduled = (Time.current - scheduled_at_or_enqueued_at).in_milliseconds.round
     EventLogger.log_form_event("submission_email_sent", { milliseconds_since_scheduled: })

--- a/db/migrate/20250325180020_add_sent_at_to_submissions.rb
+++ b/db/migrate/20250325180020_add_sent_at_to_submissions.rb
@@ -1,0 +1,6 @@
+class AddSentAtToSubmissions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :submissions, :sent_at, :datetime
+    add_index :submissions, :sent_at
+  end
+end

--- a/db/migrate/20250325180117_remove_index_on_updated_at_from_submissions.rb
+++ b/db/migrate/20250325180117_remove_index_on_updated_at_from_submissions.rb
@@ -1,0 +1,5 @@
+class RemoveIndexOnUpdatedAtFromSubmissions < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :submissions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_25_115856) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_25_180117) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -24,7 +24,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_25_115856) do
     t.string "mode"
     t.jsonb "form_document"
     t.string "mail_status", default: "pending", null: false
+    t.datetime "sent_at"
     t.index ["mail_message_id"], name: "index_submissions_on_mail_message_id"
-    t.index ["updated_at"], name: "index_submissions_on_updated_at"
+    t.index ["sent_at"], name: "index_submissions_on_sent_at"
   end
 end

--- a/spec/jobs/send_submission_job_spec.rb
+++ b/spec/jobs/send_submission_job_spec.rb
@@ -1,5 +1,6 @@
 require "rails_helper"
 
+# rubocop:disable RSpec/InstanceVariable
 RSpec.describe SendSubmissionJob, type: :job do
   include ActiveJob::TestHelper
 
@@ -33,6 +34,7 @@ RSpec.describe SendSubmissionJob, type: :job do
 
       described_class.perform_later(submission)
       travel 5.seconds do
+        @job_ran_at = Time.zone.now
         perform_enqueued_jobs
       end
     end
@@ -47,6 +49,10 @@ RSpec.describe SendSubmissionJob, type: :job do
 
     it "updates the submission mail status to pending" do
       expect(Submission.last).to have_attributes(mail_status: "pending")
+    end
+
+    it "updates the sent at time" do
+      expect(submission.reload.sent_at).to be_within(1.second).of(@job_ran_at)
     end
 
     it "sends cloudwatch metric for the submission being sent" do
@@ -107,3 +113,4 @@ RSpec.describe SendSubmissionJob, type: :job do
     end
   end
 end
+# rubocop:enable RSpec/InstanceVariable

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -162,7 +162,8 @@ RSpec.describe FormSubmissionService do
           }.to change(Submission, :count).by(1)
 
           expect(Submission.last).to have_attributes(reference:, form_id: form.id, answers: answers.deep_stringify_keys,
-                                                     mode: "live", mail_message_id: nil, form_document: form_document)
+                                                     mode: "live", mail_message_id: nil, form_document: form_document,
+                                                     sent_at: nil)
         end
       end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/Qf0gkFUE/2155-handle-bounced-submission-emails

We were relying on the updated_at to decide when to delete a Submission. However, we're now updating the Submission record when we get notification via SNS that a submission has been successfully delivered. We don't know how long it will take to get and process this notifaction, and we don't want to delay deleting submission past our 7 day retention period.

Instead, store a `sent_at` date and use that to decide when to delete submissions.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
