### PR TITLE
Remove service name dimension from SubmissionDeliveryLatency

### DIFF
--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -72,7 +72,6 @@ class CloudWatchService
           metric_name: "SubmissionDeliveryLatency",
           dimensions: [
             environment_dimension,
-            service_name_dimension,
             {
               name: "SubmissionDeliveryMethod",
               value: delivery_method,

--- a/spec/services/cloud_watch_service_spec.rb
+++ b/spec/services/cloud_watch_service_spec.rb
@@ -156,10 +156,6 @@ RSpec.describe CloudWatchService do
                 value: forms_env,
               },
               {
-                name: "ServiceName",
-                value: "forms-runner",
-              },
-              {
                 name: "SubmissionDeliveryMethod",
                 value: delivery_method,
               },
@@ -186,10 +182,6 @@ RSpec.describe CloudWatchService do
                 {
                   name: "Environment",
                   value: forms_env,
-                },
-                {
-                  name: "ServiceName",
-                  value: "forms-runner",
                 },
                 {
                   name: "SubmissionDeliveryMethod",


### PR DESCRIPTION
This will always be the same and is unused.