### PR TITLE
Enable none of the above condition triggers

### DIFF
--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -133,10 +133,16 @@ private
   def first_condition_matches?
     return unless question.respond_to?(:selection)
 
+    return question.selection == I18n.t("page.none_of_the_above") if routing_condition_none_of_the_above
+
     routing_conditions.any? && (routing_conditions.first.answer_value == question.selection)
   end
 
   def first_condition_default?
     routing_conditions.any? && routing_conditions.first.answer_value.blank?
+  end
+
+  def routing_condition_none_of_the_above
+    routing_conditions.any? && routing_conditions.first.answer_value == :none_of_the_above.to_s
   end
 end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -179,6 +179,15 @@ RSpec.describe Step do
         end
       end
 
+      context "with a matching none_of_the_above condition" do
+        let(:selection) { "None of the above" }
+        let(:routing_conditions) { [OpenStruct.new(answer_value: "none_of_the_above", goto_page_id: "5")] }
+
+        it "returns the goto_page_id of the condition" do
+          expect(step.next_page_slug_after_routing).to eq("5")
+        end
+      end
+
       context "with a non-matching condition" do
         let(:selection) { "No" }
         let(:routing_conditions) { [OpenStruct.new(answer_value: "Yes", goto_page_id: "5")] }


### PR DESCRIPTION
This bypasses a quirk with how we stored our condition answer values for "None of the above" answers. Intead of storing the answer text, we've been storing `none_of_the_above`, which has meant that the answer value check used during conditional routing hasn't been working correctly.

This fixes it so that it will work when the answer value for a condition is `none_of_the_above`, and the answer given to the selection list question is "None of the above".

### What problem does this pull request solve?

https://trello.com/c/2H6cVned/2228-routes-based-on-none-of-the-above-answers-do-not-work

It's a little fiddly to test, but you'd want to create a form which has a condition that's based on a "None of the above" selection. You should notice in admin that the answer value for the condition is displayed erroneously as `none_of_the_above` - this PR should mean that despite this, the runner will still trigger the condition on an answer of "None of the above".  

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
