### PR TITLE
Enable ActiveRecord encryption on Answers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,10 +63,14 @@ gem "lograge"
 # For AWS interactions
 gem "aws-sdk-cloudwatch"
 gem "aws-sdk-codepipeline", "~> 1.97"
+gem "aws-sdk-kms"
 gem "aws-sdk-s3"
 gem "aws-sdk-sesv2"
 gem "aws-sdk-sqs"
 gem "aws-sdk-sts"
+
+# For managing KMS keys in production
+gem "active_kms"
 
 # For sending submissions as CSV
 gem "csv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,8 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_kms (0.2.0)
+      activerecord (>= 7.1)
     activejob (8.0.2)
       activesupport (= 8.0.2)
       globalid (>= 0.3.6)
@@ -509,9 +511,11 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  active_kms
   activeresource
   aws-sdk-cloudwatch
   aws-sdk-codepipeline (~> 1.97)
+  aws-sdk-kms
   aws-sdk-s3
   aws-sdk-sesv2
   aws-sdk-sqs

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,6 +1,8 @@
 class Submission < ApplicationRecord
   delegate :preview?, to: :mode_object
 
+  encrypts :answers
+
   enum :mail_status, {
     pending: "pending",
     delivered: "delivered",

--- a/config/application.rb
+++ b/config/application.rb
@@ -80,10 +80,6 @@ module FormsRunner
     # Prevent ActiveRecord::PreparedStatementCacheExpired errors when adding columns
     config.active_record.enumerate_columns_in_select_statements = true
 
-    # Set ActiveRecord Encryption keys
-    config.active_record.encryption.primary_key = Settings.active_record_encryption.primary_key
-    config.active_record.encryption.deterministic_key = Settings.active_record_encryption.deterministic_key
-    config.active_record.encryption.key_derivation_salt = Settings.active_record_encryption.key_derivation_salt
     # TODO: remove this when all sensitive data is encrypted
     # See https://guides.rubyonrails.org/active_record_encryption.html#support-for-unencrypted-data
     config.active_record.encryption.support_unencrypted_data = true

--- a/config/application.rb
+++ b/config/application.rb
@@ -80,6 +80,14 @@ module FormsRunner
     # Prevent ActiveRecord::PreparedStatementCacheExpired errors when adding columns
     config.active_record.enumerate_columns_in_select_statements = true
 
+    # Set ActiveRecord Encryption keys
+    config.active_record.encryption.primary_key = Settings.active_record_encryption.primary_key
+    config.active_record.encryption.deterministic_key = Settings.active_record_encryption.deterministic_key
+    config.active_record.encryption.key_derivation_salt = Settings.active_record_encryption.key_derivation_salt
+    # TODO: remove this when all sensitive data is encrypted
+    # See https://guides.rubyonrails.org/active_record_encryption.html#support-for-unencrypted-data
+    config.active_record.encryption.support_unencrypted_data = true
+
     config.after_initialize do
       # Localization isn't available if this is called from an initializer
       GOVUKDesignSystemFormBuilder.configure do |conf|

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,4 +77,9 @@ Rails.application.configure do
 
   # Configure previews for mailers - https://guides.rubyonrails.org/action_mailer_basics.html#previewing-emails
   config.action_mailer.preview_paths << Rails.root.join("spec/mailers/").to_s
+
+  # Set ActiveRecord Encryption keys - this is overriding the default which is to use active_kms gem in application.rb
+  config.active_record.encryption.primary_key = Settings.active_record_encryption.primary_key
+  config.active_record.encryption.deterministic_key = Settings.active_record_encryption.deterministic_key
+  config.active_record.encryption.key_derivation_salt = Settings.active_record_encryption.key_derivation_salt
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,9 @@ Rails.application.configure do
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  # Set ActiveRecord Encryption keys
+  if ENV.key? "KMS_KEY_ID"
+    config.active_record.encryption.key_provider = ActiveKms::AwsKeyProvider.new(key_id: ENV["KMS_KEY_ID"])
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -74,4 +74,9 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.x.aws_ses_form_submission_mailer.delivery_method = :test
+
+  # Set ActiveRecord Encryption keys - this is overriding the default which is to use active_kms gem in application.rb
+  config.active_record.encryption.primary_key = Settings.active_record_encryption.primary_key
+  config.active_record.encryption.deterministic_key = Settings.active_record_encryption.deterministic_key
+  config.active_record.encryption.key_derivation_salt = Settings.active_record_encryption.key_derivation_salt
 end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,3 +1,8 @@
+active_record_encryption:
+  primary_key: CC2SOludR0L15FLQkLNv8sbiQ5yNyHiF
+  deterministic_key: vN8HaxVlbWVnohKU0aV8p36nwYEK1hZN
+  key_derivation_salt: k7cODzIzpjWkKKGqVnabRzXtTgLnT813
+
 aws:
   file_upload_s3_bucket_name: govuk-forms-dev-file-upload
   ses_submission_email_configuration_set_name: bounces_and_complaints_handling_rule

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,3 +1,8 @@
+active_record_encryption:
+  primary_key: CC2SOludR0L15FLQkLNv8sbiQ5yNyHiF
+  deterministic_key: vN8HaxVlbWVnohKU0aV8p36nwYEK1hZN
+  key_derivation_salt: k7cODzIzpjWkKKGqVnabRzXtTgLnT813
+
 forms_admin:
   # URL to form-admin
   base_url: http://localhost


### PR DESCRIPTION
## 🚨 NOTE do not merge before the secret values are set in Parameter Store (otherwise weak keys will be used to encrypt)

Answers provided by users and stored in our database are now encrypted using Rails built in ActiveRecord feature.

When I tested locally, I could see that the database encrypted the `answers` blob.

I've also deployed to Dev with the corresponding infrastructure change. I filled in a form and received the submission fine.

Related PR https://github.com/alphagov/forms-deploy/pull/1554

### What problem does this pull request solve?

Trello card: https://trello.com/c/jPL9tJkh/2174-switch-on-activerecord-encryption-for-runners-database-that-stores-user-submission-data 

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
