### PR TITLE
Add defaults for GOVUK Form Builder

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -79,5 +79,15 @@ module FormsRunner
 
     # Prevent ActiveRecord::PreparedStatementCacheExpired errors when adding columns
     config.active_record.enumerate_columns_in_select_statements = true
+
+    config.after_initialize do
+      # Localization isn't available if this is called from an initializer
+      GOVUKDesignSystemFormBuilder.configure do |conf|
+        conf.default_submit_button_text = I18n.t("govuk_design_system_formbuilder.default_submit_button_text")
+        conf.default_error_summary_title = I18n.t("govuk_design_system_formbuilder.default_error_summary_title")
+        conf.default_radio_divider_text = I18n.t("govuk_design_system_formbuilder.default_radio_divider_text")
+        conf.default_check_box_divider_text = I18n.t("govuk_design_system_formbuilder.default_check_box_divider_text")
+      end
+    end
   end
 end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -53,8 +53,9 @@ data:
 # Find translate calls
 search:
   ## Paths or `File.find` patterns to search in:
-  # paths:
-  #  - app/
+  paths:
+    - app/
+    - config/
 
   ## Root directories for relative keys resolution.
   # relative_roots:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,6 +170,11 @@ en:
         remove: Remove
         remove_file_guidance: You can remove this file if you need to upload a different one.
         your_file: Your file
+  govuk_design_system_formbuilder:
+    default_check_box_divider_text: or
+    default_error_summary_title: There is a problem
+    default_radio_divider_text: or
+    default_submit_button_text: Continue
   helpers:
     hint:
       email_confirmation_input:


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/I7wLHZQd/2240-spike-investigate-steps-needed-to-localise-dependency-content

Add defaults for GOVUK Design System Form Builder

In order to support Welsh translations, add configuration for the govuk_design_system_formbuilder gem to set default content for the components we can configure it for.

The documentation for govuk_design_system_formbuilder suggests adding this in a Rails initialiser file. However, if we try to set this configuration during initialization using translations, the localization has not yet been initialized so loading the translations fails. Due to this, we are setting the configuration in an after_initialize callback.

If translations were to fail to load, this would break our feature tests - so these test we are doing the initialization in the correct place.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
