### PR TITLE
Set the owner of the /app/tmp and /tmp volumes in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,11 +51,6 @@ CMD ["bash"]
 
 FROM base AS app
 
-# Each directory that Rails or our application needs to
-# write to under /app/tmp/ must be added individually
-VOLUME "/tmp/"
-VOLUME "/app/tmp/sockets/"
-
 ENV RAILS_ENV="${RAILS_ENV:-production}" \
     PATH="${PATH}:/home/ruby/.local/bin" \
     USER="ruby"
@@ -76,6 +71,10 @@ RUN chmod 0755 bin/*
 
 COPY --chown=ruby:ruby --from=build /usr/local/bundle /usr/local/bundle
 COPY --chown=ruby:ruby --from=build /app /app
+
+RUN mkdir -p "/app/tmp/" && chown ruby:ruby "/app/tmp/"
+VOLUME "/tmp/"
+VOLUME "/app/tmp/"
 
 EXPOSE 3000
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/KoHvaEUA/681-aws-m112-ecs-read-only-root-filesystem-configuration

AWS ECS documentation [1] shows how volume ownership should be set

We need to do this because forms-runner attempts to create new directories in the `/app/tmp` directory, which it can't do without being the owner of that mounted directory (which it isn't, by default)

[1] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
