### PR TITLE
Log SNS message timestamp

### DIFF
--- a/app/jobs/receive_submission_bounces_and_complaints_job.rb
+++ b/app/jobs/receive_submission_bounces_and_complaints_job.rb
@@ -47,6 +47,8 @@ private
 
       receipt_handle = message.receipt_handle
       sns_message = JSON.parse(message.body)
+      CurrentJobLoggingAttributes.sns_message_timestamp = sns_message["Timestamp"]
+
       ses_message = JSON.parse(sns_message["Message"])
       ses_message_id = ses_message["mail"]["messageId"]
       CurrentJobLoggingAttributes.mail_message_id = ses_message_id

--- a/app/jobs/receive_submission_deliveries_job.rb
+++ b/app/jobs/receive_submission_deliveries_job.rb
@@ -47,6 +47,8 @@ private
 
       receipt_handle = message.receipt_handle
       sns_message = JSON.parse(message.body)
+      CurrentJobLoggingAttributes.sns_message_timestamp = sns_message["Timestamp"]
+
       ses_message = JSON.parse(sns_message["Message"])
       ses_message_id = ses_message["mail"]["messageId"]
       CurrentJobLoggingAttributes.mail_message_id = ses_message_id

--- a/app/models/current_job_logging_attributes.rb
+++ b/app/models/current_job_logging_attributes.rb
@@ -1,5 +1,5 @@
 class CurrentJobLoggingAttributes < ActiveSupport::CurrentAttributes
-  attribute :job_id, :form_id, :form_name, :submission_reference, :mail_message_id, :sqs_message_id
+  attribute :job_id, :form_id, :form_name, :submission_reference, :mail_message_id, :sqs_message_id, :sns_message_timestamp
 
   def as_hash
     {
@@ -9,6 +9,7 @@ class CurrentJobLoggingAttributes < ActiveSupport::CurrentAttributes
       submission_reference:,
       mail_message_id:,
       sqs_message_id:,
+      sns_message_timestamp:,
     }.compact_blank
   end
 end

--- a/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
+++ b/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
   let(:sqs_message_id) { "sqs-message-id" }
   let(:sqs_message) { instance_double(Aws::SQS::Types::Message, message_id: sqs_message_id, receipt_handle:, body: sns_message_body) }
   let(:messages) { [] }
-  let(:sns_message_body) { { "Message" => ses_message_body.to_json }.to_json }
+  let(:sns_message_timestamp) { "2025-05-09T10:25:43.972Z" }
+  let(:sns_message_body) { { "Message" => ses_message_body.to_json, "Timestamp" => sns_message_timestamp }.to_json }
   let(:event_type) { "Bounce" }
   let(:ses_message_body) { { "mail" => { "messageId" => mail_message_id }, "eventType": event_type } }
   let(:file_upload_steps) do
@@ -106,6 +107,9 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
                                        "event" => "form_submission_bounced",
                                        "form_id" => form_with_file_upload.id,
                                        "submission_reference" => reference,
+                                       "mail_message_id" => mail_message_id,
+                                       "sqs_message_id" => sqs_message_id,
+                                       "sns_message_timestamp" => sns_message_timestamp,
                                        "job_id" => @job_id,
                                      ))
       end
@@ -168,6 +172,7 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
                                          "level" => "WARN",
                                          "mail_message_id" => mail_message_id,
                                          "sqs_message_id" => sqs_message_id,
+                                         "sns_message_timestamp" => sns_message_timestamp,
                                          "message" => "Error processing message - StandardError: Test error",
                                          "job_id" => @job_id,
                                        ))
@@ -211,6 +216,7 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
                                        "submission_reference" => reference,
                                        "mail_message_id" => mail_message_id,
                                        "sqs_message_id" => sqs_message_id,
+                                       "sns_message_timestamp" => sns_message_timestamp,
                                        "message" => "Form event",
                                        "event" => "form_submission_complaint",
                                        "job_id" => @job_id,

--- a/spec/jobs/receive_submission_deliveries_job_spec.rb
+++ b/spec/jobs/receive_submission_deliveries_job_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
   let(:event_type) { "Delivery" }
   let(:sqs_message) { instance_double(Aws::SQS::Types::Message, message_id: sqs_message_id, receipt_handle:, body: sns_delivery_message_body) }
   let(:messages) { [] }
-  let(:sns_delivery_message_body) { { "Message" => ses_delivery_message_body.to_json }.to_json }
+  let(:sns_message_timestamp) { "2025-05-09T10:25:43.972Z" }
+  let(:sns_delivery_message_body) { { "Message" => ses_delivery_message_body.to_json, "Timestamp" => sns_message_timestamp }.to_json }
   let(:ses_delivery_message_body) { { "mail" => { "messageId" => mail_message_id }, "eventType": event_type } }
   let(:file_upload_steps) do
     [
@@ -106,6 +107,7 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
                                        "event" => "form_submission_delivered",
                                        "form_id" => form_with_file_upload.id,
                                        "submission_reference" => reference,
+                                       "sns_message_timestamp" => sns_message_timestamp,
                                        "job_id" => @job_id,
                                      ))
       end
@@ -162,6 +164,7 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
                                          "level" => "WARN",
                                          "mail_message_id" => mail_message_id,
                                          "sqs_message_id" => sqs_message_id,
+                                         "sns_message_timestamp" => sns_message_timestamp,
                                          "message" => "Error processing message - StandardError: Test error",
                                          "job_id" => @job_id,
                                        ))


### PR DESCRIPTION
### What problem does this pull request solve?

Log the timestamp for SNS messages we receive for email deliveries and bounces and complaints from the SQS queues. This information is useful because if we get both a bounce and a delivery notification, we will be able to work out which notification was sent first.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
