### PR TITLE
Align submission emails sent via SES with Notify template

### DIFF
--- a/app/mailers/aws_ses_form_submission_mailer.rb
+++ b/app/mailers/aws_ses_form_submission_mailer.rb
@@ -7,12 +7,20 @@ class AwsSesFormSubmissionMailer < ApplicationMailer
     @answer_content_html = answer_content_html
     @answer_content_plain_text = answer_content_plain_text
     @mailer_options = mailer_options
-    @subject = I18n.t("mailer.submission.subject", form_title: mailer_options.title, reference: mailer_options.submission_reference)
+    @subject = email_subject
 
     files.each do |name, file|
       attachments[name] = file
     end
 
     mail(to: submission_email_address, subject: @subject)
+  end
+
+private
+
+  def email_subject
+    return I18n.t("mailer.submission.subject_preview", form_title: @mailer_options.title, reference: @mailer_options.submission_reference) if @mailer_options.is_preview
+
+    I18n.t("mailer.submission.subject", form_title: @mailer_options.title, reference: @mailer_options.submission_reference)
   end
 end

--- a/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
@@ -12,6 +12,13 @@
 <p>
   <%= I18n.t("mailer.submission.reference", submission_reference: @mailer_options.submission_reference) %>
 </p>
+
+<% if @mailer_options.payment_url.present? %>
+  <p>
+    <%= I18n.t("mailer.submission.payment") %>
+  </p>
+<% end %>
+
 <p style="margin: 0 0 20px 0; border-left: 10px solid #B1B4B6; padding: 15px;">
   <%= I18n.t("mailer.submission.check_before_using") %>
 </p>

--- a/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
@@ -1,5 +1,10 @@
 <p>
-  <%= I18n.t("mailer.submission.title", title: @mailer_options.title) %>
+  <%= if @mailer_options.is_preview
+        I18n.t("mailer.submission.title_preview", title: @mailer_options.title)
+      else
+        I18n.t("mailer.submission.title", title: @mailer_options.title)
+      end
+  %>
 </p>
 <p>
   <%= I18n.t("mailer.submission.time", time: @mailer_options.timestamp.strftime("%l:%M%P").strip, date: @mailer_options.timestamp.strftime("%-d %B %Y") ) %>

--- a/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
@@ -9,6 +9,10 @@
 
 <%= I18n.t("mailer.submission.reference", submission_reference: @mailer_options.submission_reference) %>
 
+<% if @mailer_options.payment_url.present? %>
+<%= I18n.t("mailer.submission.payment") %>
+
+<% end %>
 <%= I18n.t("mailer.submission.check_before_using") %>
 
 ---

--- a/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
@@ -1,4 +1,9 @@
-<%= I18n.t("mailer.submission.title", title: @mailer_options.title) %>
+<%= if @mailer_options.is_preview
+      I18n.t("mailer.submission.title_preview", title: @mailer_options.title)
+    else
+      I18n.t("mailer.submission.title", title: @mailer_options.title)
+    end
+%>
 
 <%= I18n.t("mailer.submission.time", time: @mailer_options.timestamp.strftime("%l:%M%P").strip, date: @mailer_options.timestamp.strftime("%-d %B %Y") ) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,6 +201,7 @@ en:
       check_before_using: Check that this data looks safe before you use it
       file_attached: "%{filename} (attached to this email)"
       from: GOV.UK Forms <%{email_address}>
+      payment: You can check that a payment has been made by using this reference number to search transactions within GOV.​UK Pay.
       reference: 'GOV.​UK Forms reference number: %{submission_reference}'
       subject: 'Form submission: %{form_title} - reference: %{reference}'
       subject_preview: 'TEST FORM SUBMISSION: %{form_title} - reference: %{reference}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -203,6 +203,7 @@ en:
       from: GOV.UK Forms <%{email_address}>
       reference: 'GOV.​UK Forms reference number: %{submission_reference}'
       subject: 'Form submission: %{form_title} - reference: %{reference}'
+      subject_preview: 'TEST FORM SUBMISSION: %{form_title} - reference: %{reference}'
       time: This form was submitted at %{time} on %{date}
       title: This is a completed “%{title}” form.
   mode:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,6 +206,7 @@ en:
       subject_preview: 'TEST FORM SUBMISSION: %{form_title} - reference: %{reference}'
       time: This form was submitted at %{time} on %{date}
       title: This is a completed “%{title}” form.
