### PR TITLE
Fix email confirmation link to call charges

### DIFF
--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -126,7 +126,7 @@ private
     notify_body = NotifyTemplateFormatter.new
     formatted_phone_number = notify_body.normalize_whitespace(@form.support_phone)
 
-    "#{formatted_phone_number}\n\n[#{I18n.t('support_details.call_charges')}](#{@current_context.support_details.call_back_url})"
+    "#{formatted_phone_number}\n\n[#{I18n.t('support_details.call_charges')}](#{@current_context.support_details.call_charges_url})"
   end
 
   def support_email_details

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -770,7 +770,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 private
 
   def contact_support_details_format
-    phone_number = "#{form_data.support_phone}\n\n[#{I18n.t('support_details.call_charges')}]()"
+    phone_number = "#{form_data.support_phone}\n\n[#{I18n.t('support_details.call_charges')}](https://www.gov.uk/call-charges)"
     email = "[#{form_data.support_email}](mailto:#{form_data.support_email})"
     online = "[#{form_data.support_url_text}](#{form_data.support_url})"
     [phone_number, email, online].compact_blank.join("\n\n")

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe FormSubmissionService do
       },
     }
   end
-  let(:current_context) { instance_double(Flow::Context, form:, journey:, completed_steps: all_steps, support_details: OpenStruct.new(call_back_url: "http://gov.uk"), answers:) }
+  let(:current_context) { instance_double(Flow::Context, form:, journey:, completed_steps: all_steps, support_details: OpenStruct.new(call_charges_url: "http://gov.uk"), answers:) }
 
   let(:output) { StringIO.new }
   let(:logger) do


### PR DESCRIPTION
Currently the form-filler email confirmation includes a link to the call charges page when the form has a contact phone number set.

This link has text but no URL. This is because the email confirmation uses an incorrect attribute for the support_details, which returns an empty string. It's sent to notify as:

```
[Find out about call charges]()
```

When notify converts the markdown to the HTML for the email it becomes:

```
<a style=3D"word-wrap: break-word; color: #1D70B8;" href=3D"http://">Find out about call charges</a>
```

In gmail it displays as:

![image](https://github.com/user-attachments/assets/7662ee14-b794-4f1b-83c8-c26abecf5bf4)

In outlook it shows as:

![image](https://github.com/user-attachments/assets/f5caa21d-c285-43fd-b2a9-a79540b60420)

It seems the attribute was always wrong and the tests written to expect a link with no URL, which I think must be a mistake.

This commit changes the attribute to the correct value and updates the tests.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
