### PR TITLE
Fix single quote escaped in page title

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,10 +2,6 @@
 
 # ApplicationHelper
 module ApplicationHelper
-  def page_title
-    join_title_elements([content_for(:title), "GOV.UK"])
-  end
-
   def set_page_title(*args)
     content_for(:title) { join_title_elements(args) }
   end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template ">
   <head>
     <meta charset="utf-8">
-    <title><%= page_title %></title>
+    <title><%= yield(:title) + " – GOV.UK" %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <%= csrf_meta_tags %>

--- a/spec/features/fill_in_and_submit_form_spec.rb
+++ b/spec/features/fill_in_and_submit_form_spec.rb
@@ -49,6 +49,7 @@ feature "Fill in and submit a form", type: :feature do
   end
 
   def then_i_should_see_the_first_question
+    expect(page).to have_title("#{question_text} - #{form.name} – GOV.UK")
     expect(page.find("h1")).to have_text question_text
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       it "returns the title with the GOV.UK suffix" do
         expect(view.content_for(:title)).to eq("Test")
-        expect(helper.page_title).to eq("Test – GOV.UK")
       end
     end
 
@@ -20,7 +19,6 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       it "returns the title with the GOV.UK suffix" do
         expect(view.content_for(:title)).to eq("Test – GOV.UK Forms")
-        expect(helper.page_title).to eq("Test – GOV.UK Forms – GOV.UK")
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/tuKLpQLL/2685-fix-encoding-so-characters-appear-correctly-in-browser-title-bar

Single quotes were appearing as HTML escaped (&#39;) in the page title as it seemed we were double HTML escaping it. This fixes that.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
