### PR TITLE
Record submission delivery latency metrics

### DIFF
--- a/app/jobs/receive_submission_deliveries_job.rb
+++ b/app/jobs/receive_submission_deliveries_job.rb
@@ -64,7 +64,7 @@ private
 
       delivery_time = Time.zone.parse(ses_message["delivery"]["timestamp"])
       submission_duration_ms = ((delivery_time - submission.created_at) * 1000).round
-      CloudWatchService.record_submission_delivery_time_metric(submission_duration_ms, "Email")
+      CloudWatchService.record_submission_delivery_latency_metric(submission_duration_ms, "Email")
     rescue StandardError => e
       Rails.logger.warn("Error processing message - #{e.class.name}: #{e.message}")
       Sentry.capture_exception(e)

--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -62,20 +62,20 @@ class CloudWatchService
     )
   end
 
-  def self.record_submission_delivery_time_metric(milliseconds_since_scheduled, delivery_type)
+  def self.record_submission_delivery_latency_metric(milliseconds_since_scheduled, delivery_method)
     return unless Settings.cloudwatch_metrics_enabled
 
     cloudwatch_client.put_metric_data(
-      namespace: JOBS_METRICS_NAMESPACE,
+      namespace: FORM_METRICS_NAMESPACE,
       metric_data: [
         {
-          metric_name: "SubmissionDeliveryTime",
+          metric_name: "SubmissionDeliveryLatency",
           dimensions: [
             environment_dimension,
             service_name_dimension,
             {
-              name: "SubmissionDeliveryType",
-              value: delivery_type,
+              name: "SubmissionDeliveryMethod",
+              value: delivery_method,
             },
           ],
           value: milliseconds_since_scheduled,

--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -62,6 +62,29 @@ class CloudWatchService
     )
   end
 
+  def self.record_submission_delivery_time_metric(milliseconds_since_scheduled, delivery_type)
+    return unless Settings.cloudwatch_metrics_enabled
+
+    cloudwatch_client.put_metric_data(
+      namespace: JOBS_METRICS_NAMESPACE,
+      metric_data: [
+        {
+          metric_name: "SubmissionDeliveryTime",
+          dimensions: [
+            environment_dimension,
+            service_name_dimension,
+            {
+              name: "SubmissionDeliveryType",
+              value: delivery_type,
+            },
+          ],
+          value: milliseconds_since_scheduled,
+          unit: "Milliseconds",
+        },
+      ],
+    )
+  end
+
   def self.record_job_failure_metric(job_name)
     return unless Settings.cloudwatch_metrics_enabled
 

--- a/app/services/s3_submission_service.rb
+++ b/app/services/s3_submission_service.rb
@@ -78,7 +78,7 @@ private
     Rails.logger.info("Uploaded submission to S3", { key: })
 
     submission_duration_ms = (Time.current - @timestamp).in_milliseconds.round
-    CloudWatchService.record_submission_delivery_time_metric(submission_duration_ms, "S3")
+    CloudWatchService.record_submission_delivery_latency_metric(submission_duration_ms, "S3")
   end
 
   def s3_client

--- a/app/services/s3_submission_service.rb
+++ b/app/services/s3_submission_service.rb
@@ -76,6 +76,9 @@ private
       key: key,
     })
     Rails.logger.info("Uploaded submission to S3", { key: })
+
+    submission_duration_ms = (Time.current - @timestamp).in_milliseconds.round
+    CloudWatchService.record_submission_delivery_time_metric(submission_duration_ms, "S3")
   end
 
   def s3_client

--- a/spec/jobs/receive_submission_deliveries_job_spec.rb
+++ b/spec/jobs/receive_submission_deliveries_job_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
       before do
         job = described_class.perform_later
         @job_id = job.job_id
-        allow(CloudWatchService).to receive(:record_submission_delivery_time_metric)
+        allow(CloudWatchService).to receive(:record_submission_delivery_latency_metric)
       end
 
       it "updates the submission mail status to delivered" do
@@ -117,7 +117,7 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
       it "sends cloudwatch metric for submission delivery time" do
         perform_enqueued_jobs
         # latency is ses_delivery_timestamp - submission.created_at
-        expect(CloudWatchService).to have_received(:record_submission_delivery_time_metric).with(6122, "Email")
+        expect(CloudWatchService).to have_received(:record_submission_delivery_latency_metric).with(6122, "Email")
       end
 
       it "deletes the SQS message" do

--- a/spec/services/cloud_watch_service_spec.rb
+++ b/spec/services/cloud_watch_service_spec.rb
@@ -130,9 +130,9 @@ RSpec.describe CloudWatchService do
     end
   end
 
-  describe ".record_submission_delivery_time_metric" do
+  describe ".record_submission_delivery_latency_metric" do
     let(:milliseconds_since_scheduled) { 2000 }
-    let(:delivery_type) { "Email" }
+    let(:delivery_method) { "Email" }
 
     context "when CloudWatch metrics are disabled" do
       let(:cloudwatch_metrics_enabled) { false }
@@ -140,16 +140,16 @@ RSpec.describe CloudWatchService do
       it "does not call the CloudWatch client with .put_metric_data" do
         expect(cloudwatch_client).not_to receive(:put_metric_data)
 
