### PR TITLE
Fix naming for methods to record CloudWatch metrics

### DIFF
--- a/app/jobs/delete_submissions_job.rb
+++ b/app/jobs/delete_submissions_job.rb
@@ -2,7 +2,7 @@ class DeleteSubmissionsJob < ApplicationJob
   queue_as :background
 
   def perform(*_args)
-    CloudWatchService.log_job_started(self.class.name)
+    CloudWatchService.record_job_started_metric(self.class.name)
     CurrentJobLoggingAttributes.job_id = job_id
 
     delete_submissions_sent_before_time = Settings.retain_submissions_for_seconds.seconds.ago

--- a/app/jobs/queue_metrics_job.rb
+++ b/app/jobs/queue_metrics_job.rb
@@ -5,6 +5,6 @@ class QueueMetricsJob < ApplicationJob
 
   def perform(*_args)
     submissions_queue_length = SolidQueue::Queue.find_by_name(SUBMISSIONS_QUEUE_NAME).size
-    CloudWatchService.log_queue_length(SUBMISSIONS_QUEUE_NAME, submissions_queue_length)
+    CloudWatchService.record_queue_length_metric(SUBMISSIONS_QUEUE_NAME, submissions_queue_length)
   end
 end

--- a/app/jobs/receive_submission_bounces_and_complaints_job.rb
+++ b/app/jobs/receive_submission_bounces_and_complaints_job.rb
@@ -10,7 +10,7 @@ class ReceiveSubmissionBouncesAndComplaintsJob < ApplicationJob
   POLLING_PERIOD = 20
 
   def perform
-    CloudWatchService.log_job_started(self.class.name)
+    CloudWatchService.record_job_started_metric(self.class.name)
     CurrentJobLoggingAttributes.job_id = job_id
 
     sts_client = Aws::STS::Client.new(region: REGION)

--- a/app/jobs/receive_submission_deliveries_job.rb
+++ b/app/jobs/receive_submission_deliveries_job.rb
@@ -10,7 +10,7 @@ class ReceiveSubmissionDeliveriesJob < ApplicationJob
   POLLING_PERIOD = 20
 
   def perform
-    CloudWatchService.log_job_started(self.class.name)
+    CloudWatchService.record_job_started_metric(self.class.name)
     CurrentJobLoggingAttributes.job_id = job_id
 
     sts_client = Aws::STS::Client.new(region: REGION)

--- a/app/jobs/send_submission_job.rb
+++ b/app/jobs/send_submission_job.rb
@@ -30,9 +30,9 @@ class SendSubmissionJob < ApplicationJob
 
     milliseconds_since_scheduled = (Time.current - scheduled_at_or_enqueued_at).in_milliseconds.round
     EventLogger.log_form_event("submission_email_sent", { milliseconds_since_scheduled: })
-    CloudWatchService.log_submission_sent(milliseconds_since_scheduled)
+    CloudWatchService.record_submission_sent_metric(milliseconds_since_scheduled)
   rescue StandardError
-    CloudWatchService.log_job_failure(self.class.name)
+    CloudWatchService.record_job_failure_metric(self.class.name)
     raise
   end
 

--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -4,7 +4,7 @@ class CloudWatchService
   JOBS_METRICS_NAMESPACE = "Forms/Jobs".freeze
   SERVICE_NAME = "forms-runner".freeze
 
-  def self.log_form_submission(form_id:)
+  def self.record_form_submission_metric(form_id:)
     return unless Settings.cloudwatch_metrics_enabled
 
     cloudwatch_client.put_metric_data(
@@ -23,7 +23,7 @@ class CloudWatchService
     )
   end
 
-  def self.log_form_start(form_id:)
+  def self.record_form_start_metric(form_id:)
     return unless Settings.cloudwatch_metrics_enabled
 
     cloudwatch_client.put_metric_data(
@@ -42,7 +42,7 @@ class CloudWatchService
     )
   end
 
-  def self.log_submission_sent(milliseconds_since_scheduled)
+  def self.record_submission_sent_metric(milliseconds_since_scheduled)
     return unless Settings.cloudwatch_metrics_enabled
 
     cloudwatch_client.put_metric_data(
@@ -62,7 +62,7 @@ class CloudWatchService
     )
   end
 
-  def self.log_job_failure(job_name)
+  def self.record_job_failure_metric(job_name)
     return unless Settings.cloudwatch_metrics_enabled
 
     cloudwatch_client.put_metric_data(
@@ -82,7 +82,7 @@ class CloudWatchService
     )
   end
 
