### PR TITLE
Display submitted at time in local time

### DIFF
--- a/app/jobs/send_submission_job.rb
+++ b/app/jobs/send_submission_job.rb
@@ -12,7 +12,7 @@ class SendSubmissionJob < ApplicationJob
     form = submission.form
     mailer_options = FormSubmissionService::MailerOptions.new(title: form.name,
                                                               is_preview: submission.preview?,
-                                                              timestamp: submission.created_at,
+                                                              timestamp: submission.submission_time,
                                                               submission_reference: submission.reference,
                                                               payment_url: form.payment_url_with_reference(submission.reference))
 
@@ -35,6 +35,8 @@ class SendSubmissionJob < ApplicationJob
     CloudWatchService.log_job_failure(self.class.name)
     raise
   end
+
+private
 
   def scheduled_at_or_enqueued_at
     scheduled_at || enqueued_at

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -15,6 +15,10 @@ class Submission < ApplicationRecord
     @form ||= form_from_document
   end
 
+  def submission_time
+    created_at.in_time_zone(submission_timezone)
+  end
+
   def self.emailed?(reference)
     submission = Submission.find_by(reference: reference)
     submission.mail_message_id.present? if submission.present?
@@ -33,5 +37,9 @@ private
   def form_from_document
     v1_blob = Api::V1::Converter.new.to_api_v1_form_snapshot(form_document)
     Form.new(v1_blob, true)
+  end
+
+  def submission_timezone
+    Rails.configuration.x.submission.time_zone || "UTC"
   end
 end

--- a/spec/jobs/send_submission_job_spec.rb
+++ b/spec/jobs/send_submission_job_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 RSpec.describe SendSubmissionJob, type: :job do
   include ActiveJob::TestHelper
 
-  let(:submission) { create :submission, form_document: form, mail_status: :pending }
+  let(:submission_created_at) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
+  let(:submission) { create :submission, form_document: form, mail_status: :pending, created_at: submission_created_at }
   let(:form) { build(:form, id: 1, name: "Form 1") }
   let(:question) { build :text, question_text: "What is the meaning of life?", text: "42" }
   let(:step) { build :step, question: }
@@ -57,6 +58,30 @@ RSpec.describe SendSubmissionJob, type: :job do
 
     it "sends cloudwatch metric for the submission being sent" do
       expect(CloudWatchService).to have_received(:log_submission_sent).with(be_within(1000).of(5000))
+    end
+
+    describe "the submission time" do
+      context "with a time in BST" do
+        let(:submission_created_at) { Time.utc(2022, 9, 14, 7, 0o0, 0o0) }
+
+        it "passes the time as BST" do
+          expect(AwsSesSubmissionService).to have_received(:new) do |**args|
+            expect(args[:mailer_options].timestamp.zone).to eq("BST")
+            expect(args[:mailer_options].timestamp.strftime("%-d %B %Y - %l:%M%P")).to eq("14 September 2022 -  8:00am")
+          end
+        end
+      end
+
+      context "with a time in GMT" do
+        let(:submission_created_at) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
+
+        it "passes the time as GMT" do
+          expect(AwsSesSubmissionService).to have_received(:new) do |**args|
+            expect(args[:mailer_options].timestamp.zone).to eq("GMT")
+            expect(args[:mailer_options].timestamp.strftime("%-d %B %Y - %l:%M%P")).to eq("14 December 2022 -  1:00pm")
+          end
+        end
+      end
     end
   end
 

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -11,6 +11,7 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
   let(:payment_url) { nil }
   let(:csv_filename) { nil }
+  let(:submission_timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
   let(:mailer_options) do
     FormSubmissionService::MailerOptions.new(title:,
                                              is_preview:,
@@ -64,22 +65,18 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
 
         describe "submission date/time" do
           context "with a time in BST" do
-            let(:timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0) }
+            let(:submission_timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0).in_time_zone(submission_timezone) }
 
             it "includes the date and time the user submitted the form" do
-              travel_to timestamp do
-                expect(part.body).to match("This form was submitted at 9:00am on 14 September 2022")
-              end
+              expect(part.body).to match("This form was submitted at 9:00am on 14 September 2022")
             end
           end
 
           context "with a time in GMT" do
-            let(:timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
+            let(:submission_timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0).in_time_zone(submission_timezone) }
 
             it "includes the date and time the user submitted the form" do
-              travel_to timestamp do
-                expect(part.body).to match("This form was submitted at 1:00pm on 14 December 2022")
-              end
+              expect(part.body).to match("This form was submitted at 1:00pm on 14 December 2022")
             end
           end
         end
@@ -116,22 +113,18 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
 
         describe "submission date/time" do
           context "with a time in BST" do
-            let(:timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0) }
+            let(:submission_timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0).in_time_zone(submission_timezone) }
 
             it "includes the date and time the user submitted the form" do
-              travel_to timestamp do
-                expect(part.body).to match("This form was submitted at 9:00am on 14 September 2022")
-              end
+              expect(part.body).to match("This form was submitted at 9:00am on 14 September 2022")
             end
           end
 
           context "with a time in GMT" do
-            let(:timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
+            let(:submission_timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0).in_time_zone(submission_timezone) }
 
             it "includes the date and time the user submitted the form" do
-              travel_to timestamp do
-                expect(part.body).to match("This form was submitted at 1:00pm on 14 December 2022")
-              end
+              expect(part.body).to match("This form was submitted at 1:00pm on 14 December 2022")
             end
           end
         end
@@ -284,9 +277,5 @@ private
 
   def submission_timezone
     Rails.configuration.x.submission.time_zone || "UTC"
-  end
-
-  def submission_timestamp
-    Time.use_zone(submission_timezone) { Time.zone.now }
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/4EnxrmLq/2864-submitted-at-time-is-in-utc-in-submission-emails-after-switching-to-ses

Emails sent using SES were displaying the submitted at time in UTC rather than in local time. This is because we are using the created_at time for the submission when processing the SendSubmissionJob, which is stored as UTC.

We need to convert the UTC time to the time we've configured to display submissions in, which is London time.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
