### PR TITLE
Fix broken link to ICO cookies information

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -261,7 +261,7 @@ cy:
           column_2: 1 year in Welsh
     section_0: Cookies are small files saved on your phone, tablet or computer when you visit a website. in Welsh
     section_1: We use cookies to make this form work. in Welsh
-    section_2_html: Find out <a rel="external" href="https://ico.org.uk/your-data-matters/online/cookies/">how to manage cookies</a>. in Welsh
+    section_2_html: Find out <a rel="external" href="https://cy.ico.org.uk/for-the-public/online/cookies">how to manage cookies</a>. in Welsh
     title: Cookies in Welsh
   environment_names:
     dev: Development in Welsh

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,7 +260,7 @@ en:
           column_2: 1 year
     section_0: Cookies are small files saved on your phone, tablet or computer when you visit a website.
     section_1: We use cookies to make this form work.
-    section_2_html: Find out <a rel="external" href="https://ico.org.uk/your-data-matters/online/cookies/">how to manage cookies</a>.
+    section_2_html: Find out <a rel="external" href="https://ico.org.uk/for-the-public/online/cookies">how to manage cookies</a>.
     title: Cookies
   environment_names:
     dev: Development


### PR DESCRIPTION
### What problem does this pull request solve?

The link to the ICO guidance about cookies was broken. This updates the link and also adds the link to the Welsh version of the page to the Welsh translation file.

Note that the "Welsh" version of the ICO page is mainly in English - but hopefully it will become Welsh one day.

(Sorry I was planning to squash these two commits but it seems that I cannot do that anymore).

Trello card:https://trello.com/c/Acu7gpwS/2879-404-link-in-cookies-page

### Things to consider when reviewing

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
