### PR TITLE
Append submission reference to filenames

### DIFF
--- a/app/lib/flow/journey.rb
+++ b/app/lib/flow/journey.rb
@@ -70,7 +70,11 @@ module Flow
 
     def populate_file_suffixes
       completed_file_upload_questions.each_with_index do |question, index|
-        count = completed_file_upload_questions.take(index).filter { it.original_filename == question.original_filename }.count
+        previous_completed_file_questions = completed_file_upload_questions.take(index)
+
+        count = previous_completed_file_questions.filter {
+          it.filename_after_reference_truncation == question.filename_after_reference_truncation
+        }.count
 
         question.filename_suffix = count.zero? ? "" : "_#{count}"
       end

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -6,6 +6,7 @@ module Question
     attribute :original_filename
     attribute :uploaded_file_key
     attribute :filename_suffix, default: ""
+    attribute :email_filename, default: ""
     validates :file, presence: true, unless: :is_optional?
     validate :validate_file_size
     validate :validate_file_extension
@@ -54,6 +55,20 @@ module Question
       base_name = ::File.basename(original_filename, extension).truncate(base_name_max_length, omission: "")
 
       "#{base_name}#{filename_suffix}#{extension}"
+    end
+
+    def populate_email_filename(submission_reference:)
+      return if original_filename.blank?
+
+      extension = ::File.extname(original_filename)
+
+      submission_reference_with_underscore = "_#{submission_reference}"
+
+      base_name_max_length = FILE_MAX_FILENAME_LENGTH - submission_reference_with_underscore.length - extension.length - filename_suffix.length
+
+      base_name = ::File.basename(original_filename, extension).truncate(base_name_max_length, omission: "")
+
+      self.email_filename = "#{base_name}#{filename_suffix}#{submission_reference_with_underscore}#{extension}"
     end
 
     def before_save

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -57,6 +57,16 @@ module Question
       "#{base_name}#{filename_suffix}#{extension}"
     end
 
+    def filename_after_reference_truncation
+      extension = ::File.extname(original_filename)
+
+      base_name_max_length = FILE_MAX_FILENAME_LENGTH - extension.length - ReferenceNumberService::REFERENCE_LENGTH
+
+      base_name = ::File.basename(original_filename, extension).truncate(base_name_max_length, omission: "")
+
+      "#{base_name}#{extension}"
+    end
+
     def populate_email_filename(submission_reference:)
       return if original_filename.blank?
 

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -38,13 +38,13 @@ module Question
     def show_answer_in_email
       return nil if original_filename.blank?
 
-      I18n.t("mailer.submission.file_attached", filename: name_with_filename_suffix)
+      I18n.t("mailer.submission.file_attached", filename: email_filename)
     end
 
     def show_answer_in_csv
       return Hash[question_text, nil] if original_filename.blank?
 
-      { question_text => name_with_filename_suffix }
+      { question_text => email_filename }
     end
 
     def name_with_filename_suffix

--- a/app/services/aws_ses_submission_service.rb
+++ b/app/services/aws_ses_submission_service.rb
@@ -18,6 +18,9 @@ class AwsSesSubmissionService
     end
 
     files = uploaded_files_in_answers
+
+    raise StandardError, "Number of files does not match number of completed file questions" unless files.count == @journey.completed_file_upload_questions.count
+
     if @form.submission_type == "email_with_csv"
       deliver_submission_email_with_csv_attachment(files)
     else

--- a/app/services/aws_ses_submission_service.rb
+++ b/app/services/aws_ses_submission_service.rb
@@ -58,7 +58,8 @@ private
 
   def uploaded_files_in_answers
     @journey.completed_file_upload_questions
-            .map { |question| [question.name_with_filename_suffix, question.file_from_s3] }
+            .each { it.populate_email_filename(submission_reference: @mailer_options.submission_reference) }
+            .map { |question| [question.email_filename, question.file_from_s3] }
             .to_h
   end
 

