### PR TITLE
Add rakes task to retry failed submission jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
     env:
       RAILS_ENV: "test"
       DATABASE_URL: "postgres://postgres:postgres@localhost:5432/forms_runner_test"
+      QUEUE_DATABASE_URL: "postgres://postgres:postgres@localhost:5432/forms_runner_test_queue"
     steps:
       # TODO: remove these steps once we can use latest Chrome again (see https://github.com/teamcapybara/capybara/issues/2800)
       - uses: nanasess/setup-chromedriver@v2

--- a/config/database.yml
+++ b/config/database.yml
@@ -37,8 +37,13 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: forms_runner_test
+  primary: &primary_test
+    <<: *default
+    database: forms_runner_test
+  queue:
+    <<: *primary_test
+    database: forms_runner_test_queue
+    migrations_paths: db/queue_migrate
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -79,4 +79,8 @@ Rails.application.configure do
   config.active_record.encryption.primary_key = Settings.active_record_encryption.primary_key
   config.active_record.encryption.deterministic_key = Settings.active_record_encryption.deterministic_key
   config.active_record.encryption.key_derivation_salt = Settings.active_record_encryption.key_derivation_salt
+
+  # Make it so we can connect to the Solid Queue database. We don't set the Active Job adapter to use Solid Queue for
+  # tests
+  config.solid_queue.connects_to = { database: { writing: :queue } }
 end

--- a/lib/tasks/submissions.rake
+++ b/lib/tasks/submissions.rake
@@ -7,7 +7,7 @@ namespace :submissions do
     abort usage_message if form_id.blank?
 
     submissions_to_retry = Submission.where(form_id: form_id)
-                                      .bounced
+                                     .bounced
 
     Rails.logger.info "#{submissions_to_retry.length} submissions to retry for form with ID: #{form_id}"
 
@@ -15,5 +15,36 @@ namespace :submissions do
       Rails.logger.info "Retrying submission with reference #{submission.reference} for form with ID: #{form_id}"
       SendSubmissionJob.perform_later(submission)
     end
+  end
+
+  desc "Retry failed send submission job"
+  task :retry_failed_send_job, %i[job_id] => :environment do |_, args|
+    job_id = args[:job_id]
+
+    usage_message = "usage: rake submissions:retry_failed_send_job[<job_id>]"
+    abort usage_message if job_id.blank?
+
+    job = SolidQueue::Job.find_by(active_job_id: job_id)
+
+    abort "Job with job_id #{job_id} not found" unless job
+
+    failed_execution = SolidQueue::FailedExecution.find_by(job_id: job.id)
+
+    abort "Job with job_id #{job_id} is not failed" unless failed_execution
+
+    failed_execution.retry
+
+    Rails.logger.info "Scheduled retry for submission job with ID: #{job_id}"
+  end
+
+  desc "Retry all failed send submission jobs"
+  task retry_all_failed_send_jobs: :environment do |_, _args|
+    failed_jobs = SolidQueue::Job.joins(:failed_execution).where(class_name: SendSubmissionJob.name)
+
+    Rails.logger.info "Found #{failed_jobs.length} failed submission jobs to retry"
+
+    SolidQueue::FailedExecution.retry_all(failed_jobs)
+
+    Rails.logger.info "Retried #{failed_jobs.length} failed submission jobs"
   end
 end

--- a/spec/factories/models/solid_queue/failed_executions.rb
+++ b/spec/factories/models/solid_queue/failed_executions.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :solid_queue_failed_execution, class: SolidQueue::FailedExecution do
+    job { association :solid_queue_job }
+  end
+end

--- a/spec/factories/models/solid_queue/jobs.rb
+++ b/spec/factories/models/solid_queue/jobs.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :solid_queue_job, class: SolidQueue::Job do
+    queue_name { "default" }
+    class_name { SendSubmissionJob.name }
+    active_job_id { Faker::Alphanumeric.alphanumeric }
+    arguments { {} }
+  end
+end

--- a/spec/lib/tasks/submissions.rake_spec.rb
+++ b/spec/lib/tasks/submissions.rake_spec.rb
@@ -86,8 +86,97 @@ RSpec.describe "submissions.rake" do
         expect {
           task.invoke(*invalid_args)
         }.to raise_error(SystemExit)
-         .and output("usage: rake submissions:retry_bounced_submissions[<form_id>]\n").to_stderr
+               .and output("usage: rake submissions:retry_bounced_submissions[<form_id>]\n").to_stderr
       end
+    end
+  end
+
+  describe "submissions:retry_failed_send_job" do
+    subject(:task) do
+      Rake::Task["submissions:retry_failed_send_job"]
+        .tap(&:reenable)
+    end
+
+    let(:job) { create :solid_queue_job }
+
+    context "with valid arguments" do
+      let(:valid_args) { [job.active_job_id] }
+
+      context "when the job is failed" do
+        before do
+          create :solid_queue_failed_execution, job: job
+        end
+
+        it "calls retry for the failed execution" do
+          # rubocop:disable RSpec/AnyInstance
+          expect_any_instance_of(SolidQueue::FailedExecution).to receive(:retry).once
+          # rubocop:enable RSpec/AnyInstance
+
+          task.invoke(*valid_args)
+        end
+
+        it "logs that the job was scheduled for retry" do
+          expect(Rails.logger).to receive(:info).with("Scheduled retry for submission job with ID: #{job.active_job_id}")
+
+          task.invoke(*valid_args)
+        end
+      end
+
+      context "when the job is not failed" do
+        it "aborts with message that the job id not failed" do
+          expect {
+            task.invoke(*valid_args)
+          }.to raise_error(SystemExit)
+                 .and output("Job with job_id #{job.active_job_id} is not failed\n").to_stderr
+        end
+      end
+
+      context "when the job does not exist" do
+        it "aborts with message that the job was not found" do
+          expect {
+            task.invoke("foo")
+          }.to raise_error(SystemExit)
+                 .and output("Job with job_id foo not found\n").to_stderr
+        end
+      end
+    end
+
+    context "with invalid arguments" do
+      it "aborts with a usage message" do
+        expect {
+          task.invoke
+        }.to raise_error(SystemExit)
+               .and output("usage: rake submissions:retry_failed_send_job[<job_id>]\n").to_stderr
+      end
+    end
+  end
+
+  describe "submissions:retry_all_failed_send_jobs" do
+    subject(:task) do
+      Rake::Task["submissions:retry_all_failed_send_jobs"]
+        .tap(&:reenable)
+    end
+
+    let(:failed_job) { create :solid_queue_job }
+    let(:other_failed_job) { create :solid_queue_job }
+    let(:failed_not_submission_job) { create :solid_queue_job, class_name: "SomethingElse" }
+    let(:not_failed_job) { create :solid_queue_job }
+
+    before do
+      create :solid_queue_failed_execution, job: failed_job
+      create :solid_queue_failed_execution, job: other_failed_job
+      create :solid_queue_failed_execution, job: failed_not_submission_job
+    end
+
+    it "retries the failed submission jobs" do
+      expect(SolidQueue::FailedExecution).to receive(:retry_all).with([failed_job, other_failed_job])
+      task.invoke
+    end
+
+    it "logs that 2 jobs were retried" do
+      expect(Rails.logger).to receive(:info).with("Found 2 failed submission jobs to retry")
+      expect(Rails.logger).to receive(:info).with("Retried 2 failed submission jobs")
+      task.invoke
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/6W6mqNEj/2251-add-rake-task-to-retry-failed-submission

Add rake tasks to:
- retry an individual failed job to send a submission
- retry all failed jobs to send submissions

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
