### PR TITLE
Add input length validations

### DIFF
--- a/app/models/question/address.rb
+++ b/app/models/question/address.rb
@@ -11,7 +11,7 @@ module Question
 
     validate :uk_address_valid?, unless: :is_international_address?
     validate :postcode, :invalid_postcode?, unless: :is_international_address?
-    validate :international_adress_valid?, if: :is_international_address?
+    validate :international_address_valid?, if: :is_international_address?
 
     def postcode=(str)
       super str.present? ? UKPostcode.parse(str).to_s : str
@@ -41,16 +41,22 @@ module Question
       return if skipping_question?
 
       errors.add(:address1, :blank) if address1.blank?
+      errors.add(:address1, :too_long) if address1.present? && address1.length > 499
+      errors.add(:address2, :too_long) if address2.present? && address2.length > 499
       errors.add(:town_or_city, :blank) if town_or_city.blank?
+      errors.add(:town_or_city, :too_long) if town_or_city.present? && town_or_city.length > 499
+      errors.add(:county, :too_long) if county.present? && county.length > 499
       errors.add(:postcode, :blank) if postcode.blank?
       errors
     end
 
-    def international_adress_valid?
+    def international_address_valid?
       return if skipping_question?
 
       errors.add(:street_address, :blank) if street_address.blank?
+      errors.add(:street_address, :too_long) if street_address.present? && street_address.length > 4999
       errors.add(:country, :blank) if country.blank?
+      errors.add(:country, :too_long) if country.present? && country.length > 499
       errors
     end
   end

--- a/app/models/question/email.rb
+++ b/app/models/question/email.rb
@@ -1,13 +1,7 @@
 module Question
   class Email < Question::QuestionBase
-    # see https://design-system.service.gov.uk/patterns/email-addresses/
-    # This model contains very lite checking - only that an @ exists. Pay and
-    # notify both have good examples of better email validation checks and ways
-    # to help users enter the right value
-
-    EMAIL_REGEX = /.*@.*/
     attribute :email
     validates :email, presence: true, unless: :is_optional?
-    validates :email, format: { with: EMAIL_REGEX, message: :invalid_email }, allow_blank: true
+    validates :email, email_address: { message: :invalid_email }, allow_blank: true
   end
 end

--- a/app/models/question/name.rb
+++ b/app/models/question/name.rb
@@ -6,12 +6,9 @@ module Question
     attribute :middle_names
     attribute :last_name
 
+    validates :title, length: { maximum: 99 }, allow_blank: true
     validate :full_name_valid?, if: :is_full_name?
-    validate :first_and_last_name_valid?, unless: :is_full_name?
-
-    def validate_title
-      needs_title? && !is_optional?
-    end
+    validate :first_middle_and_last_name_valid?, unless: :is_full_name?
 
     def needs_title?
       answer_settings.present? && answer_settings&.title_needed == "true"
@@ -34,14 +31,18 @@ module Question
       return if skipping_question?
 
       errors.add(:full_name, :blank) if full_name.blank?
+      errors.add(:full_name, :too_long) if full_name.present? && full_name.length > 499
       errors
     end
 
-    def first_and_last_name_valid?
+    def first_middle_and_last_name_valid?
       return if skipping_question?
 
       errors.add(:first_name, :blank) if first_name.blank?
+      errors.add(:first_name, :too_long) if first_name.present? && first_name.length > 499
+      errors.add(:middle_names, :too_long) if include_middle_name? && middle_names.present? && middle_names.length > 499
       errors.add(:last_name, :blank) if last_name.blank?
+      errors.add(:last_name, :too_long) if last_name.present? && last_name.length > 499
       errors
     end
 

--- a/app/models/question/number.rb
+++ b/app/models/question/number.rb
@@ -3,5 +3,6 @@ module Question
     attribute :number
     validates :number, presence: true, unless: :is_optional?
     validates :number, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
