### PR TITLE
Remove fallback to get forms from forms-api

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -12,7 +12,7 @@ class Submission < ApplicationRecord
   end
 
   def form
-    @form ||= get_form
+    @form ||= form_from_document
   end
 
   def self.emailed?(reference)
@@ -28,13 +28,6 @@ private
 
   def answer_store
     Store::DatabaseAnswerStore.new(answers)
-  end
-
-  def get_form
-    return form_from_document if form_document.present?
-
-    # We can remove this fallback when all submissions that don't have the form_document stored have been deleted
-    Api::V1::FormSnapshotRepository.find_with_mode(id: form_id, mode: mode_object)
   end
 
   def form_from_document


### PR DESCRIPTION
### What problem does this pull request solve?

For submissions sent via SES, we now store the JSON for the form document on the Submission. We left a fallback to retrieve the form from forms-api if this wasn't set so that we could successfully delete Submissions that already existed at this time. Enough time has passed for all these Submissions to have been deleted by the recurring job, so the fallback can be removed.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