--- a/spec/features/fill_in_file_upload_question_spec.rb
+++ b/spec/features/fill_in_file_upload_question_spec.rb
@@ -135,7 +135,7 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
 
     delivered_email = ActionMailer::Base.deliveries.first
 
-    expect(delivered_email.html_part.body.raw_source).to match(/a-file.txt/)
+    expect(delivered_email.html_part.body.raw_source).to match(/a-file_#{reference}.txt/)
   end
 
   def then_i_see_an_error_message_that_the_file_contains_a_virus

--- a/spec/jobs/delete_submissions_job_spec.rb
+++ b/spec/jobs/delete_submissions_job_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
 
   let(:form_with_file_upload_answers) do
     {
-      "1" => { uploaded_file_key: "key1" },
-      "2" => { uploaded_file_key: "key2" },
+      "1" => { uploaded_file_key: "key1", original_filename: "first_file.png" },
+      "2" => { uploaded_file_key: "key2", original_filename: "second_file.txt" },
     }
   end
 

--- a/spec/lib/flow/journey_spec.rb
+++ b/spec/lib/flow/journey_spec.rb
@@ -239,6 +239,37 @@ RSpec.describe Flow::Journey do
           expect(journey.all_steps[3].question.filename_suffix).to eq("_2")
         end
       end
+
+      context "when there are multiple files with different names that are the same after truncation" do
+        let(:first_page_in_form) { build(:page, answer_type: "file", id: 1, next_page: 2) }
+        let(:second_page_in_form) { build(:page, answer_type: "file", id: 2, next_page: 3) }
+        let(:third_page_in_form) { build(:page, answer_type: "file", id: 3, next_page: 4) }
+        let(:fourth_page_in_form) { build(:page, answer_type: "file", id: 4) }
+        let(:pages_data) { [first_page_in_form, second_page_in_form, third_page_in_form, fourth_page_in_form] }
+        let(:store) do
+          {
+            answers: {
+              "2" =>
+                {
+                  "1" => { uploaded_file_key: "key1", original_filename: "this_is_an_incredibly_long_filename_that_will_surely_have_to_be_truncated_somewhere_near_the_end_version_one", filename_suffix: "" },
+                  "2" => { uploaded_file_key: "key2", original_filename: "a different filename", filename_suffix: "" },
+                  "3" => { uploaded_file_key: "key3", original_filename: "this_is_an_incredibly_long_filename_that_will_surely_have_to_be_truncated_somewhere_near_the_end_version_two", filename_suffix: "" },
+                  "4" => { uploaded_file_key: "key4", original_filename: "this_is_an_incredibly_long_filename_that_will_surely_have_to_be_truncated_somewhere_near_the_end_version_three", filename_suffix: "" },
+                },
+            },
+          }
+        end
+
+        it "does not add a numerical suffix to the first instance of a filename" do
+          expect(journey.all_steps[0].question.filename_suffix).to eq("")
+          expect(journey.all_steps[1].question.filename_suffix).to eq("")
+        end
+
+        it "adds a numerical suffix to any files which would have duplicate filenames after truncation" do
+          expect(journey.all_steps[2].question.filename_suffix).to eq("_1")
+          expect(journey.all_steps[3].question.filename_suffix).to eq("_2")
+        end
+      end
     end
 
     context "when answers are loaded from the database" do

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -265,6 +265,27 @@ RSpec.describe Question::File, type: :model do
     end
   end
 
+  describe "filename_after_reference_truncation" do
+    let(:attributes) { { original_filename: } }
+
+    context "when the filename and extension are less than or equal to 100 characters" do
+      let(:original_filename) { "this_is_fairly_long_filename_that_is_luckily_just_short_enough_to_avoid_being_truncated.xlsx" }
+
+      it "returns the original_filename" do
+        expect(question.filename_after_reference_truncation).to eq original_filename
+      end
+    end
+
+    context "when the filename and extension are over 100 characters" do
+      let(:original_filename) { "this_is_an_incredibly_long_filename_that_will_surely_have_to_be_truncated_somewhere_near_the_end.xlsx" }
+
+      it "returns the original_filename" do
+        truncated_filename = "this_is_an_incredibly_long_filename_that_will_surely_have_to_be_truncated_somewhere_nea.xlsx"
+        expect(question.filename_after_reference_truncation).to eq truncated_filename
+      end
+    end
+  end
+
   describe "populate_email_filename" do
     let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
     let(:attributes) { { original_filename:, filename_suffix: } }

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -266,33 +266,26 @@ RSpec.describe Question::File, type: :model do
   end
 
   describe "populate_email_filename" do
-    let(:file_extension) { ".txt" }
-
-    let(:original_filename) { "#{file_basename}#{file_extension}" }
-    let(:filename_suffix) { "" }
     let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
-    let(:maximum_file_basename_length) { 100 - submission_reference.length - filename_suffix.length - file_extension.length - 1 }
-
     let(:attributes) { { original_filename:, filename_suffix: } }
 
     context "when no suffix is supplied" do
-      context "when the filename and extension are less than or equal to 100 characters" do
-        let(:file_basename) { Faker::Alphanumeric.alpha(number: maximum_file_basename_length) }
+      let(:filename_suffix) { "" }
 
-        it "sets email_filename to the original_filename" do
-          expect { question.populate_email_filename(submission_reference:) }.to change(question, :email_filename).from("").to("#{file_basename}_#{submission_reference}#{file_extension}")
+      context "when the filename and extension are less than or equal to 100 characters" do
+        let(:original_filename) { "a_very_very_long_filename_that_is_very_nearly_but_not_quite_long_enough_to_be_truncated.txt" }
+
+        it "sets email_filename to the original_filename with the submission reference" do
+          expect { question.populate_email_filename(submission_reference:) }.to change(question, :email_filename).from("").to("a_very_very_long_filename_that_is_very_nearly_but_not_quite_long_enough_to_be_truncated_#{submission_reference}.txt")
           expect(question.email_filename.length).to eq 100
         end
       end
 
       context "when the filename and extension are over 100 characters" do
-        let(:file_basename) { Faker::Alphanumeric.alpha(number: maximum_file_basename_length + 1) }
+        let(:original_filename) { "a_very_very_very_very_very_very_very_long_filename_just_about_long_enough_for_truncation.png" }
 
-        it "returns the original_filename" do
-          truncated_basename = file_basename.truncate(maximum_file_basename_length, omission: "")
-          truncated_filename_with_reference = "#{truncated_basename}_#{submission_reference}#{file_extension}"
-
-          expect { question.populate_email_filename(submission_reference:) }.to change(question, :email_filename).from("").to(truncated_filename_with_reference)
+        it "sets email_filename to the a truncated original_filename with the submission reference" do
+          expect { question.populate_email_filename(submission_reference:) }.to change(question, :email_filename).from("").to("a_very_very_very_very_very_very_very_long_filename_just_about_long_enough_for_truncatio_#{submission_reference}.png")
           expect(question.email_filename.length).to eq 100
         end
       end
@@ -302,22 +295,20 @@ RSpec.describe Question::File, type: :model do
       let(:filename_suffix) { "_1" }
 
       context "when the filename, suffix and extension are less than or equal to 100 characters" do
-        let(:file_basename) { Faker::Alphanumeric.alpha(number: maximum_file_basename_length) }
+        let(:original_filename) { "a_very_very_long_filename_thats_very_nearly_but_not_quite_long_enough_to_be_truncated.jpg" }
 
-        it "returns the original filename with the suffix" do
-          filename_with_suffix_and_reference = "#{file_basename}#{filename_suffix}_#{submission_reference}#{file_extension}"
-
+        it "sets email_filename to the original filename with the suffix and reference" do
+          filename_with_suffix_and_reference = "a_very_very_long_filename_thats_very_nearly_but_not_quite_long_enough_to_be_truncated_1_#{submission_reference}.jpg"
           expect { question.populate_email_filename(submission_reference:) }.to change(question, :email_filename).from("").to(filename_with_suffix_and_reference)
           expect(question.email_filename.length).to eq 100
         end
       end
 
       context "when the filename, suffix and extension are over 100 characters" do
-        let(:file_basename) { Faker::Alphanumeric.alpha(number: maximum_file_basename_length + 1) }
+        let(:original_filename) { "an_unusual_and_atypically_long_filename_that_is_just_about_long_enough_to_be_truncated.doc" }
 
-        it "returns the truncated filename with suffix" do
-          truncated_basename = file_basename.truncate(maximum_file_basename_length, omission: "")
-          truncated_filename_with_suffix_and_reference = "#{truncated_basename}#{filename_suffix}_#{submission_reference}#{file_extension}"
+        it "sets email_filename to the truncated filename with suffix and reference" do
+          truncated_filename_with_suffix_and_reference = "an_unusual_and_atypically_long_filename_that_is_just_about_long_enough_to_be_truncate_1_#{submission_reference}.doc"
 
           expect { question.populate_email_filename(submission_reference:) }.to change(question, :email_filename).from("").to(truncated_filename_with_suffix_and_reference)
           expect(question.email_filename.length).to eq 100

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -160,6 +160,11 @@ RSpec.describe Question::File, type: :model do
     let(:original_filename) { Faker::File.file_name(dir: "", directory_separator: "") }
     let(:attributes) { { original_filename:, filename_suffix: } }
     let(:filename_suffix) { "" }
+    let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+
+    before do
+      question.populate_email_filename(submission_reference:)
+    end
 
     context "when the original_filename is blank" do
       let(:original_filename) { nil }
@@ -167,28 +172,11 @@ RSpec.describe Question::File, type: :model do
       it "returns a nil value" do
         expect(question.show_answer_in_email).to be_nil
       end
-
-      context "when the file has a suffix set" do
-        let(:filename_suffix) { "_1" }
-
-        it "returns a nil value" do
-          expect(question.show_answer_in_email).to be_nil
-        end
-      end
     end
 
     context "when the original_filename has a value" do
-      it "returns the original_filename" do
-        expect(question.show_answer_in_email).to eq I18n.t("mailer.submission.file_attached", filename: question.name_with_filename_suffix)
-      end
-
-      context "when the file has a suffix set" do
-        let(:attributes) { { original_filename:, filename_suffix: } }
-        let(:filename_suffix) { "_1" }
-
-        it "returns the filename with a suffix" do
-          expect(question.show_answer_in_email).to eq I18n.t("mailer.submission.file_attached", filename: question.name_with_filename_suffix)
-        end
+      it "returns the email_filename with the email attachment text" do
+        expect(question.show_answer_in_email).to eq I18n.t("mailer.submission.file_attached", filename: question.email_filename)
       end
     end
   end
@@ -197,6 +185,11 @@ RSpec.describe Question::File, type: :model do
     let(:attributes) { { original_filename:, filename_suffix: } }
     let(:original_filename) { Faker::File.file_name(dir: "", directory_separator: "") }
     let(:filename_suffix) { "" }
+    let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+
+    before do
+      question.populate_email_filename(submission_reference:)
+    end
 
     context "when the original_filename is blank" do
       let(:original_filename) { nil }
@@ -204,29 +197,13 @@ RSpec.describe Question::File, type: :model do
       it "returns a hash with the question text and a nil value" do
         expect(question.show_answer_in_csv).to eq({ question.question_text => nil })
       end
-
-      context "when the file has a suffix set" do
-        let(:filename_suffix) { "_1" }
-
-        it "returns a hash with the question text and a nil value" do
-          expect(question.show_answer_in_csv).to eq({ question.question_text => nil })
-        end
-      end
     end
 
     context "when the original_filename has a value" do
       let(:original_filename) { Faker::File.file_name(dir: "", directory_separator: "") }
 
-      it "returns the original_filename" do
-        expect(question.show_answer_in_csv).to eq({ question.question_text => question.name_with_filename_suffix })
-      end
-
-      context "when the file has a suffix set" do
-        let(:filename_suffix) { "_1" }
-
-        it "returns the filename with a suffix" do
-          expect(question.show_answer_in_csv).to eq({ question.question_text => question.name_with_filename_suffix })
-        end
+      it "returns a hash with the email_filename" do
+        expect(question.show_answer_in_csv).to eq({ question.question_text => question.email_filename })
       end
     end
   end

--- a/spec/services/aws_ses_submission_service_spec.rb
+++ b/spec/services/aws_ses_submission_service_spec.rb
@@ -114,6 +114,18 @@ RSpec.describe AwsSesSubmissionService do
       end
 
       include_examples "it returns the message id"
+
+      context "when uploaded_files_in_answers returns the wrong number of files" do
+        before do
+          allow(service).to receive(:uploaded_files_in_answers).and_return({})
+        end
+
+        it "raises an error" do
+          expect {
+            service.submit
+          }.to raise_error(/Number of files does not match number of completed file questions/)
+        end
+      end
     end
 
     context "when the submission type is email_with_csv" do

--- a/spec/services/aws_ses_submission_service_spec.rb
+++ b/spec/services/aws_ses_submission_service_spec.rb
@@ -103,11 +103,11 @@ RSpec.describe AwsSesSubmissionService do
           service.submit
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-            { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
-              answer_content_plain_text: "#{question.question_text}\n\n#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}",
+            { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.email_filename)}</p>",
+              answer_content_plain_text: "#{question.question_text}\n\n#{I18n.t('mailer.submission.file_attached', filename: question.email_filename)}",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
-              files: { question.name_with_filename_suffix => file_content },
+              files: { question.email_filename => file_content },
               csv_filename: nil },
           ).once
         end
