### PR TITLE
Add metric when jobs for processing SQS messages are run

### DIFF
--- a/app/jobs/receive_submission_bounces_and_complaints_job.rb
+++ b/app/jobs/receive_submission_bounces_and_complaints_job.rb
@@ -10,6 +10,7 @@ class ReceiveSubmissionBouncesAndComplaintsJob < ApplicationJob
   POLLING_PERIOD = 20
 
   def perform
+    CloudWatchService.log_job_started(self.class.name)
     CurrentJobLoggingAttributes.job_id = job_id
 
     sts_client = Aws::STS::Client.new(region: REGION)

--- a/app/jobs/receive_submission_deliveries_job.rb
+++ b/app/jobs/receive_submission_deliveries_job.rb
@@ -10,6 +10,7 @@ class ReceiveSubmissionDeliveriesJob < ApplicationJob
   POLLING_PERIOD = 20
 
   def perform
+    CloudWatchService.log_job_started(self.class.name)
     CurrentJobLoggingAttributes.job_id = job_id
 
     sts_client = Aws::STS::Client.new(region: REGION)

--- a/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
+++ b/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
@@ -48,6 +48,9 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
       allow(sqs_client).to receive(:delete_message) do
         messages.shift
       end
+
+      allow(CloudWatchService).to receive(:log_job_started)
+
       Rails.logger.broadcast_to logger
     end
 
@@ -68,6 +71,11 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
       it "clears the SQS queue" do
         perform_enqueued_jobs
         expect(sqs_client).to have_received(:delete_message).exactly(message_count).times
+      end
+
+      it "sends cloudwatch metric" do
+        perform_enqueued_jobs
+        expect(CloudWatchService).to have_received(:log_job_started).with("ReceiveSubmissionBouncesAndComplaintsJob")
       end
     end
 

--- a/spec/jobs/receive_submission_deliveries_job_spec.rb
+++ b/spec/jobs/receive_submission_deliveries_job_spec.rb
@@ -48,6 +48,9 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
       allow(sqs_client).to receive(:delete_message) do
         messages.shift
       end
+
+      allow(CloudWatchService).to receive(:log_job_started)
+
       Rails.logger.broadcast_to logger
     end
 
@@ -68,6 +71,11 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
       it "clears the SQS queue" do
         perform_enqueued_jobs
         expect(sqs_client).to have_received(:delete_message).exactly(message_count).times
+      end
+
+      it "sends cloudwatch metric" do
+        perform_enqueued_jobs
+        expect(CloudWatchService).to have_received(:log_job_started).with("ReceiveSubmissionDeliveriesJob")
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/sSfVKcbD/2143-set-up-monitoring-and-observability-for-ses-file-upload-submissions

Add a metric that sends a count every time the job is run for both the ReceiveSubmissionBouncesAndComplaintsJob and the
ReceiveSubmissionDeliveriesJob. We will use this to alert if these jobs aren't run in the expected timeframe.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
