### PR TITLE
Send uploaded files with S3 submissions

### DIFF
--- a/app/lib/csv_generator.rb
+++ b/app/lib/csv_generator.rb
@@ -4,12 +4,13 @@ class CsvGenerator
   CSV_EXTENSION = ".csv".freeze
   CSV_FILENAME_PREFIX = "govuk_forms_".freeze
 
-  def self.write_submission(all_steps:, submission_reference:, timestamp:, output_file_path:)
+  def self.write_submission(all_steps:, submission_reference:, timestamp:, output_file_path:, is_s3_submission:)
     headers = ["Reference", "Submitted at"]
     values = [submission_reference, timestamp.iso8601]
     all_steps.map do |page|
-      headers.push(*page.show_answer_in_csv.keys)
-      values.push(*page.show_answer_in_csv.values)
+      answer_parts = page.show_answer_in_csv(is_s3_submission)
+      headers.push(*answer_parts.keys)
+      values.push(*answer_parts.values)
     end
 
     CSV.open(output_file_path, "w") do |csv|

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -44,12 +44,12 @@ module Question
     def show_answer_in_csv(is_s3_submission)
       return Hash[question_text, nil] if original_filename.blank?
 
-      return { question_text => name_with_filename_suffix } if is_s3_submission
+      return { question_text => filename_for_s3_submission } if is_s3_submission
 
       { question_text => email_filename }
     end
 
-    def name_with_filename_suffix
+    def filename_for_s3_submission
       extension = ::File.extname(original_filename)
 
       base_name_max_length = FILE_MAX_FILENAME_LENGTH - extension.length - filename_suffix.length

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -41,8 +41,10 @@ module Question
       I18n.t("mailer.submission.file_attached", filename: email_filename)
     end
 
-    def show_answer_in_csv
+    def show_answer_in_csv(is_s3_submission)
       return Hash[question_text, nil] if original_filename.blank?
+
+      return { question_text => name_with_filename_suffix } if is_s3_submission
 
       { question_text => email_filename }
     end

--- a/app/models/question/name.rb
+++ b/app/models/question/name.rb
@@ -53,7 +53,7 @@ module Question
       attributes_with_values.map { |attribute| generate_string_for_processing_email(attribute) }&.join("\n\n")
     end
 
-    def show_answer_in_csv
+    def show_answer_in_csv(*)
       header_values_hash = {}
       if needs_title?
         add_attribute_to_hash(:title, header_values_hash)

--- a/app/models/question/phone_number.rb
+++ b/app/models/question/phone_number.rb
@@ -13,7 +13,7 @@ module Question
     validate :phone_number, :not_enough_digits?
     validate :phone_number, :too_many_digits?
 
-    def show_answer_in_csv
+    def show_answer_in_csv(*)
       return { question_text => "" } if phone_number.blank?
       # numbers containing non-numeric characters, or starting with a non-0 digit, shouldn't need additional processing
       return { question_text => phone_number } unless phone_number.match(/^0\d*$/)

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -38,7 +38,7 @@ module Question
       show_answer
     end
 
-    def show_answer_in_csv
+    def show_answer_in_csv(*)
       Hash[question_text, show_answer]
     end
 

--- a/app/models/repeatable_step.rb
+++ b/app/models/repeatable_step.rb
@@ -85,11 +85,11 @@ class RepeatableStep < Step
     end
   end
 
-  def show_answer_in_csv
+  def show_answer_in_csv(is_s3_submission)
     if questions.present?
       header_values_hash = {}
       questions.each.with_index(1) do |question, index|
-        question.show_answer_in_csv.each do |header, value|
+        question.show_answer_in_csv(is_s3_submission:).each do |header, value|
           header_values_hash["#{header} - Answer #{index}"] = value
         end
       end

--- a/app/services/aws_ses_submission_service.rb
+++ b/app/services/aws_ses_submission_service.rb
@@ -72,6 +72,7 @@ private
       submission_reference: @mailer_options.submission_reference,
       timestamp: @mailer_options.timestamp,
       output_file_path: file.path,
