### PR TITLE
Add link back to Admin for Draft and Live Previews

### DIFF
--- a/app/components/form_header_component/view.rb
+++ b/app/components/form_header_component/view.rb
@@ -21,6 +21,7 @@ module FormHeaderComponent
           govuk_service_navigation(
             service_name: form_name,
             service_url: form_start_page_url,
+            navigation_items: navigation_items,
           ),
         ], "\n")
       else
@@ -63,6 +64,21 @@ module FormHeaderComponent
 
     def form_start_page_url
       form_path(mode: @mode.to_s, form_id: @current_context.form.id, form_slug: @current_context.form.form_slug)
+    end
+
+    def navigation_items
+      [
+        {
+          text: I18n.t("preview_header.your_questions"),
+          href: your_questions_url,
+        },
+      ]
+    end
+
+    def your_questions_url
+      return "#{Settings.forms_admin.base_url}/forms/#{@current_context.form.id}/live/pages" if @mode.preview_live?
+
+      "#{Settings.forms_admin.base_url}/forms/#{@current_context.form.id}/pages/"
     end
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -466,6 +466,8 @@ cy:
   preview_banner:
     heading: This is a preview of this form. Do not enter personal information.
     title: Important
+  preview_header:
+    your_questions: ''
   privacy:
     changes:
       heading: Newidiadau i’r hysbysiad hwn

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -467,7 +467,7 @@ cy:
     heading: This is a preview of this form. Do not enter personal information.
     title: Important
   preview_header:
-    your_questions: ''
+    your_questions: Your questions
   privacy:
     changes:
       heading: Newidiadau i’r hysbysiad hwn

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -466,6 +466,8 @@ en:
   preview_banner:
     heading: This is a preview of this form. Do not enter personal information.
     title: Important
+  preview_header:
+    your_questions: Your questions
   privacy:
     changes:
       heading: Changes to this notice

--- a/spec/components/form_header_component/view_spec.rb
+++ b/spec/components/form_header_component/view_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe FormHeaderComponent::View, type: :component do
   it "links to the form start page" do
     render_inline(described_class.new(current_context:, mode:))
 
-    expect(page).to have_link "test_form_name", href: "/form/1/test"
+    expect(page).to have_link("test_form_name", href: "/form/1/test")
   end
 
   context "when mode is preview_draft" do
@@ -33,6 +33,13 @@ RSpec.describe FormHeaderComponent::View, type: :component do
       expect(page).to have_selector(".govuk-service-navigation .govuk-service-navigation__service-name")
       expect(page).to have_selector(".app-header--preview-draft")
       expect(page).to have_content("test_form_name")
+    end
+
+    it "has a link to 'Add and edit your questions' in admin" do
+      allow(Settings.forms_admin).to receive(:base_url).and_return("http://forms-admin")
+      render_inline(described_class.new(current_context:, mode:))
+
+      expect(page).to have_link("Your questions", href: "#{Settings.forms_admin.base_url}/forms/1/pages/")
     end
 
     it "links to the forms-admin homepage" do
@@ -73,6 +80,18 @@ RSpec.describe FormHeaderComponent::View, type: :component do
       expect(page).to have_selector(".govuk-service-navigation .govuk-service-navigation__service-name")
       expect(page).to have_selector(".app-header--preview-live")
       expect(page).to have_content("test_form_name")
+    end
+
+    it "has a link to 'Your Questions' in admin" do
+      render_inline(described_class.new(current_context:, mode:))
+
+      expect(page).to have_link("Your questions")
+    end
+
+    it "does not have a link to Edit your question" do
+      render_inline(described_class.new(current_context:, mode:))
+
+      expect(page).to have_no_link("Edit your question")
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Adds a link back to Admin on preview pages. The link is part of the Service Navigation, and will send you to different Admin screens depending on whether the preview is Live or Draft.

Trello card: https://trello.com/c/T1i3CZo7/2361-help-users-get-back-to-your-questions-list-view-when-in-previewing-journey

## Demo

https://github.com/user-attachments/assets/2b9816d6-3371-4880-aeee-9bce5597a308

https://github.com/user-attachments/assets/80a40675-e7ee-4412-bc63-3c72cad271ab

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
