### PR TITLE
Add SES submissions feature flag

### DIFF
--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -40,9 +40,14 @@ private
 
   def submit_using_form_submission_type
     return s3_submission_service.submit if @form.submission_type == "s3"
-    return submit_via_aws_ses if @form.has_file_upload_question?
 
-    notify_submission_service.submit
+    if FeatureService.enabled?(:ses_submissions)
+      submit_via_aws_ses
+    else
+      return submit_via_aws_ses if @form.has_file_upload_question?
+
+      notify_submission_service.submit
+    end
   end
 
   def submit_confirmation_email_to_user
@@ -78,14 +83,6 @@ private
       timestamp: @timestamp,
       submission_reference: @submission_reference,
       is_preview: @mode.preview?,
-    )
-  end
-
-  def aws_ses_submission_service
-    AwsSesSubmissionService.new(
-      journey: @current_context.journey,
-      form: @form,
-      mailer_options:,
     )
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,5 @@
-features: {}
+features:
+  ses_submissions: false
 
 forms_admin:
   # URL to form-admin

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -22,7 +22,7 @@ describe "Settings" do
     it "has a default value" do
       features = settings[:features]
 
-      expect(features).to eq({})
+      expect(features).to eq({ "ses_submissions" => false })
     end
   end
 

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -101,106 +101,207 @@ RSpec.describe FormSubmissionService do
     end
 
     describe "submitting the form to the processing team" do
-      context "when the submission type is email" do
-        let(:submission_type) { "email" }
+      context "when the SES submissions feature is disabled", feature_ses_submissions: false do
+        context "when the submission type is email" do
+          let(:submission_type) { "email" }
 
-        it "calls NotifySubmissionService to submit the form" do
-          service.submit
-          expect(notify_submission_service_spy).to have_received(:submit)
-        end
-      end
-
-      context "when the submission type is email_with_csv" do
-        let(:submission_type) { "email_with_csv" }
-
-        it "calls NotifySubmissionService to submit the form" do
-          service.submit
-          expect(notify_submission_service_spy).to have_received(:submit)
-        end
-
-        include_examples "logging"
-      end
-
-      context "when the form has a file upload question" do
-        let(:pages) { [build(:page, id: 2, answer_type: "file")] }
-        let(:aws_ses_submission_service_spy) { instance_double(AwsSesSubmissionService) }
-        let(:mail_message_id) { "1234" }
-
-        let(:req_headers) do
-          {
-            "X-API-Token" => Settings.forms_api.auth_key,
-            "Accept" => "application/json",
-          }
-        end
-
-        before do
-          ActiveResource::HttpMock.respond_to do |mock|
-            mock.get "/api/v2/forms/1/live", req_headers, form.to_json, 200
-          end
-
-          allow(Flow::Journey).to receive(:new)
-
-          allow(AwsSesSubmissionService).to receive(:new).and_return(aws_ses_submission_service_spy)
-          allow(aws_ses_submission_service_spy).to receive(:submit).and_return(mail_message_id)
-        end
-
-        it "enqueues a job to send the submission" do
-          assert_enqueued_with(job: SendSubmissionJob) do
+          it "calls NotifySubmissionService to submit the form" do
             service.submit
-          end
-
-          expect(aws_ses_submission_service_spy).not_to have_received(:submit)
-
-          perform_enqueued_jobs
-
-          expect(aws_ses_submission_service_spy).to have_received(:submit)
-        end
-
-        it "saves the submission data" do
-          expect {
-            service.submit
-          }.to change(Submission, :count).by(1)
-
-          expect(Submission.last).to have_attributes(reference:, form_id: form.id, answers: answers.deep_stringify_keys,
-                                                     mode: "live", mail_message_id: nil, form_document: form_document,
-                                                     sent_at: nil)
-        end
-      end
-
-      context "when the submission type is s3" do
-        let(:submission_type) { "s3" }
-        let(:s3_submission_service_spy) { instance_double(S3SubmissionService) }
-
-        before do
-          allow(S3SubmissionService).to receive(:new).and_return(s3_submission_service_spy)
-          allow(s3_submission_service_spy).to receive("submit")
-        end
-
-        it "creates a S3SubmissionService instance" do
-          freeze_time do
-            service.submit
-
-            expect(S3SubmissionService).to have_received(:new).with(
-              journey:,
-              form:,
-              timestamp: Time.zone.now,
-              submission_reference: reference,
-              is_preview: mode.preview?,
-            ).once
+            expect(notify_submission_service_spy).to have_received(:submit)
           end
         end
 
-        it "calls upload_submission_csv_to_s3" do
-          service.submit
-          expect(s3_submission_service_spy).to have_received(:submit)
+        context "when the submission type is email_with_csv" do
+          let(:submission_type) { "email_with_csv" }
+
+          it "calls NotifySubmissionService to submit the form" do
+            service.submit
+            expect(notify_submission_service_spy).to have_received(:submit)
+          end
+
+          include_examples "logging"
         end
 
