### PR TITLE
Privacy notice update

### DIFF
--- a/app/views/forms/privacy_page/show.html.erb
+++ b/app/views/forms/privacy_page/show.html.erb
@@ -119,7 +119,7 @@
     <p>
       <%= t("privacy.questions_and_complaints.section_1.line_0") %>
       <br>
-      <%= govuk_link_to "DPO@cabinetoffice.gov.uk", "mailto:DPO@cabinetoffice.gov.uk" %>
+      <%= govuk_link_to "dataprotection@dsit.gov.uk", "mailto:dataprotection@dsit.gov.uk" %>
       <br>
       <%= t("privacy.questions_and_complaints.section_1.line_1") %>
       <br>

--- a/app/views/forms/privacy_page/show.html.erb
+++ b/app/views/forms/privacy_page/show.html.erb
@@ -13,7 +13,7 @@
     <p><%= t("privacy.preamble.section_1") %></p>
     <p><%= t("privacy.preamble.section_2", privacy_policy_link: link_to(t("privacy.preamble.section_2_link_text"), @privacy_policy_url)).html_safe %></p>
     <p><%= t("privacy.preamble.section_3") %></p>
-    <p><%= t("privacy.preamble.section_4", dppr_link: link_to(t("privacy.preamble.section_4_link_text"), "https://ico.org.uk/ESDWebPages/Entry/Z7414053")).html_safe %></p>
+    <p><%= t("privacy.preamble.section_4", dppr_link: link_to(t("privacy.preamble.section_4_link_text"), "https://ico.org.uk/ESDWebPages/Entry/ZB546218")).html_safe %></p>
 
     <h2 class="govuk-heading-m"><%= t("privacy.data_we_collect.heading") %></h2>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -500,13 +500,13 @@ cy:
       heading: Sut rydym yn diogelu eich data a’i gadw’n ddiogel
       section_0: Rydym wedi ymrwymo i wneud popeth y gallwn i gadw’ch data yn ddiogel. Er mwyn atal mynediad neu ddatgelu anawdurdodedig, rydym wedi rhoi gweithdrefnau technegol a sefydliadol ar waith i ddiogelu’r data rydym yn ei gasglu amdanoch chi – er enghraifft, rydym yn diogelu’ch data gan ddefnyddio lefelau amrywiol o amgryptio. Rydym hefyd yn sicrhau bod gan unrhyw drydydd partïon rydym yn delio â nhw rwymedigaeth i gadw’r holl ddata personol y maent yn ei brosesu ar ein rhan yn ddiogel.
     preamble:
-      section_0: 'Diweddarwyd ddiwethaf: 20 Medi 2022'
-      section_1: Crëwyd y ffurflen hon gan ddefnyddio GOV.UK Forms. Mae GOV.UK Forms yn gynnyrch a ddarperir gan Wasanaeth Digidol y Llywodraeth (GDS) sy’n rhan o Swyddfa’r Cabinet. Mae’n caniatáu i dimau llywodraeth y DU greu ffurflenni ar-lein i gasglu gwybodaeth gan bobl a sefydliadau.
-      section_2: Y sefydliad a greodd y ffurflen ar-lein hon gan ddefnyddio GOV.UK Forms yw rheolydd data y data maent yn ei gasglu gan ddefnyddio’r ffurflen, tra bod Swyddfa’r Cabinet, trwy GDS, yn brosesydd data. Rhaid i’r rheolydd data ddweud wrthych am beth maent yn ei wneud gyda’ch data personol - %{privacy_policy_link}.
-      section_2_link_text: darllenwch wybodaeth preifatrwydd y rheolydd data ar gyfer y ffurflen hon
-      section_3: Mae Swyddfa’r Cabinet hefyd yn casglu rhywfaint o ddata fel rheolydd data. Mae’r hysbysiad preifatrwydd hwn yn esbonio pa ddata personol y mae’r Swyddfa’r Cabinet yn ei gasglu a’i brosesu fel rheolydd data trwy ffurflenni a wneir gyda GOV.UK Forms.
+      section_0: 'Last updated: 25 June 2025'
+      section_1: This form was created using GOV.UK Forms. GOV.UK Forms is a product provided by the Government Digital Service (GDS) which is part of the Department for Science, Innovation and Technology. It lets UK government teams create online forms to collect information from people and organisations.
+      section_2: The organisation that created this online form using GOV.UK Forms is the data controller of personal data they collect using the form, whilst the Department for Science, Innovation and Technology, through GDS, is the data processor. The data controller must tell you about what they are doing with your personal data - %{privacy_policy_link}.
+      section_2_link_text: read the data controller’s privacy information for this form
+      section_3: The Department for Science, Innovation and Technology also collects some data as a data controller. This privacy notice explains what personal data the Department for Science, Innovation and Technology collects and processes as a data controller through forms made with GOV.UK Forms.
       section_4: Darllenwch %{dppr_link} i gael rhagor o wybodaeth.
-      section_4_link_text: gofnod Swyddfa’r Cabinet yn y Gofrestr Gyhoeddus Diogelu Data
+      section_4_link_text: the Department for Science, Innovation and Technology’s entry in the Data Protection Public Register
     questions_and_complaints:
       heading: Cwestiynau a chwynion
       section_0:
