### PR TITLE
Add logging of information about email bounces

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,5 +1,6 @@
 class ApplicationJob < ActiveJob::Base
   def set_submission_logging_attributes(submission)
+    CurrentJobLoggingAttributes.job_class = self.class.name
     CurrentJobLoggingAttributes.job_id = job_id
     CurrentJobLoggingAttributes.form_id = submission.form.id
     CurrentJobLoggingAttributes.form_name = submission.form.name

--- a/app/jobs/delete_submissions_job.rb
+++ b/app/jobs/delete_submissions_job.rb
@@ -3,6 +3,7 @@ class DeleteSubmissionsJob < ApplicationJob
 
   def perform(*_args)
     CloudWatchService.record_job_started_metric(self.class.name)
+    CurrentJobLoggingAttributes.job_class = self.class.name
     CurrentJobLoggingAttributes.job_id = job_id
 
     delete_submissions_sent_before_time = Settings.retain_submissions_for_seconds.seconds.ago

--- a/app/jobs/receive_submission_bounces_and_complaints_job.rb
+++ b/app/jobs/receive_submission_bounces_and_complaints_job.rb
@@ -11,6 +11,7 @@ class ReceiveSubmissionBouncesAndComplaintsJob < ApplicationJob
 
   def perform
     CloudWatchService.record_job_started_metric(self.class.name)
+    CurrentJobLoggingAttributes.job_class = self.class.name
     CurrentJobLoggingAttributes.job_id = job_id
 
     sts_client = Aws::STS::Client.new(region: REGION)

--- a/app/jobs/receive_submission_deliveries_job.rb
+++ b/app/jobs/receive_submission_deliveries_job.rb
@@ -11,6 +11,7 @@ class ReceiveSubmissionDeliveriesJob < ApplicationJob
 
   def perform
     CloudWatchService.record_job_started_metric(self.class.name)
+    CurrentJobLoggingAttributes.job_class = self.class.name
     CurrentJobLoggingAttributes.job_id = job_id
 
     sts_client = Aws::STS::Client.new(region: REGION)

--- a/app/models/current_job_logging_attributes.rb
+++ b/app/models/current_job_logging_attributes.rb
@@ -1,8 +1,9 @@
 class CurrentJobLoggingAttributes < ActiveSupport::CurrentAttributes
-  attribute :job_id, :form_id, :form_name, :submission_reference, :mail_message_id, :sqs_message_id, :sns_message_timestamp
+  attribute :job_class, :job_id, :form_id, :form_name, :submission_reference, :mail_message_id, :sqs_message_id, :sns_message_timestamp
 
   def as_hash
     {
+      job_class:,
       job_id:,
       form_id:,
       form_name:,

--- a/spec/jobs/delete_submissions_job_spec.rb
+++ b/spec/jobs/delete_submissions_job_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
           "form_name" => form_with_file_upload.name,
           "submission_reference" => sent_submission_sent_8_days_ago.reference,
           "job_id" => @job_id,
+          "job_class" => "DeleteSubmissionsJob",
         ),
         hash_including(
           "level" => "INFO",
@@ -132,6 +133,7 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
           "form_name" => form_without_file_upload.name,
           "submission_reference" => sent_submission_sent_7_days_ago.reference,
           "job_id" => @job_id,
+          "job_class" => "DeleteSubmissionsJob",
         ),
       )
     end
@@ -156,6 +158,7 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
                                      "form_id" => form_with_file_upload.id,
                                      "submission_reference" => sent_submission_sent_8_days_ago.reference,
                                      "job_id" => @job_id,
+                                     "job_class" => "DeleteSubmissionsJob",
                                    ))
     end
 

--- a/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
+++ b/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
                                        "sqs_message_id" => sqs_message_id,
                                        "sns_message_timestamp" => sns_message_timestamp,
                                        "job_id" => @job_id,
+                                       "job_class" => "ReceiveSubmissionBouncesAndComplaintsJob",
                                      ))
       end
 
@@ -175,6 +176,7 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
                                          "sns_message_timestamp" => sns_message_timestamp,
                                          "message" => "Error processing message - StandardError: Test error",
                                          "job_id" => @job_id,
+                                         "job_class" => "ReceiveSubmissionBouncesAndComplaintsJob",
                                        ))
         end
 
@@ -220,6 +222,7 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
                                        "message" => "Form event",
                                        "event" => "form_submission_complaint",
                                        "job_id" => @job_id,
+                                       "job_class" => "ReceiveSubmissionBouncesAndComplaintsJob",
                                      ))
       end
 

--- a/spec/jobs/receive_submission_deliveries_job_spec.rb
+++ b/spec/jobs/receive_submission_deliveries_job_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
                                        "submission_reference" => reference,
                                        "sns_message_timestamp" => sns_message_timestamp,
                                        "job_id" => @job_id,
+                                       "job_class" => "ReceiveSubmissionDeliveriesJob",
                                      ))
       end
 
@@ -170,6 +171,7 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
                                          "sns_message_timestamp" => sns_message_timestamp,
                                          "message" => "Error processing message - StandardError: Test error",
                                          "job_id" => @job_id,
+                                         "job_class" => "ReceiveSubmissionDeliveriesJob",
                                        ))
         end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/krMtjVAf/2344-add-extra-information-for-submission-email-bounce-notifications <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This PR adds logging about bounced emails so we can better diagnose issues we see.

I've tested this in dev with a [bounce test form](https://submit.dev.forms.service.gov.uk/preview-draft/14519/bounce-test-form), you can see logs in Splunk by searching for [index="gds_dsp_dev_forms" "submission_bounced"](https://gds.splunkcloud.com/en-GB/app/gds-543-forms/search?earliest=1750248000&latest=1750251600&q=search%20index%3D%22gds_dsp_dev_forms%22%20%22submission_bounced%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&sid=1750324171.63441_EF514FC9-3E4E-4E40-A55A-64CE41D26AAF) or looking at the latest events in Sentry at https://govuk-forms.sentry.io/issues/6451735064.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?