### PR TITLE
Log question valdation errors

### DIFF
--- a/app/models/current_request_logging_attributes.rb
+++ b/app/models/current_request_logging_attributes.rb
@@ -1,7 +1,8 @@
 class CurrentRequestLoggingAttributes < ActiveSupport::CurrentAttributes
   attribute :request_host, :request_id, :form_id, :form_name, :preview, :page_id, :page_slug, :session_id_hash, :trace_id,
             :question_number, :submission_reference, :submission_email_reference, :submission_email_id,
-            :confirmation_email_reference, :confirmation_email_id, :rescued_exception, :rescued_exception_trace
+            :confirmation_email_reference, :confirmation_email_id, :rescued_exception, :rescued_exception_trace,
+            :validation_errors
 
   def as_hash
     {
@@ -26,6 +27,7 @@ class CurrentRequestLoggingAttributes < ActiveSupport::CurrentAttributes
       }.compact,
       rescued_exception:,
       rescued_exception_trace:,
+      validation_errors:,
     }.compact_blank
   end
 end

--- a/app/models/question/question_base.rb
+++ b/app/models/question/question_base.rb
@@ -2,11 +2,14 @@ module Question
   class QuestionBase
     include ActiveModel::Model
     include ActiveModel::Validations
+    include ActiveModel::Validations::Callbacks
     include ActiveModel::Serialization
     include ActiveModel::Attributes
     include ActionView::Helpers::TagHelper
 
     attr_accessor :question_text, :hint_text, :answer_settings, :is_optional, :page_heading, :guidance_markdown
+
+    after_validation :set_validation_error_logging_attributes
 
     def initialize(attributes = {}, options = {})
       super(attributes)
@@ -62,6 +65,12 @@ module Question
 
     def question_text_for_check_your_answers
       question_text_with_optional_suffix
+    end
+
+  private
+
+    def set_validation_error_logging_attributes
+      CurrentRequestLoggingAttributes.validation_errors = errors.map { |error| "#{error.attribute}: #{error.type}" } if errors.any?
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UcS768Hz/2175-log-validation-error-messages-in-admin-and-runner

Log input validation errors for all questions. The intention is so we can track which validation errors occur regularly that we might want to re-assess.

Examples of fields added to log lines when there are validation errors:
`"validation_errors":["number: not_a_number"]`
`"validation_errors":["text: blank"]`

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
