### PR TITLE
Create SolidQueue healthcheck process

### DIFF
--- a/bin/jobs
+++ b/bin/jobs
@@ -6,12 +6,12 @@ require "solid_queue/cli"
 HEALTHCHECK_FILE = Rails.root.join('tmp/healthcheck').freeze
 
 SolidQueue.on_start do |_supervisor|
-  Rails.logger.info "[SolidQueue] Writing lifecycle file for healthcheck..."
+  Rails.logger.info "[SolidQueue] Writing healthcheck lifecycle file..."
   FileUtils.touch(Rails.root.join(HEALTHCHECK_FILE))
 end
 
 SolidQueue.on_stop do |_supervisor|
-  Rails.logger.info "[SolidQueue] Removing lifecycle file for healthcheck..."
+  Rails.logger.info "[SolidQueue] Removing healthcheck lifecycle file..."
   FileUtils.rm_f(Rails.root.join(HEALTHCHECK_FILE))
 end
 

--- a/bin/jobs
+++ b/bin/jobs
@@ -3,4 +3,16 @@
 require_relative "../config/environment"
 require "solid_queue/cli"
 
+HEALTHCHECK_FILE = Rails.root.join('tmp/healthcheck').freeze
+
+SolidQueue.on_start do |_supervisor|
+  Rails.logger.info "[SolidQueue] Writing lifecycle file for healthcheck..."
+  FileUtils.touch(Rails.root.join(HEALTHCHECK_FILE))
+end
+
+SolidQueue.on_stop do |_supervisor|
+  Rails.logger.info "[SolidQueue] Removing lifecycle file for healthcheck..."
+  FileUtils.rm_f(Rails.root.join(HEALTHCHECK_FILE))
+end
+
 SolidQueue::Cli.start(ARGV)

--- a/bin/jobs
+++ b/bin/jobs
@@ -3,16 +3,17 @@
 require_relative "../config/environment"
 require "solid_queue/cli"
 
-HEALTHCHECK_FILE = Rails.root.join('tmp/healthcheck').freeze
+SOLIDQUEUE_HEALTHCHECK_FILE = Rails.root.join('tmp/solidqueue_healthcheck').freeze
 
 SolidQueue.on_start do |_supervisor|
   Rails.logger.info "[SolidQueue] Writing healthcheck lifecycle file..."
-  FileUtils.touch(Rails.root.join(HEALTHCHECK_FILE))
+  FileUtils.touch(SOLIDQUEUE_HEALTHCHECK_FILE)
 end
 
 SolidQueue.on_stop do |_supervisor|
   Rails.logger.info "[SolidQueue] Removing healthcheck lifecycle file..."
-  FileUtils.rm_f(Rails.root.join(HEALTHCHECK_FILE))
+  FileUtils.rm_f(SOLIDQUEUE_HEALTHCHECK_FILE)
+  sleep 100
 end
 
 SolidQueue::Cli.start(ARGV)


### PR DESCRIPTION
### What problem does this pull request solve?

Trello: https://trello.com/c/f7js82Cm/635-run-solid-queue-as-its-own-ecs-task

We want to run the Solid Queue worker as a separate ECS task (see this PR: https://github.com/alphagov/forms-deploy/pull/1558). The worker ECS task needs a healthcheck to verify the task is running ok. 

This pull requests implements a "lifecycle hook" that creates a `healthcheck` file when Solid Queue starts and removes the file when the process stops. 

According to the Solid Queue README a lifecycle hook is the encouraged approach for this type of scenario (see [README](https://github.com/rails/solid_queue?tab=readme-ov-file#lifecycle-hooks)).

Thanks to @lfdebrux's research I've implemented something similar to SideKiq's file-based readiness probe (see [README](https://github.com/sidekiq/sidekiq/wiki/Kubernetes#sidekiq)).

I've tested this locally and in `dev`. The file gets created when the process starts and removed when the process stops. When deployed along side the relevant infrastructure changes the ECS tasks start running and achieve a `Healthy` "Health status".