+      title_preview: This is a test of the “%{title}” form.
   mode:
     phase_banner_tag_preview-archived: Archived preview
     phase_banner_tag_preview-draft: Draft preview

--- a/spec/mailers/aws_ses_form_submission_mailer_preview.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_preview.rb
@@ -10,4 +10,16 @@ class AwsSesFormSubmissionMailerPreview < ActionMailer::Preview
                                                                                                          payment_url: nil),
                                                 files: {})
   end
+
+  def preview_submission_email
+    AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
+                                                answer_content_plain_text: "## What's your email address?\n\nforms@example.gov.uk",
+                                                submission_email_address: "testing@gov.uk",
+                                                mailer_options: FormSubmissionService::MailerOptions.new(title: "Form 1",
+                                                                                                         is_preview: true,
+                                                                                                         timestamp: Time.zone.now,
+                                                                                                         submission_reference: Faker::Alphanumeric.alphanumeric(number: 8).upcase,
+                                                                                                         payment_url: nil),
+                                                files: {})
+  end
 end

--- a/spec/mailers/aws_ses_form_submission_mailer_preview.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_preview.rb
@@ -22,4 +22,16 @@ class AwsSesFormSubmissionMailerPreview < ActionMailer::Preview
                                                                                                          payment_url: nil),
                                                 files: {})
   end
+
+  def submission_email_with_payment_link
+    AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
+                                                answer_content_plain_text: "## What's your email address?\n\nforms@example.gov.uk",
+                                                submission_email_address: "testing@gov.uk",
+                                                mailer_options: FormSubmissionService::MailerOptions.new(title: "Form 1",
+                                                                                                         is_preview: true,
+                                                                                                         timestamp: Time.zone.now,
+                                                                                                         submission_reference: Faker::Alphanumeric.alphanumeric(number: 8).upcase,
+                                                                                                         payment_url: "https://www.gov.uk/payments/your-payment-link"),
+                                                files: {})
+  end
 end

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -160,6 +160,44 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
         end
       end
     end
+
+    context "when the form has a payment link" do
+      let(:payment_url) { "payment_url" }
+
+      describe "the html part" do
+        let(:part) { mail.html_part }
+
+        it "includes text about the payment" do
+          expect(part.body).to have_css("p", text: I18n.t("mailer.submission.payment"))
+        end
+      end
+
+      describe "the plaintext part" do
+        let(:part) { mail.text_part }
+
+        it "includes text about the payment" do
+          expect(part.body).to have_text(I18n.t("mailer.submission.payment"))
+        end
+      end
+    end
+
+    context "when the form does not have a payment link" do
+      describe "the html part" do
+        let(:part) { mail.html_part }
+
+        it "does not include text about the payment" do
+          expect(part.body).not_to have_css("p", text: I18n.t("mailer.submission.payment"))
+        end
+      end
+
+      describe "the plaintext part" do
+        let(:part) { mail.text_part }
+
+        it "does not include text about the payment" do
+          expect(part.body).not_to have_text(I18n.t("mailer.submission.payment"))
+        end
+      end
+    end
   end
 
   context "when files to attach are included in the arguments" do

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -28,7 +28,7 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
         expect(mail.subject).to eq("Form submission: #{title} - reference: #{submission_reference}")
       end
 
-      context "when looking at the html part" do
+      describe "the html part" do
         let(:part) { mail.html_part }
 
         it "has a link to GOV.UK" do
@@ -84,7 +84,7 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
         end
       end
 
-      context "when looking at the plaintext part" do
+      describe "the plaintext part" do
         let(:part) { mail.text_part }
 
         it "includes the answers" do
@@ -142,6 +142,22 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
 
       it "sets the subject" do
         expect(mail.subject).to eq("TEST FORM SUBMISSION: #{title} - reference: #{submission_reference}")
