### PR TITLE
Put CSV file in folder for submissions to s3

### DIFF
--- a/app/services/s3_submission_service.rb
+++ b/app/services/s3_submission_service.rb
@@ -63,6 +63,6 @@ private
   def key_name
     folder = @is_preview ? "test_form_submissions" : "form_submissions"
     formatted_timestamp = @timestamp.utc.strftime("%Y%m%dT%H%M%SZ")
-    "#{folder}/#{@form.id}/#{formatted_timestamp}_#{@submission_reference}.csv"
+    "#{folder}/#{@form.id}/#{formatted_timestamp}_#{@submission_reference}/form_submission.csv"
   end
 end

--- a/spec/services/s3_submission_service_spec.rb
+++ b/spec/services/s3_submission_service_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe S3SubmissionService do
 
       it "calls put_object" do
         expected_timestamp = "20220914T072434Z"
-        expected_key_name = "form_submissions/#{form.id}/#{expected_timestamp}_#{submission_reference}.csv"
+        expected_key_name = "form_submissions/#{form.id}/#{expected_timestamp}_#{submission_reference}/form_submission.csv"
         expect(mock_s3_client).to have_received(:put_object).with(
           body: file_body,
           bucket: s3_bucket_name,
@@ -79,7 +79,7 @@ RSpec.describe S3SubmissionService do
 
         it "calls put_object with a key starting with 'test_form_submissions/'" do
           expected_timestamp = "20220914T072434Z"
-          expected_key_name = "test_form_submissions/#{form.id}/#{expected_timestamp}_#{submission_reference}.csv"
+          expected_key_name = "test_form_submissions/#{form.id}/#{expected_timestamp}_#{submission_reference}/form_submission.csv"
           expect(mock_s3_client).to have_received(:put_object).with(
             body: file_body,
             bucket: s3_bucket_name,


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/6GaKpHgH/2172-decide-how-we-will-handle-including-uploaded-files-in-submissions-to-s3

To get ready for supporting file upload for S3 submissions, put the CSV file in a "folder" in S3 for the submission, which will also contain the associated uploaded files if the form has file upload questions, when we're supporting this.

The structure will look like:

```
form_submissions/<form_id>/
|- <timestamp>_<reference>/
| |- an_uploaded_file.jpg
| |- another_file_maybe.pdf
| |- form_submission.csv
```

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
