### PR TITLE
update i18n config to read check all locales files against each other

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -17,8 +17,6 @@ data:
   read:
     ## Default:
     # - config/locales/%{locale}.yml
-    ## More files:
-    - config/locales/*.yml
 
   # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
   # `i18n-tasks normalize -p` will force move the keys according to these rules


### PR DESCRIPTION

### What problem does this pull request solve?

Now that we're adding welsh translations, we need our tests to tell us when a translation is missing in one of the locales translations files. To do this, the configuration for i18n needed to be updated to allow it to read all files in the config/locales directory.

Trello card: https://trello.com/c/MJPwz0Qb/2297-enforce-that-welsh-translation-exists-for-new-content-in-forms-runner

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