+      end
+
+      describe "the html part" do
+        let(:part) { mail.html_part }
+
+        it "includes the form title text" do
+          expect(part.body).to have_css("p", text: I18n.t("mailer.submission.title_preview", title:))
+        end
+      end
+
+      describe "the plaintext part" do
+        let(:part) { mail.text_part }
+
+        it "includes the form title text" do
+          expect(part.body).to have_text(I18n.t("mailer.submission.title_preview", title:))
+        end
       end
     end
   end

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -19,119 +19,129 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
   end
 
   context "when form filler submits a completed form" do
-    it "sends an email to the form's submission email address" do
-      expect(mail.to).to eq([submission_email_address])
+    context "when form is not in preview" do
+      it "sends an email to the form's submission email address" do
+        expect(mail.to).to eq([submission_email_address])
+      end
+
+      it "sets the subject" do
+        expect(mail.subject).to eq("Form submission: #{title} - reference: #{submission_reference}")
+      end
+
+      context "when looking at the html part" do
+        let(:part) { mail.html_part }
+
+        it "has a link to GOV.UK" do
+          expect(part.body).to have_link("GOV.UK", href: "https://www.gov.uk")
+        end
+
+        it "includes the answers" do
+          expect(part.body).to match(answer_content_html)
+        end
+
+        it "includes the form title text" do
+          expect(part.body).to have_css("p", text: I18n.t("mailer.submission.title", title:))
+        end
+
+        it "includes text about the submission time" do
+          expect(part.body).to have_css("p", text: I18n.t("mailer.submission.time", time: submission_timestamp.strftime("%l:%M%P").strip, date: submission_timestamp.strftime("%-d %B %Y")))
+        end
+
+        it "includes the submission reference" do
+          expect(part.body).to have_css("p", text: I18n.t("mailer.submission.reference", submission_reference:))
+        end
+
+        it "includes text about checking the answers" do
+          expect(part.body).to have_css("p", text: I18n.t("mailer.submission.check_before_using"))
+        end
+
+        it "includes the warning about not replying" do
+          expect(part.body).to have_css("h2", text: I18n.t("mailer.submission.cannot_reply.heading"))
+          expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_form_filler_html"))
+          expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_forms_team_html"))
+        end
+
+        describe "submission date/time" do
+          context "with a time in BST" do
+            let(:timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0) }
+
+            it "includes the date and time the user submitted the form" do
+              travel_to timestamp do
+                expect(part.body).to match("This form was submitted at 9:00am on 14 September 2022")
+              end
+            end
+          end
+
+          context "with a time in GMT" do
+            let(:timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
+
+            it "includes the date and time the user submitted the form" do
+              travel_to timestamp do
+                expect(part.body).to match("This form was submitted at 1:00pm on 14 December 2022")
+              end
+            end
+          end
+        end
+      end
+
+      context "when looking at the plaintext part" do
+        let(:part) { mail.text_part }
+
+        it "includes the answers" do
+          expect(part.body).to match(answer_content_plain_text)
+        end
+
+        it "includes the form title text" do
+          expect(part.body).to have_text(I18n.t("mailer.submission.title", title:))
+        end
+
+        it "includes text about the submission time" do
+          expect(part.body).to have_text(I18n.t("mailer.submission.time", time: submission_timestamp.strftime("%l:%M%P").strip, date: submission_timestamp.strftime("%-d %B %Y")))
+        end
+
+        it "includes the submission reference" do
+          expect(part.body).to have_text(I18n.t("mailer.submission.reference", submission_reference:))
+        end
+
+        it "includes text about checking the answers" do
+          expect(part.body).to have_text(I18n.t("mailer.submission.check_before_using"))
+        end
+
+        it "includes the warning about not replying" do
+          expect(part.body).to have_text(I18n.t("mailer.submission.cannot_reply.heading"))
+          expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_form_filler_plain"))
+          expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_forms_team_plain"))
+        end
+
+        describe "submission date/time" do
+          context "with a time in BST" do
+            let(:timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0) }
+
+            it "includes the date and time the user submitted the form" do
+              travel_to timestamp do
+                expect(part.body).to match("This form was submitted at 9:00am on 14 September 2022")
+              end
+            end
+          end
+
+          context "with a time in GMT" do
+            let(:timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
+
+            it "includes the date and time the user submitted the form" do
+              travel_to timestamp do
+                expect(part.body).to match("This form was submitted at 1:00pm on 14 December 2022")
+              end
+            end
+          end
+        end
+      end
     end
 
-    it "sets the subject" do
-      expect(mail.subject).to eq("Form submission: #{title} - reference: #{submission_reference}")
-    end
+    context "when form is in preview" do
+      let(:is_preview) { true }
 
-    context "when looking at the html part" do
-      let(:part) { mail.html_part }
-
-      it "has a link to GOV.UK" do
-        expect(part.body).to have_link("GOV.UK", href: "https://www.gov.uk")
-      end
-
-      it "includes the answers" do
-        expect(part.body).to match(answer_content_html)
-      end
-
-      it "includes the form title text" do
-        expect(part.body).to have_css("p", text: I18n.t("mailer.submission.title", title:))
-      end
-
-      it "includes text about the submission time" do
-        expect(part.body).to have_css("p", text: I18n.t("mailer.submission.time", time: submission_timestamp.strftime("%l:%M%P").strip, date: submission_timestamp.strftime("%-d %B %Y")))
-      end
-
-      it "includes the submission reference" do
-        expect(part.body).to have_css("p", text: I18n.t("mailer.submission.reference", submission_reference:))
-      end
-
-      it "includes text about checking the answers" do
-        expect(part.body).to have_css("p", text: I18n.t("mailer.submission.check_before_using"))
-      end
-
-      it "includes the warning about not replying" do
-        expect(part.body).to have_css("h2", text: I18n.t("mailer.submission.cannot_reply.heading"))
-        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_form_filler_html"))
-        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_forms_team_html"))
-      end
-
-      describe "submission date/time" do
-        context "with a time in BST" do
-          let(:timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0) }
-
-          it "includes the date and time the user submitted the form" do
-            travel_to timestamp do
-              expect(part.body).to match("This form was submitted at 9:00am on 14 September 2022")
-            end
-          end
-        end
-
-        context "with a time in GMT" do
-          let(:timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
-
-          it "includes the date and time the user submitted the form" do
-            travel_to timestamp do
-              expect(part.body).to match("This form was submitted at 1:00pm on 14 December 2022")
-            end
-          end
-        end
-      end
-    end
-
-    context "when looking at the plaintext part" do
-      let(:part) { mail.text_part }
-
-      it "includes the answers" do
-        expect(part.body).to match(answer_content_plain_text)
-      end
-
-      it "includes the form title text" do
-        expect(part.body).to have_text(I18n.t("mailer.submission.title", title:))
-      end
-
-      it "includes text about the submission time" do
-        expect(part.body).to have_text(I18n.t("mailer.submission.time", time: submission_timestamp.strftime("%l:%M%P").strip, date: submission_timestamp.strftime("%-d %B %Y")))
-      end
-
-      it "includes the submission reference" do
-        expect(part.body).to have_text(I18n.t("mailer.submission.reference", submission_reference:))
-      end
-
-      it "includes text about checking the answers" do
-        expect(part.body).to have_text(I18n.t("mailer.submission.check_before_using"))
-      end
-
-      it "includes the warning about not replying" do
-        expect(part.body).to have_text(I18n.t("mailer.submission.cannot_reply.heading"))
-        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_form_filler_plain"))
-        expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_forms_team_plain"))
-      end
-
-      describe "submission date/time" do
-        context "with a time in BST" do
-          let(:timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0) }
-
-          it "includes the date and time the user submitted the form" do
-            travel_to timestamp do
-              expect(part.body).to match("This form was submitted at 9:00am on 14 September 2022")
-            end
-          end
-        end
-
-        context "with a time in GMT" do
-          let(:timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
-
-          it "includes the date and time the user submitted the form" do
-            travel_to timestamp do
-              expect(part.body).to match("This form was submitted at 1:00pm on 14 December 2022")
-            end
-          end
-        end
+      it "sets the subject" do
+        expect(mail.subject).to eq("TEST FORM SUBMISSION: #{title} - reference: #{submission_reference}")
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/C8KYvyW8

This PR does most of the work to align the submission emails sent via AWS SES with the Notify submission email template, excluding adding content when a CSV is attached. This will follow in a subsequent PR.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