-        it "does not call NotifySubmissionService to submit the form" do
-          service.submit
-          expect(notify_submission_service_spy).not_to have_received(:submit)
+        context "when the form has a file upload question" do
+          let(:pages) { [build(:page, id: 2, answer_type: "file")] }
+          let(:aws_ses_submission_service_spy) { instance_double(AwsSesSubmissionService) }
+          let(:mail_message_id) { "1234" }
+
+          let(:req_headers) do
+            {
+              "X-API-Token" => Settings.forms_api.auth_key,
+              "Accept" => "application/json",
+            }
+          end
+
+          before do
+            ActiveResource::HttpMock.respond_to do |mock|
+              mock.get "/api/v2/forms/1/live", req_headers, form.to_json, 200
+            end
+
+            allow(Flow::Journey).to receive(:new)
+
+            allow(AwsSesSubmissionService).to receive(:new).and_return(aws_ses_submission_service_spy)
+            allow(aws_ses_submission_service_spy).to receive(:submit).and_return(mail_message_id)
+          end
+
+          it "enqueues a job to send the submission" do
+            assert_enqueued_with(job: SendSubmissionJob) do
+              service.submit
+            end
+
+            expect(aws_ses_submission_service_spy).not_to have_received(:submit)
+
+            perform_enqueued_jobs
+
+            expect(aws_ses_submission_service_spy).to have_received(:submit)
+          end
+
+          it "saves the submission data" do
+            expect {
+              service.submit
+            }.to change(Submission, :count).by(1)
+
+            expect(Submission.last).to have_attributes(reference:, form_id: form.id, answers: answers.deep_stringify_keys,
+                                                       mode: "live", mail_message_id: nil, form_document: form_document,
+                                                       sent_at: nil)
+          end
         end
 
-        include_examples "logging"
+        context "when the submission type is s3" do
+          let(:submission_type) { "s3" }
+          let(:s3_submission_service_spy) { instance_double(S3SubmissionService) }
+
+          before do
+            allow(S3SubmissionService).to receive(:new).and_return(s3_submission_service_spy)
+            allow(s3_submission_service_spy).to receive("submit")
+          end
+
+          it "creates a S3SubmissionService instance" do
+            freeze_time do
+              service.submit
+
+              expect(S3SubmissionService).to have_received(:new).with(
+                journey:,
+                form:,
+                timestamp: Time.zone.now,
+                submission_reference: reference,
+                is_preview: mode.preview?,
+              ).once
+            end
+          end
+
+          it "calls upload_submission_csv_to_s3" do
+            service.submit
+            expect(s3_submission_service_spy).to have_received(:submit)
+          end
+
+          it "does not call NotifySubmissionService to submit the form" do
+            service.submit
+            expect(notify_submission_service_spy).not_to have_received(:submit)
+          end
+
+          include_examples "logging"
+        end
+      end
+
+      context "when the SES submissions feature is enabled", :feature_ses_submissions do
+        shared_examples "submits via AWS SES" do
+          let(:aws_ses_submission_service_spy) { instance_double(AwsSesSubmissionService) }
+          let(:mail_message_id) { "1234" }
+
+          let(:req_headers) do
+            {
+              "X-API-Token" => Settings.forms_api.auth_key,
+              "Accept" => "application/json",
+            }
+          end
+
+          before do
+            ActiveResource::HttpMock.respond_to do |mock|
+              mock.get "/api/v2/forms/1/live", req_headers, form.to_json, 200
+            end
+
+            allow(Flow::Journey).to receive(:new)
+
+            allow(AwsSesSubmissionService).to receive(:new).and_return(aws_ses_submission_service_spy)
+            allow(aws_ses_submission_service_spy).to receive(:submit).and_return(mail_message_id)
+          end
+
+          it "enqueues a job to send the submission" do
+            assert_enqueued_with(job: SendSubmissionJob) do
+              service.submit
+            end
+
+            expect(aws_ses_submission_service_spy).not_to have_received(:submit)
+
+            perform_enqueued_jobs
+
+            expect(aws_ses_submission_service_spy).to have_received(:submit)
+          end
+
+          it "saves the submission data" do
+            expect {
+              service.submit
+            }.to change(Submission, :count).by(1)
+
+            expect(Submission.last).to have_attributes(reference:, form_id: form.id, answers: answers.deep_stringify_keys,
+                                                       mode: "live", mail_message_id: nil, form_document: form_document,
+                                                       sent_at: nil)
+          end
+        end
+
+        context "when the submission type is email" do
+          let(:submission_type) { "email" }
+
+          include_examples "submits via AWS SES"
+
+          include_examples "logging"
+        end
+
+        context "when the submission type is email_with_csv" do
+          let(:submission_type) { "email_with_csv" }
+
+          include_examples "submits via AWS SES"
+
+          include_examples "logging"
+        end
+
+        context "when the submission type is s3" do
+          let(:submission_type) { "s3" }
+          let(:s3_submission_service_spy) { instance_double(S3SubmissionService) }
+
+          before do
+            allow(S3SubmissionService).to receive(:new).and_return(s3_submission_service_spy)
+            allow(s3_submission_service_spy).to receive("submit")
+          end
+
+          it "creates a S3SubmissionService instance" do
+            freeze_time do
+              service.submit
+
+              expect(S3SubmissionService).to have_received(:new).with(
+                journey:,
+                form:,
+                timestamp: Time.zone.now,
+                submission_reference: reference,
+                is_preview: mode.preview?,
+              ).once
+            end
+          end
+
+          it "calls upload_submission_csv_to_s3" do
+            service.submit
+            expect(s3_submission_service_spy).to have_received(:submit)
+          end
+
+          it "does not call NotifySubmissionService to submit the form" do
+            service.submit
+            expect(notify_submission_service_spy).not_to have_received(:submit)
+          end
+
+          include_examples "logging"
+        end
       end
 
       context "when form being submitted is from previewed form" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/C8KYvyW8

This PR adds a `ses_submissions` feature flag, which when enabled sends all submission emails via AWS SES rather than via Notify. 

This PR shouldn't be merged until the CSV related content in the submission emails is updated.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