-  def self.log_job_started(job_name)
+  def self.record_job_started_metric(job_name)
     return unless Settings.cloudwatch_metrics_enabled
 
     cloudwatch_client.put_metric_data(
@@ -102,7 +102,7 @@ class CloudWatchService
     )
   end
 
-  def self.log_queue_length(queue_name, length)
+  def self.record_queue_length_metric(queue_name, length)
     return unless Settings.cloudwatch_metrics_enabled
 
     cloudwatch_client.put_metric_data(

--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -122,10 +122,6 @@ class CloudWatchService
     )
   end
 
-  def self.old_form_metrics_namespace
-    "forms/#{Settings.forms_env}".downcase
-  end
-
   def self.environment_dimension
     {
       name: "Environment",

--- a/app/services/log_event_service.rb
+++ b/app/services/log_event_service.rb
@@ -22,7 +22,7 @@ class LogEventService
 
       # Logging to CloudWatch
       begin
-        CloudWatchService.log_form_submission(form_id: context.form.id)
+        CloudWatchService.record_form_submission_metric(form_id: context.form.id)
       rescue StandardError => e
         Sentry.capture_exception(e)
       end
@@ -33,7 +33,7 @@ class LogEventService
     EventLogger.log_page_event(log_event, @step.question.question_text, skipped_question?)
     if is_starting_form?
       begin
-        CloudWatchService.log_form_start(form_id: @current_context.form.id) # Logging to CloudWatch
+        CloudWatchService.record_form_start_metric(form_id: @current_context.form.id) # Logging to CloudWatch
       rescue StandardError => e
         Sentry.capture_exception(e)
       end

--- a/spec/jobs/delete_submissions_job_spec.rb
+++ b/spec/jobs/delete_submissions_job_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
     Rails.logger.broadcast_to logger
 
     allow(Question::FileUploadS3Service).to receive(:new).and_return(file_upload_s3_service_spy)
-    allow(CloudWatchService).to receive(:log_job_started)
+    allow(CloudWatchService).to receive(:record_job_started_metric)
 
     job = described_class.perform_later
     @job_id = job.job_id
@@ -138,7 +138,7 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
 
     it "sends cloudwatch metric" do
       perform_enqueued_jobs
-      expect(CloudWatchService).to have_received(:log_job_started).with("DeleteSubmissionsJob")
+      expect(CloudWatchService).to have_received(:record_job_started_metric).with("DeleteSubmissionsJob")
     end
   end
 
@@ -176,7 +176,7 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
 
     it "sends cloudwatch metric" do
       perform_enqueued_jobs
-      expect(CloudWatchService).to have_received(:log_job_started).with("DeleteSubmissionsJob")
+      expect(CloudWatchService).to have_received(:record_job_started_metric).with("DeleteSubmissionsJob")
     end
   end
 

--- a/spec/jobs/queue_metrics_job_spec.rb
+++ b/spec/jobs/queue_metrics_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe QueueMetricsJob, type: :job do
   let(:submission_queue_length) { 4 }
 
   before do
-    allow(CloudWatchService).to receive(:log_queue_length)
+    allow(CloudWatchService).to receive(:record_queue_length_metric)
 
     mock_queue = instance_double(SolidQueue::Queue, size: submission_queue_length)
     allow(SolidQueue::Queue).to receive(:find_by_name).and_return(mock_queue)
@@ -16,6 +16,6 @@ RSpec.describe QueueMetricsJob, type: :job do
   end
 
   it "sends submission queue length to CloudWatch" do
-    expect(CloudWatchService).to have_received(:log_queue_length).with("submissions", submission_queue_length)
+    expect(CloudWatchService).to have_received(:record_queue_length_metric).with("submissions", submission_queue_length)
   end
 end

--- a/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
+++ b/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
         messages.shift
       end
 
-      allow(CloudWatchService).to receive(:log_job_started)
+      allow(CloudWatchService).to receive(:record_job_started_metric)
 
       Rails.logger.broadcast_to logger
     end
@@ -76,7 +76,7 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
 
       it "sends cloudwatch metric" do
         perform_enqueued_jobs
-        expect(CloudWatchService).to have_received(:log_job_started).with("ReceiveSubmissionBouncesAndComplaintsJob")
+        expect(CloudWatchService).to have_received(:record_job_started_metric).with("ReceiveSubmissionBouncesAndComplaintsJob")
       end
     end
 

--- a/spec/jobs/receive_submission_deliveries_job_spec.rb
+++ b/spec/jobs/receive_submission_deliveries_job_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
         messages.shift
       end
 
-      allow(CloudWatchService).to receive(:log_job_started)
+      allow(CloudWatchService).to receive(:record_job_started_metric)
 
       Rails.logger.broadcast_to logger
     end
@@ -76,7 +76,7 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
 
       it "sends cloudwatch metric" do
         perform_enqueued_jobs
-        expect(CloudWatchService).to have_received(:log_job_started).with("ReceiveSubmissionDeliveriesJob")
+        expect(CloudWatchService).to have_received(:record_job_started_metric).with("ReceiveSubmissionDeliveriesJob")
       end
     end
 

--- a/spec/services/cloud_watch_service_spec.rb
+++ b/spec/services/cloud_watch_service_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe CloudWatchService do
     allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
   end
 
-  describe ".log_form_submission" do
+  describe ".record_form_submission_metric" do
     context "when CloudWatch metrics are disabled" do
       let(:cloudwatch_metrics_enabled) { false }
 
       it "does not call the CloudWatch client with .put_metric_data" do
         expect(cloudwatch_client).not_to receive(:put_metric_data)
 
-        described_class.log_form_submission(form_id:)
+        described_class.record_form_submission_metric(form_id:)
       end
     end
 
@@ -46,18 +46,18 @@ RSpec.describe CloudWatchService do
         ],
       )
 