+    validates :number, length: { maximum: 499 }, allow_blank: true
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -138,10 +138,17 @@ cy:
           attributes:
             first_name:
               blank: Rhowch enw cyntaf
+              too_long: The first name must be shorter than 500 characters
             full_name:
               blank: Rhowch enw
+              too_long: The name must be shorter than 500 characters
             last_name:
               blank: Rhowch enw olaf
+              too_long: The last name must be shorter than 500 characters
+            middle_names:
+              too_long: The middle name must be shorter than 500 characters
+            title:
+              too_long: The title must be shorter than 100 characters
         question/national_insurance_number:
           attributes:
             national_insurance_number:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -95,15 +95,23 @@ cy:
           attributes:
             address1:
               blank: Rhowch linell gyntaf y cyfeiriad
+              too_long: The first line of the address must be shorter than 500 characters
+            address2:
+              too_long: The second line of the address must be shorter than 500 characters
             country:
               blank: Rhowch y wlad
+              too_long: The country must be shorter than 500 characters
+            county:
+              too_long: The county must be shorter than 500 characters
             postcode:
               blank: Rhowch y cod post
               invalid_postcode: Rhowch god post gwirioneddol
             street_address:
               blank: Rhowch y cyfeiriad
+              too_long: The address must be shorter than 5,000 characters
             town_or_city:
               blank: Rhowch y dref neu’r ddinas
+              too_long: The town or city must be shorter than 500 characters
         question/date:
           attributes:
             date:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -153,6 +153,7 @@ cy:
               blank: Rhowch rif
               greater_than_or_equal_to: Rhaid i’r ateb fod yn fwy na 10 neu’n hafal i 0
               not_a_number: Rhaid i’r ateb fod yn rhif
+              too_long: The number must be shorter than 500 digits
         question/organisation_name:
           attributes:
             text:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,6 +153,7 @@ en:
               blank: Enter a number
               greater_than_or_equal_to: The answer must be greater than or equal to 0
               not_a_number: The answer must be a number
+              too_long: The number must be shorter than 500 digits
         question/organisation_name:
           attributes:
             text:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,15 +95,23 @@ en:
           attributes:
             address1:
               blank: Enter the first line of the address
+              too_long: The first line of the address must be shorter than 500 characters
+            address2:
+              too_long: The second line of the address must be shorter than 500 characters
             country:
               blank: Enter the country
+              too_long: The country must be shorter than 500 characters
+            county:
+              too_long: The county must be shorter than 500 characters
             postcode:
               blank: Enter the postcode
               invalid_postcode: Enter a full UK postcode
             street_address:
               blank: Enter the address
+              too_long: The address must be shorter than 5,000 characters
             town_or_city:
               blank: Enter the town or city
+              too_long: The town or city must be shorter than 500 characters
         question/date:
           attributes:
             date:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,10 +138,17 @@ en:
           attributes:
             first_name:
               blank: Enter a first name
+              too_long: The first name must be shorter than 500 characters
             full_name:
               blank: Enter a name
+              too_long: The name must be shorter than 500 characters
             last_name:
               blank: Enter a last name
+              too_long: The last name must be shorter than 500 characters
+            middle_names:
+              too_long: The middle name must be shorter than 500 characters
+            title:
+              too_long: The title must be shorter than 100 characters
         question/national_insurance_number:
           attributes:
             national_insurance_number:

--- a/spec/models/question/address_spec.rb
+++ b/spec/models/question/address_spec.rb
@@ -139,6 +139,44 @@ RSpec.describe Question::Address, type: :model do
         end
       end
     end
