### PR TITLE
Use code from GOV.UK Notify for validating email addresses in our email confirmation input object

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,9 @@ gem "csv"
 # the hash, also change in package.json
 gem "dfe-autocomplete", require: "dfe/autocomplete", github: "DFE-Digital/dfe-autocomplete", ref: "1d4cc65039e11cc3ba9e7217a719b8128d0e4d53"
 
+# IDNA conversion needed for validating email addresses
+gem "uri-idna"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,6 +473,7 @@ GEM
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     uri (1.0.3)
+    uri-idna (0.3.0)
     useragent (0.16.11)
     view_component (3.21.0)
       activesupport (>= 5.2.0, < 8.1)
@@ -553,6 +554,7 @@ DEPENDENCIES
   tzinfo
   tzinfo-data
   uk_postcode
+  uri-idna
   vite_rails
 
 RUBY VERSION

--- a/app/input_objects/email_confirmation_input.rb
+++ b/app/input_objects/email_confirmation_input.rb
@@ -7,7 +7,7 @@ class EmailConfirmationInput
   validates :send_confirmation, presence: true
   validates :send_confirmation, inclusion: { in: %w[send_email skip_confirmation] }
   validates :confirmation_email_address, presence: true, if: :validate_email?
-  validates :confirmation_email_address, format: { with: URI::MailTo::EMAIL_REGEXP, message: :invalid_email }, allow_blank: true, if: :validate_email?
+  validates :confirmation_email_address, email_address: { message: :invalid_email }, allow_blank: true, if: :validate_email?
 
   def initialize(...)
     super(...)

--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -1,0 +1,9 @@
+require "notifications_utils/recipient_validation/email_address"
+
+class EmailAddressValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    NotificationsUtils::RecipientValidation::EmailAddress.validate_email_address(value)
+  rescue NotificationsUtils::RecipientValidation::InvalidEmailError
+    record.errors.add attribute, (options[:message] || :invalid_email_address)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module FormsRunner
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks generators])
+    config.autoload_lib(ignore: %w[assets tasks generators notifications_utils])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/lib/notifications_utils/formatters.rb
+++ b/lib/notifications_utils/formatters.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# A copy of just the parts we need from https://github.com/alphagov/notifications-utils/blob/8b39f0006709662df689d52055867bca0a897230/notifications_utils/formatters.py
+
+OBSCURE_ZERO_WIDTH_WHITESPACE = [
+  "\u180e",  # Mongolian vowel separator
+  "\u200b",  # zero width space
+  "\u200c",  # zero width non-joiner
+  "\u200d",  # zero width joiner
+  "\u2060",  # word joiner
+  "\ufeff",  # zero width non-breaking space
+  "\u2028",  # line separator
+  "\u2029",  # paragraph separator
+].freeze
+
+OBSCURE_FULL_WIDTH_WHITESPACE = [
+  "\u00a0",  # non breaking space
+  "\u202f",  # narrow no break space
+].freeze
+
+module NotificationsUtils
+  module Formatters
+    def strip_and_remove_obscure_whitespace(value)
+      if value == ""
+        # Return early to avoid making multiple, slow calls to
+        # str.replace on an empty string
+        return ""
+      end
+
+      (OBSCURE_ZERO_WIDTH_WHITESPACE + OBSCURE_FULL_WIDTH_WHITESPACE).each do |character|
+        value = value.gsub(character, "")
+      end
+
+      value.strip
+    end
+
+    module_function :strip_and_remove_obscure_whitespace
+  end
+end