-      described_class.log_form_submission(form_id:)
+      described_class.record_form_submission_metric(form_id:)
     end
   end
 
-  describe ".log_form_start" do
+  describe ".record_form_start_metric" do
     context "when CloudWatch metrics are disabled" do
       let(:cloudwatch_metrics_enabled) { false }
 
       it "does not call the CloudWatch client with .put_metric_data" do
         expect(cloudwatch_client).not_to receive(:put_metric_data)
 
-        described_class.log_form_start(form_id:)
+        described_class.record_form_start_metric(form_id:)
       end
     end
 
@@ -83,11 +83,11 @@ RSpec.describe CloudWatchService do
         ],
       )
 
-      described_class.log_form_start(form_id:)
+      described_class.record_form_start_metric(form_id:)
     end
   end
 
-  describe ".log_submission_sent" do
+  describe ".record_submission_sent_metric" do
     let(:milliseconds_since_scheduled) { 1000 }
 
     context "when CloudWatch metrics are disabled" do
@@ -96,7 +96,7 @@ RSpec.describe CloudWatchService do
       it "does not call the CloudWatch client with .put_metric_data" do
         expect(cloudwatch_client).not_to receive(:put_metric_data)
 
-        described_class.log_submission_sent(milliseconds_since_scheduled)
+        described_class.record_submission_sent_metric(milliseconds_since_scheduled)
       end
     end
 
@@ -126,18 +126,18 @@ RSpec.describe CloudWatchService do
         ],
       )
 
-      described_class.log_submission_sent(milliseconds_since_scheduled)
+      described_class.record_submission_sent_metric(milliseconds_since_scheduled)
     end
   end
 
-  describe ".log_job_failure" do
+  describe ".record_job_failure_metric" do
     context "when CloudWatch metrics are disabled" do
       let(:cloudwatch_metrics_enabled) { false }
 
       it "does not call the CloudWatch client with .put_metric_data" do
         expect(cloudwatch_client).not_to receive(:put_metric_data)
 
-        described_class.log_job_failure(job_name)
+        described_class.record_job_failure_metric(job_name)
       end
     end
 
@@ -167,18 +167,18 @@ RSpec.describe CloudWatchService do
         ],
       )
 
-      described_class.log_job_failure(job_name)
+      described_class.record_job_failure_metric(job_name)
     end
   end
 
-  describe ".log_job_started" do
+  describe ".record_job_started_metric" do
     context "when CloudWatch metrics are disabled" do
       let(:cloudwatch_metrics_enabled) { false }
 
       it "does not call the CloudWatch client with .put_metric_data" do
         expect(cloudwatch_client).not_to receive(:put_metric_data)
 
-        described_class.log_job_started(job_name)
+        described_class.record_job_started_metric(job_name)
       end
     end
 
@@ -208,11 +208,11 @@ RSpec.describe CloudWatchService do
         ],
       )
 
-      described_class.log_job_started(job_name)
+      described_class.record_job_started_metric(job_name)
     end
   end
 