+
+    describe "length validations" do
+      before do
+        question.address1 = "a" * 499
+        question.address2 = "a" * 499
+        question.town_or_city = "a" * 499
+        question.county = "a" * 499
+        question.postcode = "LS11AF"
+      end
+
+      it "is valid when all fields have the maximum allowed length" do
+        expect(question).to be_valid
+      end
+
+      it "is invalid when the first line is too long" do
+        question.address1 = "a" * 500
+        expect(question).not_to be_valid
+        expect(question.errors[:address1]).to include(I18n.t("activemodel.errors.models.question/address.attributes.address1.too_long"))
+      end
+
+      it "is invalid when the second line is too long" do
+        question.address2 = "a" * 500
+        expect(question).not_to be_valid
+        expect(question.errors[:address2]).to include(I18n.t("activemodel.errors.models.question/address.attributes.address2.too_long"))
+      end
+
+      it "is invalid when the town or city is too long" do
+        question.town_or_city = "a" * 500
+        expect(question).not_to be_valid
+        expect(question.errors[:town_or_city]).to include(I18n.t("activemodel.errors.models.question/address.attributes.town_or_city.too_long"))
+      end
+
+      it "is invalid when the county is too long" do
+        question.county = "a" * 500
+        expect(question).not_to be_valid
+        expect(question.errors[:county]).to include(I18n.t("activemodel.errors.models.question/address.attributes.county.too_long"))
+      end
+    end
   end
 
   context "when the address is an international address" do
@@ -236,6 +274,29 @@ RSpec.describe Question::Address, type: :model do
         it "returns the whole address as one item in show_answer_in_csv" do
           expect(question.show_answer_in_csv).to eq(Hash[question_text, "Laskerstraße 5, 10245 Berlin, Germany"])
         end
+      end
+    end
+
+    describe "length validations" do
+      before do
+        question.street_address = "a" * 4999
+        question.country = "a" * 499
+      end
+
+      it "is valid when all fields have the maximum allowed length" do
+        expect(question).to be_valid
+      end
+
+      it "is invalid when the street address is too long" do
+        question.street_address = "a" * 5000
+        expect(question).not_to be_valid
+        expect(question.errors[:street_address]).to include(I18n.t("activemodel.errors.models.question/address.attributes.street_address.too_long"))
+      end
+
+      it "is invalid when the country is too long" do
+        question.country = "a" * 5000
+        expect(question).not_to be_valid
+        expect(question.errors[:country]).to include(I18n.t("activemodel.errors.models.question/address.attributes.country.too_long"))
       end
     end
   end

--- a/spec/models/question/email_spec.rb
+++ b/spec/models/question/email_spec.rb
@@ -10,52 +10,60 @@ RSpec.describe Question::Email, type: :model do
 
   it_behaves_like "a question model"
 
-  context "when given an empty string or nil" do
-    it "returns invalid with blank email" do
-      expect(question).not_to be_valid
-      expect(question.errors[:email]).to include(I18n.t("activemodel.errors.models.question/email.attributes.email.blank"))
+  shared_examples "format validations" do
+    context "when given a valid email address" do
+      let(:email) { Faker::Internet.email }
+
+      before do
+        question.email = email
+      end
+
+      it "is valid" do
+        expect(question).to be_valid
+      end
+
+      it "is included in show_answer" do
+        expect(question.show_answer).to eq email
+      end
+
+      it "returns the email address in show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, email])
+      end
     end
 
-    it "returns invalid with empty string" do
-      question.email = ""
-      expect(question).not_to be_valid
-      expect(question.errors[:email]).to include(I18n.t("activemodel.errors.models.question/email.attributes.email.blank"))
-      expect(question.errors[:email]).not_to include(I18n.t("activemodel.errors.models.question/email.attributes.email.invalid_email"))
-    end
-
-    it "shows as a blank string" do
-      expect(question.show_answer).to eq ""
-    end
-
-    it "returns a hash with an blank value for show_answer_in_csv" do
-      expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
+    context "when given an invalid email address" do
+      it "is invalid" do
+        question.email = "no-tld@domain"
+        expect(question).not_to be_valid
+        expect(question.errors[:email]).to include(I18n.t("activemodel.errors.models.question/email.attributes.email.invalid_email"))
+      end
     end
   end
 