@@ -514,11 +514,11 @@ cy:
         list_item_0: gyda chwestiynau am unrhyw beth yn y ddogfen hon
         list_item_1: yn meddwl bod eich data personol wedi cael ei gamddefnyddio neu ei gam-drin
       section_1:
-        line_0: Gallwch hefyd gysylltu â Swyddog Diogelu Data Swyddfa’r Cabinet.
-        line_1: Data Protection Officer
-        line_2: Cabinet Office
-        line_3: 70 Whitehall
-        line_4: London SW1A 2AS
+        line_0: You can also contact our Data Protection Officer.
+        line_1: DSIT Data Protection Officer
+        line_2: Department for Science, Innovation and Technology
+        line_3: 22-26 Whitehall
+        line_4: London SW1A 2EG
       section_2: Os oes gennych gŵyn, gallwch hefyd gysylltu â %{ico_link} (ICO). Mae’r ICO yn rheoleiddiwr annibynnol a sefydlwyd i gynnal hawliau gwybodaeth.
       section_2_link_text: Swyddfa’r Comisiynydd Gwybodaeth
       section_3:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -500,7 +500,7 @@ en:
       heading: How we protect your data and keep it secure
       section_0: We are committed to doing all that we can to keep your data secure. To prevent unauthorised access or disclosure we have put in place technical and organisational procedures to secure the data we collect about you – for example, we protect your data using varying levels of encryption. We also make sure that any third parties that we deal with have an obligation to keep all personal data they process on our behalf secure.
     preamble:
-      section_0: 'Last updated: 20 September 2022'
+      section_0: 'Last updated: 25 June 2025'
       section_1: This form was created using GOV.UK Forms. GOV.UK Forms is a product provided by the Government Digital Service (GDS) which is part of the Department for Science, Innovation and Technology. It lets UK government teams create online forms to collect information from people and organisations.
       section_2: The organisation that created this online form using GOV.UK Forms is the data controller of personal data they collect using the form, whilst the Department for Science, Innovation and Technology, through GDS, is the data processor. The data controller must tell you about what they are doing with your personal data - %{privacy_policy_link}.
       section_2_link_text: read the data controller’s privacy information for this form

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -501,12 +501,12 @@ en:
       section_0: We are committed to doing all that we can to keep your data secure. To prevent unauthorised access or disclosure we have put in place technical and organisational procedures to secure the data we collect about you – for example, we protect your data using varying levels of encryption. We also make sure that any third parties that we deal with have an obligation to keep all personal data they process on our behalf secure.
     preamble:
       section_0: 'Last updated: 20 September 2022'
-      section_1: This form was created using GOV.UK Forms. GOV.UK Forms is a product provided by the Government Digital Service (GDS) which is part of the Cabinet Office. It lets UK government teams create online forms to collect information from people and organisations.
-      section_2: The organisation that created this online form using GOV.UK Forms is the data controller of personal data they collect using the form, whilst the Cabinet Office, through GDS, is the data processor. The data controller must tell you about what they are doing with your personal data - %{privacy_policy_link}.
+      section_1: This form was created using GOV.UK Forms. GOV.UK Forms is a product provided by the Government Digital Service (GDS) which is part of the Department for Science, Innovation and Technology. It lets UK government teams create online forms to collect information from people and organisations.
+      section_2: The organisation that created this online form using GOV.UK Forms is the data controller of personal data they collect using the form, whilst the Department for Science, Innovation and Technology, through GDS, is the data processor. The data controller must tell you about what they are doing with your personal data - %{privacy_policy_link}.
       section_2_link_text: read the data controller’s privacy information for this form
-      section_3: The Cabinet Office also collects some data as a data controller. This privacy notice explains what personal data the Cabinet Office collects and processes as a data controller through forms made with GOV.UK Forms.
+      section_3: The Department for Science, Innovation and Technology also collects some data as a data controller. This privacy notice explains what personal data the Department for Science, Innovation and Technology collects and processes as a data controller through forms made with GOV.UK Forms.
       section_4: Read %{dppr_link} for more information.
-      section_4_link_text: the Cabinet Office’s entry in the Data Protection Public Register
+      section_4_link_text: the Department for Science, Innovation and Technology’s entry in the Data Protection Public Register
     questions_and_complaints:
       heading: Questions and complaints
       section_0:
@@ -514,11 +514,11 @@ en:
         list_item_0: have questions about anything in this document
         list_item_1: think that your personal data has been misused or mishandled
       section_1:
-        line_0: You can also contact the Cabinet Office Data Protection Officer.
-        line_1: Data Protection Officer
-        line_2: Cabinet Office
-        line_3: 70 Whitehall
-        line_4: London SW1A 2AS
+        line_0: You can also contact our Data Protection Officer.
+        line_1: DSIT Data Protection Officer
+        line_2: Department for Science, Innovation and Technology
+        line_3: 22-26 Whitehall
+        line_4: London SW1A 2EG
       section_2: If you have a complaint, you can also contact the %{ico_link} (ICO). The ICO is an independent regulator set up to uphold information rights.
       section_2_link_text: Information Commissioner’s Office
       section_3:


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/P8O3hZsI/2347-change-cabinet-office-to-department-of-science-innovation-and-technology-in-relevant-places-in-runner-admin-and-product-site

Updating privacy notices to say DSIT instead of Cabinet Office. 

After discussing with Stephen, I've put English content into the Welsh privacy notice so that it is obvious we need to get an updated translation before we make that feature live. 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
