### PR TITLE
Add Welsh confirmation email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,8 @@ gem "csv"
 # the hash, also change in package.json
 gem "dfe-autocomplete", require: "dfe/autocomplete", github: "DFE-Digital/dfe-autocomplete", ref: "1d4cc65039e11cc3ba9e7217a719b8128d0e4d53"
 
+gem "rails-i18n", "~> 8.0"
+
 # IDNA conversion needed for validating email addresses
 gem "uri-idna"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -542,6 +542,7 @@ DEPENDENCIES
   puma (~> 6.6.0)
   rails (= 8.0.2)
   rails-controller-testing
+  rails-i18n (~> 8.0)
   redis
   redis-session-store
   rspec-rails

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -1,6 +1,6 @@
 class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
   def send_confirmation_email(what_happens_next_markdown:, support_contact_details:, notify_response_id:, confirmation_email_address:, mailer_options:)
-    set_template(Settings.govuk_notify.form_filler_confirmation_email_template_id)
+    set_template(template_id)
 
     set_personalisation(
       title: mailer_options.title,
@@ -28,5 +28,11 @@ private
 
   def make_notify_boolean(bool)
     bool ? "yes" : "no"
+  end
+
+  def template_id
+    return Settings.govuk_notify.form_filler_confirmation_email_welsh_template_id if I18n.locale == :cy
+
+    Settings.govuk_notify.form_filler_confirmation_email_template_id
   end
 end

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -7,7 +7,7 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
       what_happens_next_text: what_happens_next_markdown,
       support_contact_details:,
       submission_time: mailer_options.timestamp.strftime("%l:%M%P").strip,
-      submission_date: mailer_options.timestamp.strftime("%-d %B %Y"),
+      submission_date: I18n.l(mailer_options.timestamp, format: "%-d %B %Y"),
       # GOV.UK Notify's templates have conditionals, but only positive
       # conditionals, so to simulate negative conditionals we add two boolean
       # flags; but they must always have opposite values!

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -3,7 +3,7 @@
 # The "main" locale.
 base_locale: en
 ## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
-# locales: [es, fr]
+locales: [en, cy]
 ## Reporting locale, default: en. Available: en, ru.
 # internal_locale: en
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,7 @@ govuk_notify:
   form_submission_email_reply_to_id: fab9373b-fb7c-483f-ae25-5a9852bfcc04
   form_submission_email_template_id: 427eb8bc-ce0d-40a3-bf54-d76e8c3ec916
   form_filler_confirmation_email_template_id: 2d1f36dc-9799-43dd-8673-b631f9e0b4a5
+  form_filler_confirmation_email_welsh_template_id: 4c5c75df-3a48-48ec-80d9-df9cabcdc9fc
 
 # Configuration for Sentry
 # Sentry will only initialise if dsn is set to some other value

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -40,6 +40,7 @@ describe "Settings" do
     include_examples expected_value_test, :form_submission_email_reply_to_id, govuk_notify, "fab9373b-fb7c-483f-ae25-5a9852bfcc04"
     include_examples expected_value_test, :form_submission_email_template_id, govuk_notify, "427eb8bc-ce0d-40a3-bf54-d76e8c3ec916"
     include_examples expected_value_test, :form_filler_confirmation_email_template_id, govuk_notify, "2d1f36dc-9799-43dd-8673-b631f9e0b4a5"
+    include_examples expected_value_test, :form_filler_confirmation_email_welsh_template_id, govuk_notify, "4c5c75df-3a48-48ec-80d9-df9cabcdc9fc"
   end
 
   describe "sentry" do

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -119,9 +119,39 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
           end
         end
 
-        it "includes the date user submitted the form" do
-          travel_to timestamp do
-            expect(mail.govuk_notify_personalisation[:submission_date]).to eq("14 September 2022")
+        context "when the request locale is not set" do
+          it "includes the date user submitted the form in English" do
+            travel_to timestamp do
+              expect(mail.govuk_notify_personalisation[:submission_date]).to eq("14 September 2022")
+            end
+          end
+        end
+
+        context "when the request locale is set to :en" do
+          around do |example|
+            I18n.with_locale(:en) do
+              example.run
+            end
+          end
+
+          it "includes the date user submitted the form in English" do
+            travel_to timestamp do
+              expect(mail.govuk_notify_personalisation[:submission_date]).to eq("14 September 2022")
+            end
+          end
+        end
+
+        context "when the request locale is set to :cy" do
+          around do |example|
+            I18n.with_locale(:cy) do
+              example.run
+            end
+          end
+
+          it "includes the date user submitted the form in Welsh" do
+            travel_to timestamp do
+              expect(mail.govuk_notify_personalisation[:submission_date]).to eq("14 Medi 2022")
+            end
           end
         end
       end

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -37,11 +37,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
     end
 
     context "when the request locale is set to :en" do
-      around do |example|
-        I18n.with_locale(:en) do
-          example.run
-        end
-      end
+      include_context "with locale set to :en"
 
       it "uses the English language template" do
         expect(mail.govuk_notify_template).to eq("123456")
@@ -49,11 +45,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
     end
 
     context "when the request locale is set to :cy" do
-      around do |example|
-        I18n.with_locale(:cy) do
-          example.run
-        end
-      end
+      include_context "with locale set to :cy"
 
       it "uses the Welsh language template" do
         expect(mail.govuk_notify_template).to eq("7891011")
@@ -128,12 +120,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
         end
 
         context "when the request locale is set to :en" do
-          around do |example|
-            I18n.with_locale(:en) do
-              example.run
-            end
-          end
-
+          include_context "with locale set to :en"
           it "includes the date user submitted the form in English" do
             travel_to timestamp do
               expect(mail.govuk_notify_personalisation[:submission_date]).to eq("14 September 2022")
@@ -142,11 +129,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
         end
 
         context "when the request locale is set to :cy" do
-          around do |example|
-            I18n.with_locale(:cy) do
-              example.run
-            end
-          end
+          include_context "with locale set to :cy"
 
           it "includes the date user submitted the form in Welsh" do
             travel_to timestamp do

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -25,9 +25,39 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
   let(:payment_url) { nil }
 
   context "when form filler wants an form submission confirmation email" do
-    it "sends an email with the correct template" do
+    before do
       Settings.govuk_notify.form_filler_confirmation_email_template_id = "123456"
-      expect(mail.govuk_notify_template).to eq("123456")
+      Settings.govuk_notify.form_filler_confirmation_email_welsh_template_id = "7891011"
+    end
+
+    context "when the request locale is not set" do
+      it "uses the English language template" do
+        expect(mail.govuk_notify_template).to eq("123456")
+      end
+    end
+
+    context "when the request locale is set to :en" do
+      around do |example|
+        I18n.with_locale(:en) do
+          example.run
+        end
+      end
+
+      it "uses the English language template" do
+        expect(mail.govuk_notify_template).to eq("123456")
+      end
+    end
+
+    context "when the request locale is set to :cy" do
+      around do |example|
+        I18n.with_locale(:cy) do
+          example.run
+        end
+      end
+
+      it "uses the Welsh language template" do
+        expect(mail.govuk_notify_template).to eq("7891011")
+      end
     end
 
     it "sends an email to the form filler's email address" do

--- a/spec/support/shared_context/locale.rb
+++ b/spec/support/shared_context/locale.rb
@@ -1,0 +1,15 @@
+RSpec.shared_context "with locale set to :en" do
+  around do |example|
+    I18n.with_locale(:en) do
+      example.run
+    end
+  end
+end
+
+RSpec.shared_context "with locale set to :cy" do
+  around do |example|
+    I18n.with_locale(:cy) do
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/7RWlFifj/2299-make-confirmation-email-send-in-welsh-for-welsh-forms

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Adds code to send a different email template (written in Welsh) when the locale of the request is set to Welsh.

Includes:

- configuring the new template
- Making the month part of the date appear in Welsh (adds the [rails-i18n](https://github.com/svenfuchs/rails-i18n/) gem to do this easily)
- A new support file which should make testing locale-related features easier

I've also added a new template in Notify for this.
### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