-  context "when given a string with an @ symbol in" do
-    before do
-      question.email = " @ "
+  context "when question is mandatory" do
+    context "when given an empty string or nil" do
+      it "returns invalid with blank email" do
+        expect(question).not_to be_valid
+        expect(question.errors[:email]).to include(I18n.t("activemodel.errors.models.question/email.attributes.email.blank"))
+      end
+
+      it "returns invalid with empty string" do
+        question.email = ""
+        expect(question).not_to be_valid
+        expect(question.errors[:email]).to include(I18n.t("activemodel.errors.models.question/email.attributes.email.blank"))
+        expect(question.errors[:email]).not_to include(I18n.t("activemodel.errors.models.question/email.attributes.email.invalid_email"))
+      end
+
+      it "shows as a blank string" do
+        expect(question.show_answer).to eq ""
+      end
+
+      it "returns a hash with an blank value for show_answer_in_csv" do
+        expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
+      end
     end
 
-    it "validates" do
-      expect(question).to be_valid
-    end
-
-    it "is included in show_answer" do
-      expect(question.show_answer).to eq " @ "
-    end
-
-    it "returns the email address in show_answer_in_csv" do
-      expect(question.show_answer_in_csv).to eq(Hash[question_text, " @ "])
-    end
-  end
-
-  context "when given a string without an @ symbol in" do
-    it "does not validate an address without an @" do
-      question.email = "not an email address"
-      expect(question).not_to be_valid
-      expect(question.errors[:email]).to include(I18n.t("activemodel.errors.models.question/email.attributes.email.invalid_email"))
-    end
+    include_examples "format validations"
   end
 
   context "when question is optional" do
@@ -81,30 +89,6 @@ RSpec.describe Question::Email, type: :model do
       expect(question.show_answer_in_csv).to eq(Hash[question_text, ""])
     end
 
-    context "when given a string with an @ symbol in" do
-      before do
-        question.email = " @ "
-      end
-
-      it "validates" do
-        expect(question).to be_valid
-      end
-
-      it "is included in show_answer" do
-        expect(question.show_answer).to eq " @ "
-      end
-
-      it "returns the email address in show_answer_in_csv" do
-        expect(question.show_answer_in_csv).to eq(Hash[question_text, " @ "])
-      end
-    end
-
-    context "when given a string without an @ symbol in" do
-      it "does not validate an address without an @" do
-        question.email = "not an email address"
-        expect(question).not_to be_valid
-        expect(question.errors[:email]).to include(I18n.t("activemodel.errors.models.question/email.attributes.email.invalid_email"))
-      end
-    end
+    include_examples "format validations"
   end
 end

--- a/spec/models/question/name_spec.rb
+++ b/spec/models/question/name_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe Question::Name, type: :model do
 
   it_behaves_like "a question model"
 
+  shared_examples "title length validation" do
+    it "is valid when the title is less than 100 characters" do
+      question.title = "a" * 99
+      expect(question).to be_valid
+      expect(question.errors).to be_empty
+    end
+
+    it "is invalid when the title is more than 99 characters" do
+      question.title = "a" * 100
+      expect(question).not_to be_valid
+      expect(question.errors[:title]).to include(I18n.t("activemodel.errors.models.question/name.attributes.title.too_long"))
+    end
+  end
+
   context "when the name question is in full name format" do
     context "when the answer is empty" do
       it "returns invalid with blank full_name field" do
@@ -56,6 +70,20 @@ RSpec.describe Question::Name, type: :model do
 
       it "returns a hash with the full name for show_answer_in_csv" do
         expect(question.show_answer_in_csv).to eq({ "#{question_text} - Full name" => name })
+      end
+    end
+
+    describe "length validation" do
+      it "is valid with length under 500 characters" do
+        question.full_name = "a" * 499
+        expect(question).to be_valid
+        expect(question.errors[:full_name]).to be_empty
+      end
+
+      it "is invalid with length over 499 characters" do
+        question.full_name = "a" * 500
+        expect(question).not_to be_valid
+        expect(question.errors[:full_name]).to include(I18n.t("activemodel.errors.models.question/name.attributes.full_name.too_long"))
       end
     end
   end
