### PR TITLE
Log when file upload details component is clicked

### DIFF
--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -9,7 +9,8 @@ import {
   installAnalyticsScript,
   setDefaultConsent,
   sendPageViewEvent,
-  attachExternalLinkTracker
+  attachExternalLinkTracker,
+  attachDetailsOpenTracker
 } from '../javascript/utils/google-analytics'
 import { CookieBanner } from '../../components/cookie_banner_component/cookie-banner'
 import { CookiePage } from '../../components/cookie_consent_form_component/cookie-consent-form'
@@ -47,6 +48,7 @@ if (document.body.dataset.googleAnalyticsEnabled === 'true') {
   // will be sent
   sendPageViewEvent()
   attachExternalLinkTracker()
+  attachDetailsOpenTracker()
 }
 
 initAll()

--- a/app/frontend/javascript/utils/google-analytics/index.js
+++ b/app/frontend/javascript/utils/google-analytics/index.js
@@ -96,3 +96,20 @@ export function attachExternalLinkTracker () {
     })
   })
 }
+
+export function attachDetailsOpenTracker () {
+  const detailsComponents = document.querySelectorAll('details')
+  window.dataLayer = window.dataLayer || []
+  detailsComponents.forEach(function (detailsElement) {
+    detailsElement.addEventListener('toggle', function (event) {
+      const summary = detailsElement.querySelector('summary')
+      if (detailsElement.open) {
+        window.dataLayer.push({
+          event: 'details_opened',
+          url: window.location,
+          text: summary.textContent
+        })
+      }
+    })
+  })
+}

--- a/app/frontend/javascript/utils/google-analytics/index.test.js
+++ b/app/frontend/javascript/utils/google-analytics/index.test.js
@@ -11,6 +11,10 @@ import {
 } from '.'
 import { describe, beforeEach, afterEach, it, expect } from 'vitest'
 
+const sleep = milliseconds => {
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
+}
+
 describe('google_tag.mjs', () => {
   afterEach(() => {
     document.getElementsByTagName('html')[0].innerHTML = ''
@@ -162,8 +166,12 @@ describe('google_tag.mjs', () => {
     })
 
     describe('when the user closes an open details component', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         window.document.body.innerHTML = `<details open="true"><summary>${summaryText}</summary></details>`
+
+        // wait for HTML parsing and rendering to complete before adding the event listener
+        await sleep(0)
+
         attachDetailsOpenTracker()
       })
 
@@ -179,8 +187,12 @@ describe('google_tag.mjs', () => {
     })
 
     describe('when the user opens a closed details component', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         window.document.body.innerHTML = `<details><summary>${summaryText}</summary></details>`
+
+        // wait for HTML parsing and rendering to complete before adding the event listener
+        await sleep(0)
+
         attachDetailsOpenTracker()
       })
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/0mqWd67h/2177-log-when-what-files-can-i-upload-details-component-is-clicked

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Adds a new tracker for Gogle Analytics that will push an event to the dataLayer if a details component is clicked:

```js
{
  event: 'details_opened',
  url: "https://submit.forms.service.gov.uk/form/5616/apply-for-a-juggling-licence-advanced/24586",
  text: "What files can I upload?"
}
```

This will help us see how often these bits of guidance are being used.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
