### PR TITLE
Add translations for form builder gem

### DIFF
--- a/app/components/question/date_component/view.html.erb
+++ b/app/components/question/date_component/view.html.erb
@@ -1,5 +1,6 @@
 <%= form_builder.govuk_date_field :date,
                                   date_of_birth: date_of_birth?,
                                   legend: { text: question_text_with_extra_suffix, **question_text_size_and_tag },
-                                  hint: { text: question.hint_text }
+                                  hint: { text: question.hint_text },
+                                  segment_names: { day: t("date_segment_names.day"), month: t("date_segment_names.month"), year: t("date_segment_names.year") }
 %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -262,6 +262,10 @@ cy:
     section_1: Rydym yn defnyddio cwcis i wneud i’r ffurflen hon weithio.
     section_2_html: Darganfyddwch <a rel="external" href="https://cy.ico.org.uk/for-the-public/online/cookies">sut i reoli cwcis</a>.
     title: Cwcis
+  date_segment_names:
+    day: Diwrnod
+    month: Mis
+    year: Blwyddyn
   environment_names:
     dev: Development
     local: Local

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -369,6 +369,8 @@ cy:
     govuk_summary_list:
       change: Newid
   helpers:
+    error:
+      message_prefix: Gwall
     hint:
       email_confirmation_input:
         send_confirmation: Byddwn ond yn defnyddio’r cyfeiriad e-bost rydych yn ei ddarparu yma i anfon cadarnhad bod eich ffurflen wedi’i chyflwyno’n llwyddiannus. Ni fydd yn cynnwys copi o’ch atebion.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -262,6 +262,10 @@ en:
     section_1: We use cookies to make this form work.
     section_2_html: Find out <a rel="external" href="https://ico.org.uk/for-the-public/online/cookies">how to manage cookies</a>.
     title: Cookies
+  date_segment_names:
+    day: Day
+    month: Month
+    year: Year
   environment_names:
     dev: Development
     local: Local

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,6 +369,8 @@ en:
     govuk_summary_list:
       change: Change
   helpers:
+    error:
+      message_prefix: Error
     hint:
       email_confirmation_input:
         send_confirmation: We’ll only use the email address you provide here to send a confirmation that your form’s been successfully submitted. It will not contain a copy of your answers.


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/CbwtWUHk

This PR adds translations for:
- hidden error prefix for inline error messages
- segment names for date fields

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