@@ -147,6 +175,30 @@ RSpec.describe Question::Name, type: :model do
         })
       end
     end
+
+    describe "length validation" do
+      before do
+        question.first_name = "a" * 499
+        question.last_name = "a" * 499
+      end
+
+      it "is valid when all fields have the maximum allowed length" do
+        expect(question).to be_valid
+        expect(question.errors).to be_empty
+      end
+
+      it "is invalid when the first name is over 499 characters" do
+        question.first_name = "a" * 500
+        expect(question).not_to be_valid
+        expect(question.errors[:first_name]).to include(I18n.t("activemodel.errors.models.question/name.attributes.first_name.too_long"))
+      end
+
+      it "is invalid when the last name is over 499 characters" do
+        question.last_name = "a" * 500
+        expect(question).not_to be_valid
+        expect(question.errors[:last_name]).to include(I18n.t("activemodel.errors.models.question/name.attributes.last_name.too_long"))
+      end
+    end
   end
 
   context "when the name question is in first, middle and last name format" do
@@ -213,6 +265,37 @@ RSpec.describe Question::Name, type: :model do
           "#{question_text} - Middle names" => middle_name,
           "#{question_text} - Last name" => last_name,
         })
+      end
+    end
+
+    describe "length validation" do
+      before do
+        question.first_name = "a" * 499
+        question.middle_names = "a" * 499
+        question.last_name = "a" * 499
+      end
+
+      it "is valid when all fields have the maximum allowed length" do
+        expect(question).to be_valid
+        expect(question.errors).to be_empty
+      end
+
+      it "is invalid when the first name is over 499 characters" do
+        question.first_name = "a" * 500
+        expect(question).not_to be_valid
+        expect(question.errors[:first_name]).to include(I18n.t("activemodel.errors.models.question/name.attributes.first_name.too_long"))
+      end
+
+      it "is invalid when the middle name is over 499 characters" do
+        question.middle_names = "a" * 500
+        expect(question).not_to be_valid
+        expect(question.errors[:middle_names]).to include(I18n.t("activemodel.errors.models.question/name.attributes.middle_names.too_long"))
+      end
+
+      it "is invalid when the last name is over 499 characters" do
+        question.last_name = "a" * 500
+        expect(question).not_to be_valid
+        expect(question.errors[:last_name]).to include(I18n.t("activemodel.errors.models.question/name.attributes.last_name.too_long"))
       end
     end
   end
@@ -333,6 +416,8 @@ RSpec.describe Question::Name, type: :model do
             "#{question_text} - Title" => title,
           })
         end
+
+        include_examples "title length validation"
       end
     end
 
@@ -400,6 +485,8 @@ RSpec.describe Question::Name, type: :model do
             "#{question_text} - Title" => title,
           })
         end
+
+        include_examples "title length validation"
       end
     end
   end

--- a/spec/models/question/number_spec.rb
+++ b/spec/models/question/number_spec.rb
@@ -159,4 +159,18 @@ RSpec.describe Question::Number, type: :model do
       end
     end
   end
+
+  describe "length validations" do
+    it "is valid with length under 500 characters" do
+      question.number = "1" * 499
+      expect(question).to be_valid
+      expect(question.errors[:number]).to be_empty
+    end
+
+    it "is invalid with length over 499 characters" do
+      question.number = "1" * 500
+      expect(question).not_to be_valid
+      expect(question.errors[:number]).to include(I18n.t("activemodel.errors.models.question/number.attributes.number.too_long"))
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ocGdtU52/2360-add-character-limit-validation-to-all-user-inputs-in-forms-runner

Add validations for maximum lengths for question inputs that previously had no length validation:
- Name
- Number
- UK address
- International address
- Email address

For email address questions, we are now using the full email address validation that matches the validation that Notify does.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
