### PR TITLE
Log answer type

### DIFF
--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -5,6 +5,7 @@ module Forms
     def set_request_logging_attributes
       super
       CurrentRequestLoggingAttributes.question_number = @step.page_number if @step&.page_number
+      CurrentRequestLoggingAttributes.answer_type = @step&.page&.answer_type if @step&.page&.answer_type
     end
 
     def show

--- a/app/models/current_request_logging_attributes.rb
+++ b/app/models/current_request_logging_attributes.rb
@@ -1,7 +1,22 @@
 class CurrentRequestLoggingAttributes < ActiveSupport::CurrentAttributes
-  attribute :request_host, :request_id, :form_id, :form_name, :preview, :page_id, :page_slug, :session_id_hash, :trace_id,
-            :question_number, :submission_reference, :submission_email_reference, :submission_email_id,
-            :confirmation_email_reference, :confirmation_email_id, :rescued_exception, :rescued_exception_trace,
+  attribute :request_host,
+            :request_id,
+            :form_id,
+            :form_name,
+            :preview,
+            :page_id,
+            :page_slug,
+            :answer_type,
+            :session_id_hash,
+            :trace_id,
+            :question_number,
+            :submission_reference,
+            :submission_email_reference,
+            :submission_email_id,
+            :confirmation_email_reference,
+            :confirmation_email_id,
+            :rescued_exception,
+            :rescued_exception_trace,
             :validation_errors
 
   def as_hash
@@ -13,6 +28,7 @@ class CurrentRequestLoggingAttributes < ActiveSupport::CurrentAttributes
       preview: preview.to_s,
       page_id:,
       page_slug:,
+      answer_type:,
       session_id_hash:,
       trace_id:,
       question_number:,

--- a/spec/models/current_request_logging_attributes_spec.rb
+++ b/spec/models/current_request_logging_attributes_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe CurrentRequestLoggingAttributes, type: :model do
       current.confirmation_email_id = "a-confirmation-email-id"
       current.rescued_exception = "StandardError"
       current.rescued_exception_trace = "a trace"
+      current.validation_errors = ["text: blank"]
 
       expect(current.as_hash).to eq({
         request_host: "www.example.com",
@@ -55,6 +56,7 @@ RSpec.describe CurrentRequestLoggingAttributes, type: :model do
         },
         rescued_exception: "StandardError",
         rescued_exception_trace: "a trace",
+        validation_errors: ["text: blank"],
       })
     end
 
@@ -70,6 +72,12 @@ RSpec.describe CurrentRequestLoggingAttributes, type: :model do
 
       expect(current.as_hash[:notification_ids].keys).to include :submission_email_id
       expect(current.as_hash[:notification_ids].keys).not_to include :confirmation_email_id
+    end
+
+    it "does not include the validation errors array if empty" do
+      current.validation_errors = []
+
+      expect(current.as_hash.keys).not_to include :validation_errors
     end
   end
 end

--- a/spec/models/current_request_logging_attributes_spec.rb
+++ b/spec/models/current_request_logging_attributes_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe CurrentRequestLoggingAttributes, type: :model do
       current.preview = false
       current.page_id = 2
       current.page_slug = "a-page"
+      current.answer_type = "text"
       current.session_id_hash = "a-session-id"
       current.trace_id = "a-trace-id"
       current.question_number = 3
@@ -39,6 +40,7 @@ RSpec.describe CurrentRequestLoggingAttributes, type: :model do
         preview: "false",
         page_id: 2,
         page_slug: "a-page",
+        answer_type: "text",
         session_id_hash: "a-session-id",
         trace_id: "a-trace-id",
         question_number: 3,

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -94,6 +94,10 @@ RSpec.describe Forms::PageController, type: :request do
     it "adds the question_number to the instrumentation payload" do
       expect(log_lines[0]["question_number"]).to eq(1)
     end
+
+    it "adds the answer_type to the instrumentation payload" do
+      expect(log_lines[0]["answer_type"]).to eq("text")
+    end
   end
 
   shared_examples "ordered steps" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/R267eUxr/2178-log-answer-type-in-splunk-in-admin-and-runner

When a route is for a question, log the answer type of that question as an attribute.

Example logging attribute:
`"answer_type":"selection"`

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
