### PR TITLE
Add localization for design system component defaults

### DIFF
--- a/app/components/cookie_banner_component/view.html.erb
+++ b/app/components/cookie_banner_component/view.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_cookie_banner(html_attributes: {hidden: true, data: { module: "cookie-banner" }}) do |banner| %>
+<%= govuk_cookie_banner(html_attributes: {hidden: true, data: { module: "cookie-banner" }}, aria_label: t("cookie_banner.aria_label")) do |banner| %>
   <%= banner.with_message(heading_text: t("cookie_banner.heading")) do |message| %>
     <% message.with_action { content_tag(:button, t("cookie_banner.accept"), type:"button", class:"govuk-button", data: {function: "accept-cookies", module: "govuk-button"}) } %>
     <% message.with_action { content_tag(:button, t("cookie_banner.reject"), type:"button", class:"govuk-button", data: {function: "reject-cookies", module: "govuk-button"}) } %>

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -57,7 +57,7 @@ module Forms
       {
         key: { text: helpers.sanitize(question_name) },
         value: { text: page.show_answer },
-        actions: [{ href: change_link(page), visually_hidden_text: helpers.strip_tags(question_name) }],
+        actions: [{ text: I18n.t("govuk_components.govuk_summary_list.change"), href: change_link(page), visually_hidden_text: helpers.strip_tags(question_name) }],
       }
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,7 @@ en:
       title: Success
   cookie_banner:
     accept: Accept analytics cookies
+    aria_label: Cookie banner
     content: We’d like to use analytics cookies so we can understand how you use this website and make improvements.
     heading: Cookies on GOV.UK Forms
     policy_link: How we use cookies
@@ -172,6 +173,9 @@ en:
         remove_file_guidance: You can remove this file if you need to upload a different one.
         your_file: Your file
   gov_uk_forms: GOV.UK Forms
+  govuk_components:
+    govuk_summary_list:
+      change: Change
   govuk_design_system_formbuilder:
     default_check_box_divider_text: or
     default_error_summary_title: There is a problem


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/I7wLHZQd/2240-spike-investigate-steps-needed-to-localise-dependency-content

So that we can add Welsh translations, localize the content for components that came from the defaults

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