--- a/lib/notifications_utils/recipient_validation/email_address.rb
+++ b/lib/notifications_utils/recipient_validation/email_address.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# This is pretty much a copy of https://github.com/alphagov/notifications-utils/blob/8b39f0006709662df689d52055867bca0a897230/notifications_utils/recipient_validation/email_address.py
+
+require "uri/idna"
+
+require "notifications_utils/formatters"
+require "notifications_utils/recipient_validation/errors"
+
+# Valid characters taken from https://en.wikipedia.org/wiki/Email_address#Local-part
+# Note: Normal apostrophe eg `Firstname-o'surname@domain.com` is allowed.
+# hostname_part regex: xn in regex signifies possible punycode conversions, which would start `xn--`;
+# the hyphens are matched for later in the regex.
+HOSTNAME_PART = Regexp.compile("^(xn|[a-z0-9]+)(-?-[a-z0-9]+)*$", Regexp::IGNORECASE)
+TLD_PART = Regexp.compile("^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$", Regexp::IGNORECASE)
+VALID_LOCAL_CHARS = "a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\-"
+EMAIL_REGEX_PATTERN = /^[#{VALID_LOCAL_CHARS}]+@([^.@][^@\s]+)$/
+
+module NotificationsUtils
+  module RecipientValidation
+    module EmailAddress
+      def validate_email_address(email_address)
+        # almost exactly the same as by https://github.com/wtforms/wtforms/blob/master/wtforms/validators.py,
+        # with minor tweaks for SES compatibility - to avoid complications we are a lot stricter with the local part
+        # than neccessary - we don't allow any double quotes or semicolons to prevent SES Technical Failures
+        email_address = Formatters.strip_and_remove_obscure_whitespace(email_address)
+        match = EMAIL_REGEX_PATTERN.match(email_address)
+
+        raise InvalidEmailError unless match
+
+        raise InvalidEmailError if email_address.length > 320
+
+        # don't allow consecutive periods in either part
+        raise InvalidEmailError if email_address.include? ".."
+
+        hostname = match[1]
+        # idna = "Internationalized domain name" - this encode/decode cycle converts unicode into its accurate ascii
+        # representation as the web uses. URI::IDNA.lookup('例え.テスト') == 'xn--r8jz45g.xn--zckzah'
+        begin
+          hostname = URI::IDNA.lookup hostname.downcase(:ascii)
+        rescue URI::IDNA::Error, URI::IDNA::InvalidCodepointError
+          raise InvalidEmailError
+        end
+
+        parts = hostname.split(".")
+
+        raise InvalidEmailError if hostname.length > 253 || parts.length < 2
+
+        parts.each do |part|
+          raise InvalidEmailError if !part || part.length > 63 || !HOSTNAME_PART.match(part)
+        end
+
+        # if the part after the last . is not a valid TLD then bail out
+        raise InvalidEmailError unless TLD_PART.match(parts[-1])
+
+        email_address
+      end
+
+      module_function :validate_email_address
+    end
+  end
+end

--- a/lib/notifications_utils/recipient_validation/errors.rb
+++ b/lib/notifications_utils/recipient_validation/errors.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copy of just the bits we need from https://github.com/alphagov/notifications-utils/blob/8b39f0006709662df689d52055867bca0a897230/notifications_utils/recipient_validation/errors.py
+
+module NotificationsUtils
+  module RecipientValidation
+    class InvalidRecipientError < StandardError
+      def message
+        "Not a valid recipient address"
+      end
+    end
+
+    class InvalidEmailError < StandardError
+      def message
+        "Not a valid email address"
+      end
+    end
+  end
+end

--- a/spec/input_objects/email_confirmation_input_spec.rb
+++ b/spec/input_objects/email_confirmation_input_spec.rb
@@ -2,6 +2,38 @@ require "rails_helper"
 
 RSpec.describe EmailConfirmationInput, type: :model do
   let(:email_confirmation_input) { build :email_confirmation_input }
+  let(:invalid_emails) do
+    ["email@123.123.123.123",
+     "email@[123.123.123.123]",
+     "plainaddress",
+     "@no-local-part.com",
+     "Outlook Contact <outlook-contact@domain.com>",
+     "no-at.domain.com",
+     "no-tld@domain",
+     ";beginning-semicolon@domain.co.uk",
+     "middle-semicolon@domain.co;uk",
+     "trailing-semicolon@domain.com;",
+     '"email+leading-quotes@domain.com',
+     'email+middle"-quotes@domain.com',
+     '"quoted-local-part"@domain.com',
+     '"quoted@domain.com"',
+     "lots-of-dots@domain..gov..uk",
+     "two-dots..in-local@domain.com",
+     "multiple@domains@domain.com",
+     "spaces in local@domain.com",
+     "spaces-in-domain@dom ain.com",
+     "underscores-in-domain@dom_ain.com",
+     "pipe-in-domain@example.com|gov.uk",
+     "comma,in-local@gov.uk",
+     "comma-in-domain@domain,gov.uk",
+     "pound-sign-in-local£@domain.com",
+     "local-with-’-apostrophe@domain.com",
+     "local-with-”-quotes@domain.com",
+     "domain-starts-with-a-dot@.domain.com",
+     "brackets(in)local@domain.com",
+     "email-too-long-#{'a' * 320}@example.com",
+     "incorrect-punycode@xn---something.com"]
+  end
 
   context "when given an empty string or nil" do
     it "returns invalid with blank email" do
@@ -20,11 +52,13 @@ RSpec.describe EmailConfirmationInput, type: :model do
   end
 
   context "when user opts in and provides an invalid email address" do
-    let(:email_confirmation_input) { build :email_confirmation_input_opted_in, confirmation_email_address: "not an email address" }
+    it "does not allow invalid emails" do
+      invalid_emails.each do |invalid_email|
+        email_confirmation_input = build :email_confirmation_input_opted_in, confirmation_email_address: invalid_email
 
-    it "does not validate an address without an @" do
-      expect(email_confirmation_input).not_to be_valid
-      expect(email_confirmation_input.errors[:confirmation_email_address]).to include(I18n.t("activemodel.errors.models.email_confirmation_input.attributes.confirmation_email_address.invalid_email"))
+        expect(email_confirmation_input).not_to be_valid
+        expect(email_confirmation_input.errors[:confirmation_email_address]).to include(I18n.t("activemodel.errors.models.email_confirmation_input.attributes.confirmation_email_address.invalid_email"))
+      end
     end
   end
 

--- a/spec/lib/notifications_utils/formatters_spec.rb
+++ b/spec/lib/notifications_utils/formatters_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+require "./spec/support/custom_matchers"
+
+require "notifications_utils/formatters"
+
+RSpec.describe NotificationsUtils::Formatters do
+  include described_class
+
+  describe ".strip_and_remove_obscure_whitespace" do
+    [
+      "notifications-email",
+      "  \tnotifications-email \x0c ",
+      "\rn\u200coti\u200dfi\u200bcati\u2060ons-\u180eemai\ufeffl\ufeff",
+    ].each do |value|
+      it "removes obscure whitespace" do
+        expect(strip_and_remove_obscure_whitespace(value)).to eq_string "notifications-email"
+      end
+    end
+
+    it "only removes normal whitespace from ends" do
+      sentence = "   words \n over multiple lines with \ttabs\t   "
+      expect(strip_and_remove_obscure_whitespace(sentence)).to eq_string "words \n over multiple lines with \ttabs"
+    end
+  end
+end

--- a/spec/lib/notifications_utils/recipient_validation/email_address_spec.rb
+++ b/spec/lib/notifications_utils/recipient_validation/email_address_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "./spec/support/custom_matchers"
+
+require "notifications_utils/recipient_validation/email_address"
+
+RSpec.describe NotificationsUtils::RecipientValidation::EmailAddress do
+  [
+    "email@domain.com",
+    "email@domain.COM",
+    "firstname.lastname@domain.com",
+    "firstname.o'lastname@domain.com",
+    "email@subdomain.domain.com",
+    "firstname+lastname@domain.com",
+    "1234567890@domain.com",
+    "email@domain-one.com",
+    "_______@domain.com",
+    "email@domain.name",
+    "email@domain.superlongtld",
+    "email@domain.co.jp",
+    "firstname-lastname@domain.com",
+    "info@german-financial-services.vermögensberatung",
+    "info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase",
+    "japanese-info@例え.テスト",
+    "email@double--hyphen.com",
+  ].each do |valid_email_address|
+    context "with #{valid_email_address.dump}" do
+      it "accepts valid email address" do
+        expect(described_class.validate_email_address(valid_email_address)).to be_truthy
+      end
+    end
+  end
+
+  [
+    " email@domain.com ",
+    "\temail@domain.com",
+    "\temail@domain.com\n",
+    "\u200bemail@domain.com\u200b",
+  ].each do |email_address|
+    it "strips whitespace" do
+      expect(described_class.validate_email_address(email_address)).to eq_string "email@domain.com"
+    end
+  end
+
+  [
+    "email@123.123.123.123",
+    "email@[123.123.123.123]",
+    "plainaddress",
+    "@no-local-part.com",
+    "Outlook Contact <outlook-contact@domain.com>",
+    "no-at.domain.com",
+    "no-tld@domain",
+    ";beginning-semicolon@domain.co.uk",
+    "middle-semicolon@domain.co;uk",
+    "trailing-semicolon@domain.com;",
+    '"email+leading-quotes@domain.com',
+    'email+middle"-quotes@domain.com',
+    '"quoted-local-part"@domain.com',
+    '"quoted@domain.com"',
+    "lots-of-dots@domain..gov..uk",
+    "two-dots..in-local@domain.com",
+    "multiple@domains@domain.com",
+    "spaces in local@domain.com",
+    "spaces-in-domain@dom ain.com",
+    "underscores-in-domain@dom_ain.com",
+    "pipe-in-domain@example.com|gov.uk",
+    "comma,in-local@gov.uk",
+    "comma-in-domain@domain,gov.uk",
+    "pound-sign-in-local£@domain.com",
+    "local-with-’-apostrophe@domain.com",
+    "local-with-”-quotes@domain.com",
+    "domain-starts-with-a-dot@.domain.com",
+    "brackets(in)local@domain.com",
+    "email-too-long-#{'a' * 320}@example.com",
+    "incorrect-punycode@xn---something.com",
+  ].each do |invalid_email_address|
+    context "with #{invalid_email_address.dump}" do
+      it "raises for invalid email address" do
+        expect {
+          described_class.validate_email_address(invalid_email_address)
+        }.to raise_error NotificationsUtils::RecipientValidation::InvalidEmailError, "Not a valid email address"
+      end
+    end
+  end
+end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -1,0 +1,20 @@
+# eq_string matcher includes special characters in the output on failure for easier debugging
+RSpec::Matchers.define :eq_string do |expected|
+  match do |string|
+    unless expected.respond_to?(:dump)
+      raise TypeError, "expected for eq_string should be a string"
+    end
+
+    string == expected
+  end
+
+  failure_message do |string|
+    got = string.respond_to?(:dump) ? string.dump : string.inspect
+    "expected: #{expected.dump}\n     got: #{got}"
+  end
+
+  failure_message_when_negated do |string|
+    got = string.respond_to?(:dump) ? string.dump : string.inspect
+    "expected: value != #{expected.dump}\n     got: #{got}"
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/tf6aUbYa/2266-make-email-address-validation-consistent <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We've been seeing errors in production from the GOV.UK Notify API from invalid email addresses [[1]]:

```
ValidationError: email_address Not a valid email address (Notifications::Client::BadRequestError)
```

This is happening because when we ask form fillers for an email address for their confirmation email, the validation we do to check whether the email address is valid is much simpler than the validation done by Notify themselves.

It's preferable that we pre-validate the emails on our servers rather than rely on Notify to validate for us, especially if we want to start sending confirmation emails asynchronously.

So we need to have the same validation logic for email addresses as Notify. Unfortunately the rules around what is a valid email address are quite complicated.

This PR copies a bunch of code from the alphagov/notifications-utils repo related to checking if an email address is valid. That code is written in Python, so the code in this commit has been lightly rewritten, but the emphasis was on keeping similarity with the original rather than making it fully idiomatic Ruby. We then wrap it in a very thin Rails-y validator class to make it work with our input objects.

This approach means that hopefully it is easier to stay in sync with Notify if they ever need to change their email address validation.

[1]: https://govuk-forms.sentry.io/issues/6360367242/

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?