+      is_s3_submission: false,
     )
   end
 

--- a/app/services/notify_submission_service.rb
+++ b/app/services/notify_submission_service.rb
@@ -59,6 +59,7 @@ private
       submission_reference: @mailer_options.submission_reference,
       timestamp: @mailer_options.timestamp,
       output_file_path: file.path,
+      is_s3_submission: false,
     )
   end
 

--- a/app/services/s3_submission_service.rb
+++ b/app/services/s3_submission_service.rb
@@ -1,5 +1,6 @@
 class S3SubmissionService
-  def initialize(journey:, form:,
+  def initialize(journey:,
+                 form:,
                  timestamp:,
                  submission_reference:,
                  is_preview:)
@@ -8,6 +9,7 @@ class S3SubmissionService
     @timestamp = timestamp
     @submission_reference = submission_reference
     @is_preview = is_preview
+    @file_upload_bucket_name = Settings.aws.file_upload_s3_bucket_name
   end
 
   def submit
@@ -15,38 +17,72 @@ class S3SubmissionService
     raise StandardError, "S3 bucket account ID is not set on the form" if @form.s3_bucket_aws_account_id.nil?
     raise StandardError, "S3 bucket region is not set on the form" if @form.s3_bucket_region.nil?
 
+    # We send the uploaded files before the submissions CSV so that processors can have automations run when the CSV
+    # file arrives and the referenced files will already be present
+    copy_uploaded_files_to_bucket
+
     # rubocop:disable Rails/SaveBang
     Tempfile.create do |file|
       write_submission_csv(file)
-      upload_file_to_s3(file.path)
+      upload_submission_csv_to_s3(file.path)
     end
     # rubocop:enable Rails/SaveBang
+
+    delete_uploaded_files_from_our_bucket
   end
 
 private
 
-  # we only need all_steps. Should we just pass this in, or are we missing something that needs completed_steps?
+  def copy_uploaded_files_to_bucket
+    @journey.completed_file_upload_questions.each(&method(:copy_file_to_bucket))
+  end
+
+  def copy_file_to_bucket(file)
+    source_key = file.uploaded_file_key
+    target_key = uploaded_file_target_key(file)
+    s3_client.copy_object({
+      bucket: @form.s3_bucket_name,
+      expected_bucket_owner: @form.s3_bucket_aws_account_id,
+      copy_source: "/#{@file_upload_bucket_name}/#{source_key}",
+      key: target_key,
+      tagging_directive: "REPLACE", # we don't want to copy tags
+    })
+    Rails.logger.info("Copied uploaded file to submission S3 bucket", {
+      source_key:,
+      target_key:,
+    })
+  end
+
+  def delete_uploaded_files_from_our_bucket
+    @journey.completed_file_upload_questions.each(&:delete_from_s3)
+  end
+
   def write_submission_csv(file)
     CsvGenerator.write_submission(
       all_steps: @journey.all_steps,
       submission_reference: @submission_reference,
       timestamp: @timestamp,
       output_file_path: file.path,
+      is_s3_submission: true,
     )
   end
 
-  def upload_file_to_s3(file_path)
-    s3 = Aws::S3::Client.new(
-      region: @form.s3_bucket_region,
-      credentials: assume_role,
-    )
-    s3.put_object({
+  def upload_submission_csv_to_s3(file_path)
+    key = csv_submission_key
+    s3_client.put_object({
       body: File.read(file_path),
       bucket: @form.s3_bucket_name,
       expected_bucket_owner: @form.s3_bucket_aws_account_id,
-      key: key_name,
+      key: key,
     })
-    Rails.logger.info("Uploaded submission to S3", { key_name: })
+    Rails.logger.info("Uploaded submission to S3", { key: })
+  end
+
+  def s3_client
+    @s3_client ||= Aws::S3::Client.new(
+      region: @form.s3_bucket_region,
+      credentials: assume_role,
+    )
   end
 
   def assume_role
@@ -60,9 +96,17 @@ private
     credentials
   end
 
-  def key_name
+  def csv_submission_key
+    generate_key("form_submission.csv")
+  end
+
+  def uploaded_file_target_key(file)
+    generate_key(file.name_with_filename_suffix)
+  end
+
+  def generate_key(filename)
     folder = @is_preview ? "test_form_submissions" : "form_submissions"
     formatted_timestamp = @timestamp.utc.strftime("%Y%m%dT%H%M%SZ")
-    "#{folder}/#{@form.id}/#{formatted_timestamp}_#{@submission_reference}/form_submission.csv"
+    "#{folder}/#{@form.id}/#{formatted_timestamp}_#{@submission_reference}/#{filename}"
   end
 end

--- a/app/services/s3_submission_service.rb
+++ b/app/services/s3_submission_service.rb
@@ -101,7 +101,7 @@ private
   end
 
   def uploaded_file_target_key(file)
-    generate_key(file.name_with_filename_suffix)
+    generate_key(file.filename_for_s3_submission)
   end
 
   def generate_key(filename)

--- a/spec/lib/csv_generator_spec.rb
+++ b/spec/lib/csv_generator_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe CsvGenerator do
   let(:page) { build :page }
   let(:text_question) { build :text, :with_answer, question_text: "What is the meaning of life?" }
   let(:name_question) { build :first_middle_last_name_question, question_text: "What is your name?" }
+  let(:file_question) { build :file, :with_uploaded_file, question_text: "Upload a file", original_filename: "test.txt" }
   let(:first_step) { build :step, question: text_question }
   let(:second_step) { build :step, question: name_question }
-  let(:all_steps) { [first_step, second_step] }
+  let(:third_step) { build :step, question: file_question }
+  let(:all_steps) { [first_step, second_step, third_step] }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
   let(:timestamp) do
     Time.use_zone("London") { Time.zone.local(2022, 9, 14, 8, 0o0, 0o0) }
@@ -20,57 +22,79 @@ RSpec.describe CsvGenerator do
   end
 
   describe "#write_submission" do
-    before do
-      described_class.write_submission(all_steps:, submission_reference:, timestamp:, output_file_path: test_file.path)
-    end
+    context "when the submission is being sent by email" do
+      before do
+        file_question.populate_email_filename(submission_reference:)
+        described_class.write_submission(all_steps:, submission_reference:, timestamp:,
+                                         output_file_path: test_file.path, is_s3_submission: false)
+      end
 
-    it "writes submission to CSV file" do
-      expect(CSV.open(test_file.path).readlines).to eq(
-        [
-          ["Reference", "Submitted at", "What is the meaning of life?", "What is your name? - First name", "What is your name? - Last name"],
-          [submission_reference, "2022-09-14T08:00:00+01:00", text_question.text, name_question.first_name, name_question.last_name],
-        ],
-      )
-    end
-
-    context "when a question is optional and answer is not provided" do
-      let(:text_question) { build :text, question_text: "What is the meaning of life?", is_optional: true, text: nil }
-
-      it "writes submission to CSV file including blank column for unanswered optional question" do
+      it "writes submission to CSV file" do
         expect(CSV.open(test_file.path).readlines).to eq(
           [
-            ["Reference", "Submitted at", "What is the meaning of life?", "What is your name? - First name", "What is your name? - Last name"],
-            [submission_reference, "2022-09-14T08:00:00+01:00", "", name_question.first_name, name_question.last_name],
+            ["Reference", "Submitted at", "What is the meaning of life?", "What is your name? - First name", "What is your name? - Last name", "Upload a file"],
+            [submission_reference, "2022-09-14T08:00:00+01:00", text_question.text, name_question.first_name, name_question.last_name, "test_#{submission_reference}.txt"],
           ],
         )
       end
+
+      context "when a question is optional and answer is not provided" do
+        let(:text_question) { build :text, question_text: "What is the meaning of life?", is_optional: true, text: nil }
+
+        it "writes submission to CSV file including blank column for unanswered optional question" do
+          expect(CSV.open(test_file.path).readlines).to eq(
+            [
+              ["Reference", "Submitted at", "What is the meaning of life?", "What is your name? - First name", "What is your name? - Last name", "Upload a file"],
+              [submission_reference, "2022-09-14T08:00:00+01:00", "", name_question.first_name, name_question.last_name, "test_#{submission_reference}.txt"],
+            ],
+          )
+        end
+      end
+
+      context "when there are repeated steps" do
+        let(:name_question_repeated) { build :first_middle_last_name_question, question_text: "What is your name?" }
+        let(:second_step) { build :repeatable_step, questions: [name_question, name_question_repeated] }
+
+        it "writes submission to CSV file with headers containing suffixes for the repeated steps" do
+          expect(CSV.open(test_file.path).readlines).to eq(
+            [
+              [
+                "Reference",
+                "Submitted at",
+                "What is the meaning of life?",
+                "What is your name? - First name - Answer 1",
+                "What is your name? - Last name - Answer 1",
+                "What is your name? - First name - Answer 2",
+                "What is your name? - Last name - Answer 2",
+                "Upload a file",
+              ],
+              [
+                submission_reference,
+                "2022-09-14T08:00:00+01:00",
+                text_question.text,
+                name_question.first_name,
+                name_question.last_name,
+                name_question_repeated.first_name,
+                name_question_repeated.last_name,
+                "test_#{submission_reference}.txt",
+              ],
+            ],
+          )
+        end
+      end
     end
 
-    context "when there are repeated steps" do
-      let(:name_question_repeated) { build :first_middle_last_name_question, question_text: "What is your name?" }
-      let(:second_step) { build :repeatable_step, questions: [name_question, name_question_repeated] }
+    context "when the submission is being sent to an S3 bucket" do
+      before do
+        described_class.write_submission(all_steps:, submission_reference:, timestamp:,
+                                         output_file_path: test_file.path, is_s3_submission: true)
+      end
 
-      it "writes submission to CSV file with headers containing suffixes for the repeated steps" do
+      it "writes submission to CSV file without including the submission reference in the filename" do
         expect(CSV.open(test_file.path).readlines).to eq(
           [
-            [
-              "Reference",
-              "Submitted at",
-              "What is the meaning of life?",
-              "What is your name? - First name - Answer 1",
-              "What is your name? - Last name - Answer 1",
-              "What is your name? - First name - Answer 2",
-              "What is your name? - Last name - Answer 2",
-            ],
-            [
-              submission_reference,
-              "2022-09-14T08:00:00+01:00",
-              text_question.text,
-              name_question.first_name,
-              name_question.last_name,
-              name_question_repeated.first_name,
-              name_question_repeated.last_name,
-            ],
+            ["Reference", "Submitted at", "What is the meaning of life?", "What is your name? - First name", "What is your name? - Last name", "Upload a file"],
+            [submission_reference, "2022-09-14T08:00:00+01:00", text_question.text, name_question.first_name, name_question.last_name, file_question.original_filename],
           ],
         )
       end

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -195,15 +195,23 @@ RSpec.describe Question::File, type: :model do
       let(:original_filename) { nil }
 
       it "returns a hash with the question text and a nil value" do
-        expect(question.show_answer_in_csv).to eq({ question.question_text => nil })
+        expect(question.show_answer_in_csv(false)).to eq({ question.question_text => nil })
       end
     end
 
     context "when the original_filename has a value" do
-      let(:original_filename) { Faker::File.file_name(dir: "", directory_separator: "") }
+      context "when is_s3_submission is false" do
+        let(:original_filename) { Faker::File.file_name(dir: "", directory_separator: "") }
 
-      it "returns a hash with the email_filename" do
-        expect(question.show_answer_in_csv).to eq({ question.question_text => question.email_filename })
+        it "returns a hash with the email_filename" do
+          expect(question.show_answer_in_csv(false)).to eq({ question.question_text => question.email_filename })
+        end
+      end
+
+      context "when is_s3_submission is true" do
+        it "returns a hash with the filename_for_s3_submission" do
+          expect(question.show_answer_in_csv(true)).to eq({ question.question_text => question.filename_for_s3_submission })
+        end
       end
     end
   end

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe Question::File, type: :model do
     end
   end
 
-  describe "name_with_filename_suffix" do
+  describe "#filename_for_s3_submission" do
     let(:file_extension) { ".txt" }
 
     let(:original_filename) { "#{file_basename}#{file_extension}" }
@@ -230,8 +230,8 @@ RSpec.describe Question::File, type: :model do
         let(:file_basename) { Faker::Alphanumeric.alpha(number: maximum_file_basename_length) }
 
         it "returns the original_filename" do
-          expect(question.name_with_filename_suffix).to eq original_filename
-          expect(question.name_with_filename_suffix.length).to eq 100
+          expect(question.filename_for_s3_submission).to eq original_filename
+          expect(question.filename_for_s3_submission.length).to eq 100
         end
       end
 
@@ -241,8 +241,8 @@ RSpec.describe Question::File, type: :model do
         it "returns the original_filename" do
           truncated_basename = file_basename.truncate(maximum_file_basename_length, omission: "")
           truncated_filename = "#{truncated_basename}#{file_extension}"
-          expect(question.name_with_filename_suffix).to eq truncated_filename
-          expect(question.name_with_filename_suffix.length).to eq 100
+          expect(question.filename_for_s3_submission).to eq truncated_filename
+          expect(question.filename_for_s3_submission.length).to eq 100
         end
       end
     end
@@ -255,8 +255,8 @@ RSpec.describe Question::File, type: :model do
 
         it "returns the original filename with the suffix" do
           filename_with_suffix = "#{file_basename}#{filename_suffix}#{file_extension}"
-          expect(question.name_with_filename_suffix).to eq filename_with_suffix
-          expect(question.name_with_filename_suffix.length).to eq 100
+          expect(question.filename_for_s3_submission).to eq filename_with_suffix
+          expect(question.filename_for_s3_submission.length).to eq 100
         end
       end
 
@@ -266,8 +266,8 @@ RSpec.describe Question::File, type: :model do
         it "returns the truncated filename with suffix" do
           truncated_basename = file_basename.truncate(maximum_file_basename_length, omission: "")
           truncated_filename_with_suffix = "#{truncated_basename}#{filename_suffix}#{file_extension}"
-          expect(question.name_with_filename_suffix).to eq truncated_filename_with_suffix
-          expect(question.name_with_filename_suffix.length).to eq 100
+          expect(question.filename_for_s3_submission).to eq truncated_filename_with_suffix
+          expect(question.filename_for_s3_submission.length).to eq 100
         end
       end
     end

--- a/spec/models/repeatable_step_spec.rb
+++ b/spec/models/repeatable_step_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe RepeatableStep, type: :model do
 
       it "returns a hash of all answers with keys containing the answer numbers" do
         # we convert to an array to test the ordering of the hash
-        expect(repeatable_step.show_answer_in_csv.to_a).to eq({
+        expect(repeatable_step.show_answer_in_csv(false).to_a).to eq({
           "What is your name? - First name - Answer 1" => first_question.first_name,
           "What is your name? - Last name - Answer 1" => first_question.last_name,
           "What is your name? - First name - Answer 2" => second_question.first_name,
@@ -186,7 +186,7 @@ RSpec.describe RepeatableStep, type: :model do
 
       it "returns a hash of all answers with keys containing the answer numbers" do
         # we convert to an array to test the ordering of the hash
-        expect(repeatable_step.show_answer_in_csv.to_a).to eq({
+        expect(repeatable_step.show_answer_in_csv(false).to_a).to eq({
           "What is the meaning of life? - Answer 1" => first_question.text,
           "What is the meaning of life? - Answer 2" => second_question.text,
         }.to_a)
@@ -197,7 +197,7 @@ RSpec.describe RepeatableStep, type: :model do
       let(:question) { build :text, is_optional: false }
 
       it "returns a hash containing a key for the first answer with a blank value" do
-        expect(repeatable_step.show_answer_in_csv).to eq({
+        expect(repeatable_step.show_answer_in_csv(false)).to eq({
           "#{question.question_text} - Answer 1" => "",
         })
       end

--- a/spec/services/aws_ses_submission_service_spec.rb
+++ b/spec/services/aws_ses_submission_service_spec.rb
@@ -140,7 +140,8 @@ RSpec.describe AwsSesSubmissionService do
                                     .with(all_steps:,
                                           submission_reference:,
                                           timestamp:,
-                                          output_file_path: an_instance_of(String))
+                                          output_file_path: an_instance_of(String),
+                                          is_s3_submission: false)
         end
       end
 

--- a/spec/services/notify_submission_service_spec.rb
+++ b/spec/services/notify_submission_service_spec.rb
@@ -88,7 +88,8 @@ RSpec.describe NotifySubmissionService do
             .with(all_steps:,
                   submission_reference:,
                   timestamp: Time.zone.now,
-                  output_file_path: an_instance_of(String))
+                  output_file_path: an_instance_of(String),
+                  is_s3_submission: false)
         end
       end
 

--- a/spec/services/s3_submission_service_spec.rb
+++ b/spec/services/s3_submission_service_spec.rb
@@ -16,76 +16,157 @@ RSpec.describe S3SubmissionService do
   let(:s3_bucket_name) { "a-bucket" }
   let(:s3_bucket_aws_account_id) { "23423423423423" }
   let(:s3_bucket_region) { "eu-west-1" }
+  let(:file_upload_bucket) { "file-upload-bucket" }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
   let(:timestamp) do
     Time.use_zone("London") { Time.zone.local(2022, 9, 14, 8, 24, 34) }
   end
+  let(:expected_timestamp) { "20220914T072434Z" }
   let(:all_steps) { [step] }
-  let(:journey) { instance_double(Flow::Journey, completed_steps: all_steps, all_steps:) }
-  let(:step) { build :step }
+  let(:completed_file_upload_questions) { [] }
+  let(:journey) { instance_double(Flow::Journey, completed_steps: all_steps, all_steps:, completed_file_upload_questions:) }
+  let(:question) { build :text, question_text: "What is the meaning of life?", text: "42" }
+  let(:step) { build :step, question: }
   let(:is_preview) { false }
 
-  describe "#upload_submission_csv_to_s3" do
+  describe "#submit" do
     let(:mock_credentials) { { foo: "bar" } }
     let(:mock_sts_client) { Aws::STS::Client.new(stub_responses: true) }
     let(:mock_s3_client) { Aws::S3::Client.new(stub_responses: true) }
+    let(:mock_file_upload_s3_service) { instance_double(Question::FileUploadS3Service) }
     let(:role_arn) { "arn:aws:iam::11111111111:role/test-role" }
 
     context "when the form is configured correctly with S3 bucket details" do
       before do
-        allow(CsvGenerator).to receive(:write_submission) do |args|
-          File.write(args[:output_file_path], file_body)
-        end
         allow(Aws::AssumeRoleCredentials).to receive(:new).and_return(mock_credentials)
         allow(Aws::STS::Client).to receive(:new).and_return(mock_sts_client)
         allow(Aws::S3::Client).to receive(:new).and_return(mock_s3_client)
-        allow(mock_s3_client).to receive(:put_object)
-        allow(Settings.aws).to receive(:s3_submission_iam_role_arn).and_return(role_arn)
+        allow(Question::FileUploadS3Service).to receive(:new).and_return(mock_file_upload_s3_service)
+        allow(mock_file_upload_s3_service).to receive(:delete_from_s3)
+        allow(Settings.aws).to receive_messages(s3_submission_iam_role_arn: role_arn, file_upload_s3_bucket_name: file_upload_bucket)
+      end
+
+      it "writes a CSV file" do
+        expect(CsvGenerator).to receive(:write_submission)
+                                  .with(all_steps:,
+                                        submission_reference:,
+                                        timestamp:,
+                                        output_file_path: an_instance_of(String),
+                                        is_s3_submission: true)
 
         service.submit
       end
 
-      it "writes a CSV file" do
-        expect(CsvGenerator).to have_received(:write_submission)
-          .with(all_steps:,
-                submission_reference:,
-                timestamp:,
-                output_file_path: an_instance_of(String))
-      end
-
       it "calls AWS to assume the role to upload to S3" do
         expected_session_name = "forms-runner-#{submission_reference}"
-        expect(Aws::AssumeRoleCredentials).to have_received(:new).with(client: mock_sts_client, role_arn:,
-                                                                       role_session_name: expected_session_name)
+        expect(Aws::AssumeRoleCredentials).to receive(:new).with(client: mock_sts_client, role_arn:,
+                                                                 role_session_name: expected_session_name)
+        service.submit
       end
 
       it "creates an S3 client with the credentials for the assumed role" do
-        expect(Aws::S3::Client).to have_received(:new).with(region: s3_bucket_region, credentials: mock_credentials)
+        expect(Aws::S3::Client).to receive(:new).with(region: s3_bucket_region, credentials: mock_credentials)
+        service.submit
       end
 
-      it "calls put_object" do
-        expected_timestamp = "20220914T072434Z"
+      it "calls put_object for CSV file" do
         expected_key_name = "form_submissions/#{form.id}/#{expected_timestamp}_#{submission_reference}/form_submission.csv"
-        expect(mock_s3_client).to have_received(:put_object).with(
-          body: file_body,
-          bucket: s3_bucket_name,
-          expected_bucket_owner: s3_bucket_aws_account_id,
-          key: expected_key_name,
+        expected_csv_content = "Reference,Submitted at,What is the meaning of life?\n#{submission_reference},2022-09-14T08:24:34+01:00,42\n"
+        expect(mock_s3_client).to receive(:put_object).with(
+          {
+            body: expected_csv_content,
+            bucket: s3_bucket_name,
+            expected_bucket_owner: s3_bucket_aws_account_id,
+            key: expected_key_name,
+          },
         )
+
+        service.submit
+      end
+
+      context "when the form has answered file upload questions" do
+        let(:first_file_upload_question) { build(:file, :with_uploaded_file, original_filename: "file.txt") }
+        let(:second_file_upload_question) { build(:file, :with_uploaded_file, original_filename: "file.txt", filename_suffix: "_1") }
+        let(:completed_file_upload_questions) { [first_file_upload_question, second_file_upload_question] }
+        let(:all_steps) do
+          [
+            build(:step, question: first_file_upload_question),
+            build(:step, question: second_file_upload_question),
+          ]
+        end
+
+        it "creates the CSV file with the expected filenames" do
+          expected_key_name = "form_submissions/#{form.id}/#{expected_timestamp}_#{submission_reference}/form_submission.csv"
+          expected_csv_content = "Reference,Submitted at,#{first_file_upload_question.question_text},#{second_file_upload_question.question_text}\n" \
+            "#{submission_reference},2022-09-14T08:24:34+01:00,file.txt,file_1.txt\n"
+          expect(mock_s3_client).to receive(:put_object).with(
+            {
+              body: expected_csv_content,
+              bucket: s3_bucket_name,
+              expected_bucket_owner: s3_bucket_aws_account_id,
+              key: expected_key_name,
+            },
+          )
+
+          service.submit
+        end
+
+        it "copies the file objects to the submission S3 bucket" do
+          expect(mock_s3_client).to receive(:copy_object).with({
+            bucket: s3_bucket_name,
+            expected_bucket_owner: s3_bucket_aws_account_id,
+            copy_source: "/#{file_upload_bucket}/#{first_file_upload_question.uploaded_file_key}",
+            key: "form_submissions/#{form.id}/#{expected_timestamp}_#{submission_reference}/file.txt",
+            tagging_directive: "REPLACE",
+          })
+
+          expect(mock_s3_client).to receive(:copy_object).with({
+            bucket: s3_bucket_name,
+            expected_bucket_owner: s3_bucket_aws_account_id,
+            copy_source: "/#{file_upload_bucket}/#{second_file_upload_question.uploaded_file_key}",
+            key: "form_submissions/#{form.id}/#{expected_timestamp}_#{submission_reference}/file_1.txt",
+            tagging_directive: "REPLACE",
+          })
+
+          service.submit
+        end
+
+        it "deletes the file objects from the file upload S3 bucket" do
+          expect(mock_file_upload_s3_service).to receive(:delete_from_s3).with(first_file_upload_question.uploaded_file_key)
+          expect(mock_file_upload_s3_service).to receive(:delete_from_s3).with(second_file_upload_question.uploaded_file_key)
+
+          service.submit
+        end
       end
 
       context "when a preview is being submitted" do
         let(:is_preview) { true }
+        let(:question) { build(:file, :with_uploaded_file, original_filename: "file.txt") }
+        let(:completed_file_upload_questions) { [question] }
 
-        it "calls put_object with a key starting with 'test_form_submissions/'" do
-          expected_timestamp = "20220914T072434Z"
+        it "calls put_object with the 'test_form_submissions/' key prefix" do
           expected_key_name = "test_form_submissions/#{form.id}/#{expected_timestamp}_#{submission_reference}/form_submission.csv"
-          expect(mock_s3_client).to have_received(:put_object).with(
-            body: file_body,
+          expected_csv_content = "Reference,Submitted at,#{question.question_text}\n#{submission_reference},2022-09-14T08:24:34+01:00,file.txt\n"
+          expect(mock_s3_client).to receive(:put_object).with({
+            body: expected_csv_content,
             bucket: s3_bucket_name,
             expected_bucket_owner: s3_bucket_aws_account_id,
             key: expected_key_name,
-          )
+          })
+
+          service.submit
+        end
+
+        it "copies uploaded files with the 'test_form_submissions/' key prefix" do
+          expect(mock_s3_client).to receive(:copy_object).with({
+            bucket: s3_bucket_name,
+            expected_bucket_owner: s3_bucket_aws_account_id,
+            copy_source: "/#{file_upload_bucket}/#{question.uploaded_file_key}",
+            key: "test_form_submissions/#{form.id}/#{expected_timestamp}_#{submission_reference}/file.txt",
+            tagging_directive: "REPLACE",
+          })
+
+          service.submit
         end
       end
     end

--- a/spec/support/shared_examples/question_models.rb
+++ b/spec/support/shared_examples/question_models.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples "a question model" do |_parameter|
   end
 
   it "responds with a hash to .show_answer_in_csv" do
-    expect(question.show_answer_in_csv).to be_a(Hash)
+    expect(question.show_answer_in_csv(true)).to be_a(Hash)
   end
 
   it "responds serializable_hash with a hash" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/hqPJsvS9/2194-support-file-upload-for-submissions-to-s3

When the `submission_type` is set to `s3` for a form, and the form has answered file upload questions, send the uploaded files to the s3 bucket set on the form.

Do this by copying the files to the target bucket and then deleting them from our S3 bucket. Do not copy the object tagging when we do the copy as the form processor does not need the tag added by GuardDuty and to copy the tagging we would need to ask form processors to allow the s3:PutObjectTagging permission for our IAM role.

Copy the files before uploading the submission S3 to the target bucket so that form processors are able to add automations on the CSV file being added and be sure that any uploaded files referenced in the CSV are already present.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
