### PR TITLE
Remove unused aws_ses_submission_service method from FormSubmissionService

### DIFF
--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -81,14 +81,6 @@ private
     )
   end
 
-  def aws_ses_submission_service
-    AwsSesSubmissionService.new(
-      journey: @current_context.journey,
-      form: @form,
-      mailer_options:,
-    )
-  end
-
   def submit_via_aws_ses
     submission = Submission.create!(
       reference: @submission_reference,


### PR DESCRIPTION
This method isn't called anywhere. The "submit_via_aws_ses" method is used instead of SES submissions.