### PR TITLE
Stop using delivered mail status

### DIFF
--- a/app/jobs/receive_submission_deliveries_job.rb
+++ b/app/jobs/receive_submission_deliveries_job.rb
@@ -76,7 +76,6 @@ private
   def process_delivery(submission)
     set_submission_logging_attributes(submission)
 
-    submission.delivered!
     EventLogger.log_form_event("submission_delivered")
   end
 end

--- a/db/migrate/20250529084029_update_mail_status_for_pending_submissions.rb
+++ b/db/migrate/20250529084029_update_mail_status_for_pending_submissions.rb
@@ -1,0 +1,5 @@
+class UpdateMailStatusForPendingSubmissions < ActiveRecord::Migration[8.0]
+  def change
+    Submission.where(mail_status: :delivered).update_all(mail_status: :pending)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_25_180117) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_29_084029) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/spec/jobs/receive_submission_deliveries_job_spec.rb
+++ b/spec/jobs/receive_submission_deliveries_job_spec.rb
@@ -90,11 +90,6 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
         allow(CloudWatchService).to receive(:record_submission_delivery_latency_metric)
       end
 
-      it "updates the submission mail status to delivered" do
-        perform_enqueued_jobs
-        expect(submission.reload.delivered?).to be true
-      end
-
       it "doesn't change the mail status for other submissions" do
         perform_enqueued_jobs
         expect(other_submission.reload.bounced?).to be true


### PR DESCRIPTION
### What problem does this pull request solve?

We've found that we can receive a delivery and bounce notification for a given SES message. This means there is potential for a delivery notification to be processed after a bounce notification for a given SES message, which will result in the corresponding `Submission` being deleted.

This PR stops us setting the `mail_status` for Submissions to delivered, and migrates any remaining Submissions with that `mail_status` to pending, in advance of code changes to remove the delivered `mail_status` entirely.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
