### PR TITLE
Show error message if the file is empty

### DIFF
--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -10,6 +10,7 @@ module Question
     validates :file, presence: true, unless: :is_optional?
     validate :validate_file_size
     validate :validate_file_extension
+    validate :validate_not_empty
 
     after_validation :set_logging_attributes
 
@@ -137,6 +138,12 @@ module Question
     def validate_file_extension
       if file.present? && FILE_TYPES.exclude?(file.content_type)
         errors.add(:file, :disallowed_type)
+      end
+    end
+
+    def validate_not_empty
+      if file.present? && ::File.zero?(file.path)
+        errors.add(:file, :empty)
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,7 @@ en:
               blank: Select a file
               contains_virus: The selected file contains a virus
               disallowed_type: The selected file must be a CSV, DOC, DOCX, JPEG, JPG, JSON, ODT, PDF, PNG, RTF, TXT, or XLSX
+              empty: The selected file is empty
               scan_failure: The selected file could not be uploaded - try again
               too_big: The selected file must be smaller than 7MB
         question/name:

--- a/spec/features/fill_in_file_upload_question_spec.rb
+++ b/spec/features/fill_in_file_upload_question_spec.rb
@@ -41,7 +41,7 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
     allow(mock_s3_client).to receive(:put_object)
     allow(mock_s3_client).to receive(:get_object_tagging).and_return({ tag_set: [{ key: "GuardDutyMalwareScanStatus", value: scan_status }] })
 
-    FileUtils.touch test_file
+    File.write(test_file, "some content")
   end
 
   context "when the file is successfully uploaded" do

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -629,6 +629,7 @@ RSpec.describe Forms::PageController, type: :request do
         let(:question) { { file: Rack::Test::UploadedFile.new(tempfile.path, content_type) } }
 
         before do
+          File.write(tempfile, "some content")
           allow(Aws::S3::Client).to receive(:new).and_return(mock_s3_client)
           allow(mock_s3_client).to receive(:get_object_tagging).and_return({ tag_set: [{ key: "GuardDutyMalwareScanStatus", value: "NO_THREATS_FOUND" }] })
         end
@@ -687,7 +688,7 @@ RSpec.describe Forms::PageController, type: :request do
         end
 
         it "adds validation_errors logging attribute" do
-          expect(log_lines[0]["validation_errors"]).to eq(["file: disallowed_type"])
+          expect(log_lines[0]["validation_errors"]).to eq(["file: disallowed_type", "file: empty"])
         end
 
         it "adds answer_metadata logging attribute" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/VB6S8I1d/2197-add-error-messages-for-form-fillers-if-the-file-they-select-is-empty

Validate that files aren't empty, and if they are show a validation error to the user.

<img width="943" alt="Screenshot 2025-04-23 at 16 42 35" src="https://github.com/user-attachments/assets/1cc52578-caf2-4bce-80b6-4140973471c2" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
