### PR TITLE
Remove explicit file upload validation logging

### DIFF
--- a/app/models/current_request_logging_attributes.rb
+++ b/app/models/current_request_logging_attributes.rb
@@ -17,7 +17,8 @@ class CurrentRequestLoggingAttributes < ActiveSupport::CurrentAttributes
             :confirmation_email_id,
             :rescued_exception,
             :rescued_exception_trace,
-            :validation_errors
+            :validation_errors,
+            :answer_metadata
 
   def as_hash
     {
@@ -44,6 +45,7 @@ class CurrentRequestLoggingAttributes < ActiveSupport::CurrentAttributes
       rescued_exception:,
       rescued_exception_trace:,
       validation_errors:,
+      answer_metadata:,
     }.compact_blank
   end
 end

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -11,6 +11,8 @@ module Question
     validate :validate_file_size
     validate :validate_file_extension
 
+    after_validation :set_logging_attributes
+
     FILE_UPLOAD_MAX_SIZE_IN_MB = 7
     FILE_TYPES = [
       "text/csv",
@@ -153,6 +155,15 @@ module Question
       uuid = SecureRandom.uuid
       extension = ::File.extname(file.path)
       "#{uuid}#{extension}"
+    end
+
+    def set_logging_attributes
+      if file.present?
+        CurrentRequestLoggingAttributes.answer_metadata = {
+          file_size_in_bytes: file.size,
+          file_type: file.content_type,
+        }
+      end
     end
   end
 end

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -96,10 +96,7 @@ module Question
       key = file_upload_s3_key(tempfile)
       FileUploadS3Service.new.upload_to_s3(tempfile, key)
 
-      FileUploadLogger.log_s3_operation(key, "Uploaded file to S3 for file upload question", {
-        file_size_in_bytes: file.size,
-        file_type: file.content_type,
-      })
+      FileUploadLogger.log_s3_operation(key, "Uploaded file to S3 for file upload question")
 
       check_scan_result(key)
 
@@ -133,20 +130,12 @@ module Question
 
     def validate_file_size
       if file.present? && file.size > FILE_UPLOAD_MAX_SIZE_IN_MB.megabytes
-        Rails.logger.info("File upload question validation failed: file too big", {
-          file_size_in_bytes: file.size,
-          file_type: file.content_type,
-        })
         errors.add(:file, :too_big)
       end
     end
 
     def validate_file_extension
       if file.present? && FILE_TYPES.exclude?(file.content_type)
-        Rails.logger.info("File upload question validation failed: disallowed file type", {
-          file_size_in_bytes: file.size,
-          file_type: file.content_type,
-        })
         errors.add(:file, :disallowed_type)
       end
     end

--- a/spec/models/current_request_logging_attributes_spec.rb
+++ b/spec/models/current_request_logging_attributes_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe CurrentRequestLoggingAttributes, type: :model do
       current.rescued_exception = "StandardError"
       current.rescued_exception_trace = "a trace"
       current.validation_errors = ["text: blank"]
+      current.answer_metadata = { foo: "bar" }
 
       expect(current.as_hash).to eq({
         request_host: "www.example.com",
@@ -57,6 +58,7 @@ RSpec.describe CurrentRequestLoggingAttributes, type: :model do
         rescued_exception: "StandardError",
         rescued_exception_trace: "a trace",
         validation_errors: ["text: blank"],
+        answer_metadata: { foo: "bar" },
       })
     end
 
@@ -78,6 +80,12 @@ RSpec.describe CurrentRequestLoggingAttributes, type: :model do
       current.validation_errors = []
 
       expect(current.as_hash.keys).not_to include :validation_errors
+    end
+
+    it "does not include the answer metadata if hash is empty" do
+      current.answer_metadata = {}
+
+      expect(current.as_hash.keys).not_to include :answer_metadata
     end
   end
 end

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -78,9 +78,7 @@ RSpec.describe Question::File, type: :model do
 
         it "logs information about the file" do
           expect(Rails.logger).to have_received(:info).with("Uploaded file to S3 for file upload question",
-                                                            { file_size_in_bytes:,
-                                                              file_type:,
-                                                              s3_object_key: key })
+                                                            { s3_object_key: key })
         end
 
         it "does not add any errors" do
@@ -425,20 +423,11 @@ RSpec.describe Question::File, type: :model do
       before do
         allow(uploaded_file).to receive_messages(size: file_size_in_bytes, content_type: file_type)
         question.file = uploaded_file
-
-        allow(Rails.logger).to receive(:info).at_least(:once)
       end
 
       it "returns an error" do
         expect(question).not_to be_valid
         expect(question.errors[:file]).to include "The selected file must be smaller than 7MB"
-      end
-
-      it "logs information about the file" do
-        question.validate
-        expect(Rails.logger).to have_received(:info).with("File upload question validation failed: file too big",
-                                                          { file_size_in_bytes:,
-                                                            file_type: })
       end
     end
 
@@ -450,20 +439,11 @@ RSpec.describe Question::File, type: :model do
       before do
         allow(uploaded_file).to receive_messages(size: file_size_in_bytes, content_type: file_type)
         question.file = uploaded_file
-
-        allow(Rails.logger).to receive(:info).at_least(:once)
       end
 
       it "returns an error" do
         expect(question).not_to be_valid
         expect(question.errors[:file]).to include I18n.t("activemodel.errors.models.question/file.attributes.file.disallowed_type")
-      end
-
-      it "logs information about the file" do
-        question.validate
-        expect(Rails.logger).to have_received(:info).with("File upload question validation failed: disallowed file type",
-                                                          { file_size_in_bytes:,
-                                                            file_type: })
       end
     end
 
@@ -475,18 +455,11 @@ RSpec.describe Question::File, type: :model do
         before do
           allow(uploaded_file).to receive_messages(size: file_size_in_bytes, content_type: file_type)
           question.file = uploaded_file
-
-          allow(Rails.logger).to receive(:info).at_least(:once)
         end
 
         it "does not return an error" do
           expect(question).to be_valid
           expect(question.errors[:file]).to be_empty
-        end
-
-        it "does not log information about the file" do
-          question.validate
-          expect(Rails.logger).not_to have_received(:info)
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UcS768Hz/2175-log-validation-error-messages-in-admin-and-runner

Add an `answer_metadata` logging attribute to log lines, and populate this for `file` questions with the file_type and file_size attributes for the answer. We can then consume our standard request logs for the request to submit a file upload answer, which also now includes any validation errors rather than needing to add explicit logging for file upload in order to extract and report on this data.

Remove the explicit logging that is no longer needed.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
