### PR TITLE
 Localise licence in footer

### DIFF
--- a/app/components/footer_component/view.html.erb
+++ b/app/components/footer_component/view.html.erb
@@ -1,1 +1,9 @@
-<%= govuk_footer meta_items_title: t("footer.helpful_links"), meta_items: meta_links %>
+<%= govuk_footer(meta_items_title: t("footer.helpful_links"), copyright_text: t("footer.copyright"), meta_items: meta_links) do |footer| %>
+    <%= footer.with_meta_licence_html do %>
+      <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+        <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+      </svg>
+
+      <%= t("footer.licence", link: govuk_footer_link_to(t("footer.licence_link_text"), t("footer.licence_link_url"))).html_safe %>
+    <% end %>
+<% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -316,7 +316,11 @@ cy:
   footer:
     accessibility_statement: Datganiad hygyrchedd
     cookies: Cwcis
+    copyright: "© Hawlfraint y Goron"
     helpful_links: Helpful links
+    licence: Mae’r holl gynnwys ar gael o dan y %{link}, ac eithrio lle nodir yn wahanol
+    licence_link_text: Trwydded Llywodraeth Agored v3.0
+    licence_link_url: https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/
     privacy_policy: Preifatrwydd
   form:
     check_your_answers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,7 +316,11 @@ en:
   footer:
     accessibility_statement: Accessibility statement
     cookies: Cookies
+    copyright: "© Crown copyright"
     helpful_links: Helpful links
+    licence: All content is available under the %{link}, except where otherwise stated
+    licence_link_text: Open Government Licence v3.0
+    licence_link_url: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
     privacy_policy: Privacy
   form:
     check_your_answers:

--- a/spec/components/footer_component/view_spec.rb
+++ b/spec/components/footer_component/view_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe FooterComponent::View, type: :component do
     it "includes the cookies link without a language query parameter" do
       expect(page).to have_link("Cookies", href: cookies_path)
     end
+
+    it "includes the licence link" do
+      expect(page).to have_link(I18n.t("footer.licence_link_text"), href: I18n.t("footer.licence_link_url"))
+    end
   end
 
   context "when the locale is cy" do
@@ -33,6 +37,10 @@ RSpec.describe FooterComponent::View, type: :component do
 
     it "includes the cookies link with a language query parameter" do
       expect(page).to have_link(I18n.t("footer.cookies", locale: :cy), href: cookies_path(locale: "cy"))
+    end
+
+    it "includes the licence link in Welsh" do
+      expect(page).to have_link(I18n.t("footer.licence_link_text", locale: :cy), href: I18n.t("footer.licence_link_url", locale: :cy))
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/NOWquTsH/2283-update-govuk-components-gem-to-allow-html-in-the-metalicence-attribute

This PR localises the licence in the footer, using a `meta_licence_html` block passed into the govuk-footer.

![Screenshot 2025-06-10 at 11 23 52](https://github.com/user-attachments/assets/a4289d95-a509-4f00-b769-a6cfc10e7a09)
![Screenshot 2025-06-10 at 11 24 05](https://github.com/user-attachments/assets/3f1d3228-f9d7-434b-b8d6-6c5d44b23412)


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