-        described_class.record_submission_delivery_time_metric(milliseconds_since_scheduled, delivery_type)
+        described_class.record_submission_delivery_latency_metric(milliseconds_since_scheduled, delivery_method)
       end
     end
 
     it "calls the cloudwatch client with put_metric_data" do
       expect(cloudwatch_client).to receive(:put_metric_data).with(
-        namespace: "Forms/Jobs",
+        namespace: "Forms",
         metric_data: [
           {
-            metric_name: "SubmissionDeliveryTime",
+            metric_name: "SubmissionDeliveryLatency",
             dimensions: [
               {
                 name: "Environment",
@@ -160,8 +160,8 @@ RSpec.describe CloudWatchService do
                 value: "forms-runner",
               },
               {
-                name: "SubmissionDeliveryType",
-                value: delivery_type,
+                name: "SubmissionDeliveryMethod",
+                value: delivery_method,
               },
             ],
             value: milliseconds_since_scheduled,
@@ -170,18 +170,18 @@ RSpec.describe CloudWatchService do
         ],
       )
 
-      described_class.record_submission_delivery_time_metric(milliseconds_since_scheduled, delivery_type)
+      described_class.record_submission_delivery_latency_metric(milliseconds_since_scheduled, delivery_method)
     end
 
     context "with different delivery types" do
-      let(:delivery_type) { "S3" }
+      let(:delivery_method) { "S3" }
 
       it "uses the correct delivery type in the metric dimensions" do
         expect(cloudwatch_client).to receive(:put_metric_data).with(
-          namespace: "Forms/Jobs",
+          namespace: "Forms",
           metric_data: [
             {
-              metric_name: "SubmissionDeliveryTime",
+              metric_name: "SubmissionDeliveryLatency",
               dimensions: [
                 {
                   name: "Environment",
@@ -192,8 +192,8 @@ RSpec.describe CloudWatchService do
                   value: "forms-runner",
                 },
                 {
-                  name: "SubmissionDeliveryType",
-                  value: delivery_type,
+                  name: "SubmissionDeliveryMethod",
+                  value: delivery_method,
                 },
               ],
               value: milliseconds_since_scheduled,
@@ -202,7 +202,7 @@ RSpec.describe CloudWatchService do
           ],
         )
 
-        described_class.record_submission_delivery_time_metric(milliseconds_since_scheduled, delivery_type)
+        described_class.record_submission_delivery_latency_metric(milliseconds_since_scheduled, delivery_method)
       end
     end
   end

--- a/spec/services/s3_submission_service_spec.rb
+++ b/spec/services/s3_submission_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe S3SubmissionService do
         allow(Question::FileUploadS3Service).to receive(:new).and_return(mock_file_upload_s3_service)
         allow(mock_file_upload_s3_service).to receive(:delete_from_s3)
         allow(Settings.aws).to receive_messages(s3_submission_iam_role_arn: role_arn, file_upload_s3_bucket_name: file_upload_bucket)
-        allow(CloudWatchService).to receive(:record_submission_delivery_time_metric)
+        allow(CloudWatchService).to receive(:record_submission_delivery_latency_metric)
       end
 
       it "writes a CSV file" do
@@ -141,7 +141,7 @@ RSpec.describe S3SubmissionService do
       end
 
       it "sends cloudwatch metric for submission delivery time" do
-        expect(CloudWatchService).to receive(:record_submission_delivery_time_metric).with(2000, "S3")
+        expect(CloudWatchService).to receive(:record_submission_delivery_latency_metric).with(2000, "S3")
         travel_to timestamp + 2.seconds do
           service.submit
         end

--- a/spec/services/s3_submission_service_spec.rb
+++ b/spec/services/s3_submission_service_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe S3SubmissionService do
         allow(Question::FileUploadS3Service).to receive(:new).and_return(mock_file_upload_s3_service)
         allow(mock_file_upload_s3_service).to receive(:delete_from_s3)
         allow(Settings.aws).to receive_messages(s3_submission_iam_role_arn: role_arn, file_upload_s3_bucket_name: file_upload_bucket)
+        allow(CloudWatchService).to receive(:record_submission_delivery_time_metric)
       end
 
       it "writes a CSV file" do
@@ -135,6 +136,13 @@ RSpec.describe S3SubmissionService do
           expect(mock_file_upload_s3_service).to receive(:delete_from_s3).with(first_file_upload_question.uploaded_file_key)
           expect(mock_file_upload_s3_service).to receive(:delete_from_s3).with(second_file_upload_question.uploaded_file_key)
 
+          service.submit
+        end
+      end
+
+      it "sends cloudwatch metric for submission delivery time" do
+        expect(CloudWatchService).to receive(:record_submission_delivery_time_metric).with(2000, "S3")
+        travel_to timestamp + 2.seconds do
           service.submit
         end
       end


### PR DESCRIPTION
This adds a new "SubmissionDeliveryLatency" metric that show the latency for delivery times for all submission types. This differs from "TimeToSendSubmission" as it records the latency for the submission until we confirmation that submission has been delivered, instead of when we just "sent" the submission to be delivered.

This metric supports both S3 and Email delivery methods.

This metric will support work to build service level indicators about the delivery latency and the user experience of the submission process.

