### PR TITLE
Include `preview` flag on log lines

### DIFF
--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -19,6 +19,7 @@ module Forms
     def set_request_logging_attributes
       super
       CurrentRequestLoggingAttributes.form_name = current_form.name
+      CurrentRequestLoggingAttributes.preview = mode.preview?
     end
 
   private

--- a/app/models/current_request_logging_attributes.rb
+++ b/app/models/current_request_logging_attributes.rb
@@ -1,5 +1,5 @@
 class CurrentRequestLoggingAttributes < ActiveSupport::CurrentAttributes
-  attribute :request_host, :request_id, :form_id, :form_name, :page_id, :page_slug, :session_id_hash, :trace_id,
+  attribute :request_host, :request_id, :form_id, :form_name, :preview, :page_id, :page_slug, :session_id_hash, :trace_id,
             :question_number, :submission_reference, :submission_email_reference, :submission_email_id,
             :confirmation_email_reference, :confirmation_email_id, :rescued_exception, :rescued_exception_trace
 
@@ -9,6 +9,7 @@ class CurrentRequestLoggingAttributes < ActiveSupport::CurrentAttributes
       request_id:,
       form_id:,
       form_name:,
+      preview: preview.to_s,
       page_id:,
       page_slug:,
       session_id_hash:,

--- a/spec/models/current_request_logging_attributes_spec.rb
+++ b/spec/models/current_request_logging_attributes_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe CurrentRequestLoggingAttributes, type: :model do
       current.request_id = "a-request-id"
       current.form_id = 1
       current.form_name = "A form"
+      current.preview = false
       current.page_id = 2
       current.page_slug = "a-page"
       current.session_id_hash = "a-session-id"
@@ -35,6 +36,7 @@ RSpec.describe CurrentRequestLoggingAttributes, type: :model do
         request_id: "a-request-id",
         form_id: 1,
         form_name: "A form",
+        preview: "false",
         page_id: 2,
         page_slug: "a-page",
         session_id_hash: "a-session-id",

--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -94,6 +94,10 @@ RSpec.describe Forms::BaseController, type: :request do
       expect(log_lines[0]["form_id"]).to eq(form_id.to_s)
     end
 
+    it "includes preview bool on log lines" do
+      expect(log_lines[0]["preview"]).to eq("false")
+    end
+
     it "includes the trace ID on log lines" do
       expect(log_lines[0]["trace_id"]).to eq(trace_id)
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Include a `preview` flag that indicates whether the form is being filled out in preview mode or not. Most events we don't log in preview mode, but it's useful to know for the logs that we do have so we can exclude preview submissions from certain dashboards and reports.

Include it as a string rather than a boolean because otherwise we strip it out in the logger if it's set to false.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
