### PR TITLE
Add translations for autocomplete text

### DIFF
--- a/app/components/question/selection_component/view.html.erb
+++ b/app/components/question/selection_component/view.html.erb
@@ -12,7 +12,7 @@
                                           ),
   )%>
 
-  <%= helpers.init_autocomplete_script(show_all_values: true) %>
+  <%= helpers.init_autocomplete_script %>
 <% else %>
   <%= selection_html %>
 <% end %>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,6 +55,12 @@ module ApplicationHelper
             rawAttribute: #{raw_attribute},
             source: #{source},
             autoselect: #{auto_select},
+            tNoResults: () => '#{I18n.t('autocomplete.no_results')}',
+            tStatusQueryTooShort: (minQueryLength) => `#{I18n.t('autocomplete.status.query_too_short')}`,
+            tStatusNoResults: () => '#{I18n.t('autocomplete.status.no_results')}',
+            tStatusSelectedOption: (selectedOption, length, index) => `#{I18n.t('autocomplete.status.selected_option')}`,
+            tStatusResults: (length, contentSelectedOption) => (length === 1 ? `#{I18n.t('autocomplete.status.results_single')}` : `#{I18n.t('autocomplete.status.results_plural')}`),
+            tAssistiveHint: () => '#{I18n.t('autocomplete.assistive_hint')}',
           })
         }
       });

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,17 +44,17 @@ module ApplicationHelper
     "/node_modules/govuk-frontend/dist/govuk/assets"
   end
 
-  def init_autocomplete_script(show_all_values: false, raw_attribute: false, source: false, auto_select: false)
+  def init_autocomplete_script
     content_for(:body_end) do
       javascript_tag defer: true do
         "
       document.addEventListener('DOMContentLoaded', function(event) {
         if(window.dfeAutocomplete !== undefined && typeof window.dfeAutocomplete === 'function') {
           dfeAutocomplete({
-            showAllValues: #{show_all_values},
-            rawAttribute: #{raw_attribute},
-            source: #{source},
-            autoselect: #{auto_select},
+            showAllValues: true,
+            rawAttribute: false,
+            source: false,
+            autoselect: false,
             tNoResults: () => '#{I18n.t('autocomplete.no_results')}',
             tStatusQueryTooShort: (minQueryLength) => `#{I18n.t('autocomplete.status.query_too_short')}`,
             tStatusNoResults: () => '#{I18n.t('autocomplete.status.no_results')}',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,7 +99,15 @@ en:
             remove:
               blank: You must select an option
   autocomplete:
+    assistive_hint: When autocomplete results are available use up and down arrows to review and enter to select.  Touch device users, explore by touch or with swipe gestures.
+    no_results: No results found
     prompt: Select an answer
+    status:
+      no_results: No search results
+      query_too_short: Type in ${minQueryLength} or more characters for results
+      results_plural: "${length} results are available. ${contentSelectedOption}"
+      results_single: "${length} result is available. ${contentSelectedOption}"
+      selected_option: "${selectedOption} ${index + 1} of ${length} is highlighted"
   banner:
     success:
       file_removed: Your file has been removed

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -96,4 +96,32 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.format_paragraphs("Paragraph 1\n\n<h2>paragraph 2</h2>")).to eq "<p>Paragraph 1</p>\n\n<p>&lt;h2&gt;paragraph 2&lt;/h2&gt;</p>"
     end
   end
+
+  describe "#init_autocomplete_script" do
+    context "with default options" do
+      before do
+        helper.init_autocomplete_script
+      end
+
+      it "returns the autocomplete script" do
+        expect(view.content_for(:body_end)).to include("
+        document.addEventListener('DOMContentLoaded', function(event) {
+          if(window.dfeAutocomplete !== undefined && typeof window.dfeAutocomplete === 'function') {
+            dfeAutocomplete({
+              showAllValues: false,
+              rawAttribute: false,
+              source: false,
+              autoselect: false,
+              tNoResults: () => 'No results found',
+              tStatusQueryTooShort: (minQueryLength) => `Type in ${minQueryLength} or more characters for results`,
+              tStatusNoResults: () => 'No search results',
+              tStatusSelectedOption: (selectedOption, length, index) => `${selectedOption} ${index + 1} of ${length} is highlighted`,
+              tStatusResults: (length, contentSelectedOption) => (length === 1 ? `${length} result is available. ${contentSelectedOption}` : `${length} results are available. ${contentSelectedOption}`),
+              tAssistiveHint: () => 'When autocomplete results are available use up and down arrows to review and enter to select.  Touch device users, explore by touch or with swipe gestures.',
+            })
+          }
+        });")
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -98,30 +98,28 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#init_autocomplete_script" do
-    context "with default options" do
-      before do
-        helper.init_autocomplete_script
-      end
+    before do
+      helper.init_autocomplete_script
+    end
 
-      it "returns the autocomplete script" do
-        expect(view.content_for(:body_end)).to include("
-        document.addEventListener('DOMContentLoaded', function(event) {
-          if(window.dfeAutocomplete !== undefined && typeof window.dfeAutocomplete === 'function') {
-            dfeAutocomplete({
-              showAllValues: false,
-              rawAttribute: false,
-              source: false,
-              autoselect: false,
-              tNoResults: () => 'No results found',
-              tStatusQueryTooShort: (minQueryLength) => `Type in ${minQueryLength} or more characters for results`,
-              tStatusNoResults: () => 'No search results',
-              tStatusSelectedOption: (selectedOption, length, index) => `${selectedOption} ${index + 1} of ${length} is highlighted`,
-              tStatusResults: (length, contentSelectedOption) => (length === 1 ? `${length} result is available. ${contentSelectedOption}` : `${length} results are available. ${contentSelectedOption}`),
-              tAssistiveHint: () => 'When autocomplete results are available use up and down arrows to review and enter to select.  Touch device users, explore by touch or with swipe gestures.',
-            })
-          }
-        });")
-      end
+    it "returns the autocomplete script" do
+      expect(view.content_for(:body_end)).to include("
+      document.addEventListener('DOMContentLoaded', function(event) {
+        if(window.dfeAutocomplete !== undefined && typeof window.dfeAutocomplete === 'function') {
+          dfeAutocomplete({
+            showAllValues: true,
+            rawAttribute: false,
+            source: false,
+            autoselect: false,
+            tNoResults: () => 'No results found',
+            tStatusQueryTooShort: (minQueryLength) => `Type in ${minQueryLength} or more characters for results`,
+            tStatusNoResults: () => 'No search results',
+            tStatusSelectedOption: (selectedOption, length, index) => `${selectedOption} ${index + 1} of ${length} is highlighted`,
+            tStatusResults: (length, contentSelectedOption) => (length === 1 ? `${length} result is available. ${contentSelectedOption}` : `${length} results are available. ${contentSelectedOption}`),
+            tAssistiveHint: () => 'When autocomplete results are available use up and down arrows to review and enter to select.  Touch device users, explore by touch or with swipe gestures.',
+          })
+        }
+      });")
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/8M8ZYBYu/2271-localise-autocomplete-in-forms-runner

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Explicitly passes in translations to the autocomplete component. The text being passed in matches the existing default text included in accessible-autocomplete. 

Also removes some unused parameters from the init_autocomplete_script helper.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
