### PR TITLE
Update event structure for details_opened GA event

### DIFF
--- a/app/frontend/javascript/utils/google-analytics/index.js
+++ b/app/frontend/javascript/utils/google-analytics/index.js
@@ -105,9 +105,12 @@ export function attachDetailsOpenTracker () {
       const summary = detailsElement.querySelector('summary')
       if (detailsElement.open) {
         window.dataLayer.push({
-          event: 'details_opened',
-          url: window.location,
-          text: summary.textContent
+          event: 'event_data',
+          event_data: {
+            event_name: 'details_opened',
+            url: window.location,
+            text: summary.textContent
+          }
         })
       }
     })

--- a/app/frontend/javascript/utils/google-analytics/index.test.js
+++ b/app/frontend/javascript/utils/google-analytics/index.test.js
@@ -206,9 +206,12 @@ describe('google_tag.mjs', () => {
         document.querySelector('details').querySelector('summary').click()
 
         expect(window.dataLayer).toContainEqual({
-          event: 'details_opened',
-          url: document.location,
-          text: summaryText
+          event: 'event_data',
+          event_data: {
+            event_name: 'details_opened',
+            url: document.location,
+            text: summaryText
+          }
         })
       })
     })


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/0mqWd67h/2177-log-when-what-files-can-i-upload-details-component-is-clicked

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Followup to #1394, updates the Google Analytics event to use the event_data format, so that it can be picked up by the event logic.

### Testing instructions
- open the javascript console
- click a details component (e.g. 'What files can I upload?') on a file upload question page
- type `dataLayer` into the console and observe that the array contains an item int he format:
 
```js
{
  event: 'event_data',
  event_data: {
    event_name: 'details_opened',
    url: "http://localhost:3001/preview-draft/33/test-a-new-feature/87",
    text: "What files can I upload?"
  }
}
```


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
