### PR TITLE
Add CSV file information to submission emails

### DIFF
--- a/app/mailers/aws_ses_form_submission_mailer.rb
+++ b/app/mailers/aws_ses_form_submission_mailer.rb
@@ -3,11 +3,12 @@ class AwsSesFormSubmissionMailer < ApplicationMailer
           reply_to: Settings.ses_submission_email.reply_to_email_address,
           delivery_method: Rails.configuration.x.aws_ses_form_submission_mailer["delivery_method"]
 
-  def submission_email(answer_content_html:, answer_content_plain_text:, submission_email_address:, mailer_options:, files:)
+  def submission_email(answer_content_html:, answer_content_plain_text:, submission_email_address:, mailer_options:, files:, csv_filename: nil)
     @answer_content_html = answer_content_html
     @answer_content_plain_text = answer_content_plain_text
     @mailer_options = mailer_options
     @subject = email_subject
+    @csv_filename = csv_filename
 
     files.each do |name, file|
       attachments[name] = file

--- a/app/services/aws_ses_submission_service.rb
+++ b/app/services/aws_ses_submission_service.rb
@@ -32,16 +32,17 @@ private
       write_submission_csv(file)
 
       files = files.merge({ csv_filename => File.read(file.path) })
-      deliver_submission_email(files)
+      deliver_submission_email(files, csv_filename)
     end
   end
 
-  def deliver_submission_email(files)
+  def deliver_submission_email(files, csv_filename = nil)
     mail = AwsSesFormSubmissionMailer.submission_email(answer_content_html:,
                                                        answer_content_plain_text:,
                                                        submission_email_address: @form.submission_email,
                                                        mailer_options: @mailer_options,
-                                                       files:).deliver_now
+                                                       files:,
+                                                       csv_filename:).deliver_now
 
     CurrentJobLoggingAttributes.mail_message_id = mail.message_id
     mail.message_id

--- a/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
@@ -27,6 +27,12 @@
 
 <%= @answer_content_html.html_safe %>
 
+<% if @csv_filename.present? %>
+  <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
+  <h2><%= I18n.t("mailer.submission.csv_file") %></h2>
+  <p><%= I18n.t("mailer.submission.file_attached", filename: @csv_filename) %></p>
+<% end %>
+
 <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
 
 <div

--- a/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
@@ -19,6 +19,14 @@
 
 <%= @answer_content_plain_text %>
 
+<% if @csv_filename.present? %>
+---
+
+<%= I18n.t("mailer.submission.csv_file") %>
+
+<%= I18n.t("mailer.submission.file_attached", filename: @csv_filename) %>
+<% end %>
+
 ---
 
 <%= I18n.t("mailer.submission.cannot_reply.heading") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -199,6 +199,7 @@ en:
         contact_forms_team_plain: If you’re experiencing a technical issue with this form, contact the GOV.​UK Forms team (https://www.forms.service.gov.uk/support) with details of the issue and the form it relates to.
         heading: You cannot reply to this email
       check_before_using: Check that this data looks safe before you use it
+      csv_file: CSV file of these answers
       file_attached: "%{filename} (attached to this email)"
       from: GOV.UK Forms <%{email_address}>
       payment: You can check that a payment has been made by using this reference number to search transactions within GOV.​UK Pay.

--- a/spec/mailers/aws_ses_form_submission_mailer_preview.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_preview.rb
@@ -34,4 +34,17 @@ class AwsSesFormSubmissionMailerPreview < ActionMailer::Preview
                                                                                                          payment_url: "https://www.gov.uk/payments/your-payment-link"),
                                                 files: {})
   end
+
+  def submission_email_with_csv
+    AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
+                                                answer_content_plain_text: "## What's your email address?\n\nforms@example.gov.uk",
+                                                submission_email_address: "testing@gov.uk",
+                                                mailer_options: FormSubmissionService::MailerOptions.new(title: "Form 1",
+                                                                                                         is_preview: true,
+                                                                                                         timestamp: Time.zone.now,
+                                                                                                         submission_reference: Faker::Alphanumeric.alphanumeric(number: 8).upcase,
+                                                                                                         payment_url: "https://www.gov.uk/payments/your-payment-link"),
+                                                files: {},
+                                                csv_filename: "my_answers.csv")
+  end
 end

--- a/spec/services/aws_ses_submission_service_spec.rb
+++ b/spec/services/aws_ses_submission_service_spec.rb
@@ -73,7 +73,8 @@ RSpec.describe AwsSesSubmissionService do
               answer_content_plain_text: "What is the meaning of life?\n\n42",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
-              files: {} },
+              files: {},
+              csv_filename: nil },
           ).once
         end
       end
@@ -106,7 +107,8 @@ RSpec.describe AwsSesSubmissionService do
               answer_content_plain_text: "#{question.question_text}\n\n#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
-              files: { question.name_with_filename_suffix => file_content } },
+              files: { question.name_with_filename_suffix => file_content },
+              csv_filename: nil },
           ).once
         end
       end
@@ -143,7 +145,8 @@ RSpec.describe AwsSesSubmissionService do
               answer_content_plain_text: "What is the meaning of life?\n\n42",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
-              files: { "govuk_forms_form_#{form.id}_#{submission_reference}.csv" => expected_csv_content } },
+              files: { "govuk_forms_form_#{form.id}_#{submission_reference}.csv" => expected_csv_content },
+              csv_filename: "govuk_forms_form_#{form.id}_#{submission_reference}.csv" },
           ).once
         end
       end
@@ -176,7 +179,8 @@ RSpec.describe AwsSesSubmissionService do
                   files: {
                     "govuk_forms_form_#{form.id}_#{submission_reference}.csv" => expected_csv_content,
                     question.name_with_filename_suffix => file_content,
-                  } },
+                  },
+                  csv_filename: "govuk_forms_form_#{form.id}_#{submission_reference}.csv" },
               ).once
             end
           end
@@ -199,7 +203,8 @@ RSpec.describe AwsSesSubmissionService do
                 answer_content_plain_text: "What is the meaning of life?\n\n42",
                 submission_email_address: submission_email,
                 mailer_options: instance_of(FormSubmissionService::MailerOptions),
-                files: {} },
+                files: {},
+                csv_filename: nil },
             ).once
           end
         end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/C8KYvyW8

We need to add CSV related info to the submission emails sent via AWS SES, so that forms that are receiving answers in CSV files receive submission emails with the right content once we switch over to using AWS SES for all submission emails.

<details><summary>Mailer previews</summary>
HTML:

![Screenshot 2025-04-14 at 10 15 21](https://github.com/user-attachments/assets/bde9fb72-74a7-4a22-9a72-c1f07d8d4de9)

Plain-text:
```
This is a test of the “Form 1” form.

This form was submitted at 9:15am on 14 April 2025

GOV.​UK Forms reference number: GKCW5J8V

You can check that a payment has been made by using this reference number to search transactions within GOV.​UK Pay.

Check that this data looks safe before you use it

---

## What's your email address?

forms@example.gov.uk

---

CSV file of these answers

my_answers.csv (attached to this email)

---

You cannot reply to this email

If you need to contact the person who completed this form, you’ll need to contact them directly.
If you’re experiencing a technical issue with this form, contact the GOV.​UK Forms team (https://www.forms.service.gov.uk/support) with details of the issue and the form it relates to.
```
</details> 

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