-  describe ".log_queue_length" do
+  describe ".record_queue_length_metric" do
     let(:queue_name) { "test-queue" }
     let(:queue_length) { 42 }
 
@@ -222,7 +222,7 @@ RSpec.describe CloudWatchService do
       it "does not call the CloudWatch client with .put_metric_data" do
         expect(cloudwatch_client).not_to receive(:put_metric_data)
 
-        described_class.log_queue_length(queue_name, queue_length)
+        described_class.record_queue_length_metric(queue_name, queue_length)
       end
     end
 
@@ -252,7 +252,7 @@ RSpec.describe CloudWatchService do
         ],
       )
 
-      described_class.log_queue_length(queue_name, queue_length)
+      described_class.record_queue_length_metric(queue_name, queue_length)
     end
   end
 end

--- a/spec/services/log_event_service_spec.rb
+++ b/spec/services/log_event_service_spec.rb
@@ -33,18 +33,18 @@ RSpec.describe LogEventService do
         allow(Sentry).to receive(:capture_exception)
       end
 
-      it "calls the CloudWatchService with .log_form_start" do
-        allow(CloudWatchService).to receive(:log_form_start).and_return(true)
+      it "calls the CloudWatchService with .record_form_start_metric" do
+        allow(CloudWatchService).to receive(:record_form_start_metric).and_return(true)
 
         log_event_service = described_class.new(current_context, step, request, changing_answers, answers)
 
         log_event_service.log_page_save
 
-        expect(CloudWatchService).to have_received(:log_form_start).with(form_id: current_context.form.id)
+        expect(CloudWatchService).to have_received(:record_form_start_metric).with(form_id: current_context.form.id)
       end
 
       it "Sentry doesn't receive an error" do
-        allow(CloudWatchService).to receive(:log_form_start).and_return(true)
+        allow(CloudWatchService).to receive(:record_form_start_metric).and_return(true)
 
         log_event_service = described_class.new(current_context, step, request, changing_answers, answers)
 
@@ -55,7 +55,7 @@ RSpec.describe LogEventService do
 
       context "when CloudWatchService returns an error" do
         it "raises the error to Sentry" do
-          allow(CloudWatchService).to receive(:log_form_start).and_raise(StandardError)
+          allow(CloudWatchService).to receive(:record_form_start_metric).and_raise(StandardError)
 
           log_event_service = described_class.new(current_context, step, request, changing_answers, answers)
 
@@ -73,7 +73,7 @@ RSpec.describe LogEventService do
 
     before do
       allow(EventLogger).to receive(:log_form_event).and_return(true)
-      allow(CloudWatchService).to receive(:log_form_submission).and_return(true)
+      allow(CloudWatchService).to receive(:record_form_submission_metric).and_return(true)
       described_class.log_submit(current_context, requested_email_confirmation:, preview:, submission_type: "email")
     end
 
@@ -85,7 +85,7 @@ RSpec.describe LogEventService do
       end
 
       it "does not call the cloud watch service" do
-        expect(CloudWatchService).not_to have_received(:log_form_submission)
+        expect(CloudWatchService).not_to have_received(:record_form_submission_metric)
       end
     end
 
@@ -96,8 +96,8 @@ RSpec.describe LogEventService do
         expect(EventLogger).to have_received(:log_form_event).with("submission", { submission_type: "email" })
       end
 
-      it "calls the cloud watch service with .log_form_submission" do
-        expect(CloudWatchService).to have_received(:log_form_submission).with(form_id: current_context.form.id)
+      it "calls the cloud watch service with .record_form_submission_metric" do
+        expect(CloudWatchService).to have_received(:record_form_submission_metric).with(form_id: current_context.form.id)
       end
 
       context "when email confirmation is requested" do
@@ -118,7 +118,7 @@ RSpec.describe LogEventService do
 
       context "when CloudWatchService returns an error" do
         it "raises the error to Sentry" do
-          allow(CloudWatchService).to receive(:log_form_submission).and_raise(StandardError)
+          allow(CloudWatchService).to receive(:record_form_submission_metric).and_raise(StandardError)
           allow(Sentry).to receive(:capture_exception)
 
           described_class.log_submit(current_context, requested_email_confirmation:, preview:, submission_type: "email")


### PR DESCRIPTION
Methods that were responsible for recording CloudWatch Metrics used the verb "log", which is confusing as "logs" are a different and distinct of observation signal to metrics.