@@ -169,16 +169,16 @@ RSpec.describe AwsSesSubmissionService do
 
               service.submit
 
-              expected_csv_content = "Reference,Submitted at,#{question.question_text}\n#{submission_reference},2022-09-14T08:00:00Z,#{question.name_with_filename_suffix}\n"
+              expected_csv_content = "Reference,Submitted at,#{question.question_text}\n#{submission_reference},2022-09-14T08:00:00Z,#{question.email_filename}\n"
 
               expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-                { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}</p>",
-                  answer_content_plain_text: "#{question.question_text}\n\n#{I18n.t('mailer.submission.file_attached', filename: question.name_with_filename_suffix)}",
+                { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.email_filename)}</p>",
+                  answer_content_plain_text: "#{question.question_text}\n\n#{I18n.t('mailer.submission.file_attached', filename: question.email_filename)}",
                   submission_email_address: submission_email,
                   mailer_options: instance_of(FormSubmissionService::MailerOptions),
                   files: {
                     "govuk_forms_form_#{form.id}_#{submission_reference}.csv" => expected_csv_content,
-                    question.name_with_filename_suffix => file_content,
+                    question.email_filename => file_content,
                   },
                   csv_filename: "govuk_forms_form_#{form.id}_#{submission_reference}.csv" },
               ).once


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/QTeGemP4/2173-add-the-submission-reference-number-to-the-uploaded-files

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Appends the submission reference to the filenames of email attachments.

Includes:
- Adding a new attribute to the Question::File model to store the filename for the email.
- Adding a new `populate_email_filename` method to the file model, which populates the new attribute.
- Adding a check so that we're alerted if the number of files we pass to the mailer is wrong

See individual commit messages for details.

### Testing instructions
- Upload a file on any form with a file upload question
- submit the form
- check that the filename written in the email matches the filename on the attached file
- check that the filename ends with a submission reference
- check that the submission reference on the filename matches the one written in the email and the confirmation page

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
