### PR TITLE
Stop sending old form started/submitted metrics

### DIFF
--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -21,25 +21,6 @@ class CloudWatchService
         },
       ],
     )
-
-    # Stop sending this metric once we have been sending the new metric for long enough and switched over
-    # forms-admin to read the new metric
-    cloudwatch_client.put_metric_data(
-      namespace: old_form_metrics_namespace,
-      metric_data: [
-        {
-          metric_name: "submitted",
-          dimensions: [
-            {
-              name: "form_id",
-              value: form_id.to_s,
-            },
-          ],
-          value: 1,
-          unit: "Count",
-        },
-      ],
-    )
   end
 
   def self.log_form_start(form_id:)
@@ -53,25 +34,6 @@ class CloudWatchService
           dimensions: [
             environment_dimension,
             form_id_dimension(form_id),
-          ],
-          value: 1,
-          unit: "Count",
-        },
-      ],
-    )
-
-    # Stop sending this metric once we have been sending the new metric for long enough and switched over
-    # forms-admin to read the new metric
-    cloudwatch_client.put_metric_data(
-      namespace: old_form_metrics_namespace,
-      metric_data: [
-        {
-          metric_name: "started",
-          dimensions: [
-            {
-              name: "form_id",
-              value: form_id.to_s,
-            },
           ],
           value: 1,
           unit: "Count",

--- a/spec/services/cloud_watch_service_spec.rb
+++ b/spec/services/cloud_watch_service_spec.rb
@@ -45,22 +45,6 @@ RSpec.describe CloudWatchService do
           },
         ],
       )
-      expect(cloudwatch_client).to receive(:put_metric_data).once.with(
-        namespace: "forms/#{forms_env}",
-        metric_data: [
-          {
-            metric_name: "submitted",
-            dimensions: [
-              {
-                name: "form_id",
-                value: form_id.to_s,
-              },
-            ],
-            value: 1,
-            unit: "Count",
-          },
-        ],
-      )
 
       described_class.log_form_submission(form_id:)
     end
@@ -90,22 +74,6 @@ RSpec.describe CloudWatchService do
               },
               {
                 name: "FormId",
-                value: form_id.to_s,
-              },
-            ],
-            value: 1,
-            unit: "Count",
-          },
-        ],
-      )
-      expect(cloudwatch_client).to receive(:put_metric_data).once.with(
-        namespace: "forms/#{forms_env}",
-        metric_data: [
-          {
-            metric_name: "started",
-            dimensions: [
-              {
-                name: "form_id",
                 value: form_id.to_s,
               },
             ],


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/yxarCr91/2241-use-new-cloudwatch-metrics-in-forms-admin

We've added new metrics that have a different name, namespace and dimensions for displaying the form metrics to form creators and were sending these alongside the old metrics. The new metrics better conformed to the CloudWatch naming conventions. Forms-admin is now using the new metrics, so we can stop sending the old metrics.

Forms-admin was changed to read the new metrics in https://github.com/alphagov/forms-admin/pull/1929

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
