### PR TITLE
Add new renamed columns to generalise the Submission model

### DIFF
--- a/app/jobs/delete_submissions_job.rb
+++ b/app/jobs/delete_submissions_job.rb
@@ -7,8 +7,10 @@ class DeleteSubmissionsJob < ApplicationJob
     CurrentJobLoggingAttributes.job_id = job_id
 
     delete_submissions_sent_before_time = Settings.retain_submissions_for_seconds.seconds.ago
-    submissions_to_delete = Submission.where(sent_at: ..delete_submissions_sent_before_time)
-                                      .not_bounced
+    submissions_to_delete = Submission
+      .where(sent_at: ..delete_submissions_sent_before_time)
+      .or(Submission.where(last_delivery_attempt: ..delete_submissions_sent_before_time))
+      .not_bounced
 
     submissions_to_delete.find_each { |submission| delete_submission_data(submission) }
   end

--- a/app/jobs/send_submission_job.rb
+++ b/app/jobs/send_submission_job.rb
@@ -25,7 +25,9 @@ class SendSubmissionJob < ApplicationJob
     submission.update!(
       mail_message_id: message_id,
       mail_status: :pending,
+      delivery_status: :delivery_pending,
       sent_at: Time.zone.now,
+      last_delivery_attempt: Time.zone.now,
     )
 
     milliseconds_since_scheduled = (Time.current - scheduled_at_or_enqueued_at).in_milliseconds.round

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -8,6 +8,29 @@ class Submission < ApplicationRecord
     bounced: "bounced",
   }
 
+  enum :delivery_status, {
+    delivery_pending: "pending",
+    delivery_bounced: "bounced",
+  }
+
+  def pending?
+    mail_status == "pending" || delivery_status == "delivery_pending"
+  end
+
+  def bounced?
+    mail_status == "bounced" || delivery_status == "delivery_bounced"
+  end
+
+  scope :not_bounced, -> { where.not(mail_status: :bounced).and(where.not(delivery_status: :delivery_bounced)) }
+  scope :not_pending, -> { where.not(mail_status: :pending).where.not(delivery_status: :delivery_pending) }
+
+  scope :pending, -> { where(mail_status: :pending, delivery_status: :delivery_pending) }
+  scope :bounced, -> { where(mail_status: :bounced).or(where(delivery_status: :delivery_bounced)) }
+
+  def pending!
+    update(mail_status: "pending", delivery_status: "delivery_pending")
+  end
+
   def journey
     @journey ||= Flow::Journey.new(answer_store:, form:)
   end

--- a/db/migrate/20250710153418_update_submission_fields.rb
+++ b/db/migrate/20250710153418_update_submission_fields.rb
@@ -1,0 +1,9 @@
+class UpdateSubmissionFields < ActiveRecord::Migration[8.0]
+  def change
+    change_table :submissions, bulk: true do |t|
+      t.string :delivery_status, default: "pending", null: false
+      t.datetime :last_delivery_attempt, null: true
+      t.datetime :delivered_at, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_29_084029) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_10_153418) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -25,6 +25,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_29_084029) do
     t.jsonb "form_document"
     t.string "mail_status", default: "pending", null: false
     t.datetime "sent_at"
+    t.string "delivery_status", default: "pending", null: false
+    t.datetime "last_delivery_attempt"
+    t.datetime "delivered_at"
     t.index ["mail_message_id"], name: "index_submissions_on_mail_message_id"
     t.index ["sent_at"], name: "index_submissions_on_sent_at"
   end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     mode { "live" }
     form_document { build :v2_form_document }
     mail_status { :pending }
+    delivery_status { :delivery_pending }
 
     trait :sent do
       mail_message_id { Faker::Alphanumeric.alphanumeric }

--- a/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
+++ b/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
   let(:mail_message_id) { "mail-message-id" }
   let(:reference) { "submission-reference" }
   let!(:submission) { create :submission, mail_message_id:, reference:, form_id: form_with_file_upload.id, form_document: form_with_file_upload, answers: form_with_file_upload_answers }
-  let!(:other_submission) { create :submission, mail_message_id: "abc", mail_status: :pending, reference: "other-submission-reference", form_id: 2, answers: form_with_file_upload_answers }
+  let!(:other_submission) { create :submission, mail_message_id: "abc", delivery_status: :delivery_pending, reference: "other-submission-reference", form_id: 2, answers: form_with_file_upload_answers }
 
   let(:output) { StringIO.new }
   let(:logger) do

--- a/spec/jobs/receive_submission_deliveries_job_spec.rb
+++ b/spec/jobs/receive_submission_deliveries_job_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
   let(:mail_message_id) { "mail-message-id" }
   let(:reference) { "submission-reference" }
   let!(:submission) { create :submission, created_at: Time.zone.parse("2025-05-09T10:25:35.001Z"), mail_message_id:, reference:, form_id: form_with_file_upload.id, form_document: form_with_file_upload, answers: form_with_file_upload_answers }
-  let!(:other_submission) { create :submission, created_at: Time.zone.parse("2025-05-09T10:25:35.001Z"), mail_message_id: "abc", mail_status: :bounced, reference: "other-submission-reference", form_id: 2, answers: form_with_file_upload_answers }
+  let!(:other_submission) { create :submission, created_at: Time.zone.parse("2025-05-09T10:25:35.001Z"), mail_message_id: "abc", delivery_status: :delivery_bounced, reference: "other-submission-reference", form_id: 2, answers: form_with_file_upload_answers }
 
   let(:output) { StringIO.new }
   let(:logger) do

--- a/spec/jobs/send_submission_job_spec.rb
+++ b/spec/jobs/send_submission_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SendSubmissionJob, type: :job do
   include ActiveJob::TestHelper
 
   let(:submission_created_at) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
-  let(:submission) { create :submission, form_document: form, mail_status: :pending, created_at: submission_created_at }
+  let(:submission) { create :submission, form_document: form, delivery_status: :delivery_pending, created_at: submission_created_at }
   let(:form) { build(:form, id: 1, name: "Form 1") }
   let(:question) { build :text, question_text: "What is the meaning of life?", text: "42" }
   let(:step) { build :step, question: }

--- a/spec/lib/tasks/submissions.rake_spec.rb
+++ b/spec/lib/tasks/submissions.rake_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "submissions.rake" do
     end
 
     before do
-      create :submission, :sent, mail_status: :pending, reference: "test_ref"
+      create :submission, :sent, delivery_status: :delivery_pending, reference: "test_ref"
     end
 
     it "displays submission data when found" do
@@ -41,11 +41,11 @@ RSpec.describe "submissions.rake" do
     before do
       create :submission,
              :sent,
-             mail_status: :pending
+             delivery_status: :delivery_pending
 
       create_list :submission, 2,
                   :sent,
-                  mail_status: :bounced
+                  delivery_status: :delivery_bounced
     end
 
     it "logs how many submissions there are for each mail status" do
@@ -69,20 +69,20 @@ RSpec.describe "submissions.rake" do
       create :submission,
              :sent,
              form_id:,
-             mail_status: :bounced
+             delivery_status: :delivery_bounced
     end
     let!(:pending_submission) do
       create :submission,
              :sent,
              form_id:,
-             mail_status: :pending
+             delivery_status: :delivery_pending
     end
 
     before do
       create :submission,
              :sent,
              form_id: other_form_id,
-             mail_status: :pending
+             delivery_status: :delivery_pending
     end
 
     context "with valid arguments" do
@@ -146,7 +146,7 @@ RSpec.describe "submissions.rake" do
     end
 
     let(:form_id) { 1 }
-    let(:mail_status) { :bounced }
+    let(:delivery_status) { :delivery_bounced }
     let(:reference) { "submission-reference" }
     let(:args) { [reference] }
 
@@ -154,7 +154,7 @@ RSpec.describe "submissions.rake" do
       create :submission,
              :sent,
              form_id:,
-             mail_status:,
+             delivery_status:,
              reference:
     end
 
@@ -181,14 +181,14 @@ RSpec.describe "submissions.rake" do
           task.invoke(*args)
         end
 
-        it "does not update the submission mail_status" do
+        it "does not update the submission delivery_status" do
           task.invoke(*args)
           expect(Submission.first.bounced?).to be true
         end
       end
 
       context "when the submission has not bounced" do
-        let(:mail_status) { :pending }
+        let(:delivery_status) { :delivery_pending }
 
         it "logs that there the submission hasn't bounced" do
           allow(Rails.logger).to receive(:info)
@@ -197,7 +197,7 @@ RSpec.describe "submissions.rake" do
           task.invoke(*args)
         end
 
-        it "does not update the submission mail_status" do
+        it "does not update the submission delivery_status" do
           task.invoke(*args)
           expect(Submission.first.pending?).to be true
         end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -25,6 +25,33 @@ RSpec.describe Submission, type: :model do
     end
   end
 
+  describe "delivery_status" do
+    let(:submission) { create :submission }
+
+    describe "validations" do
+      it "is valid for a submission's delivery_status to be pending" do
+        submission.delivery_pending!
+        expect(submission).to be_valid
+      end
+
+      it "is valid for a submission's delivery_status to be bounced" do
+        submission.delivery_bounced!
+        expect(submission).to be_valid
+      end
+
+      it "is not valid for a submission's delivery_status to be something else" do
+        expect { submission.delivery_status = "some other string" }.to raise_error(ArgumentError).with_message(/is not a valid delivery_status/)
+      end
+    end
+
+    describe "delivery_status enum" do
+      it "returns a list of delivery statuses" do
+        expect(described_class.delivery_statuses.keys).to eq(%w[delivery_pending delivery_bounced])
+        expect(described_class.delivery_statuses.values).to eq(%w[pending bounced])
+      end
+    end
+  end
+
   describe "mail_status" do
     let(:submission) { create :submission }
 


### PR DESCRIPTION
### What problem does this pull request solve?

This PR adds new columns "delivery_status" and "last_delivery_attempt" to rename "mail_status" and "sent_at". The new names are to generalise the Submission model to allow it to be used to store submission data for all delivery methods (including S3). Therefore needed to remove direct references to the email delivery method.

This is first part of the migration to rename these columns. Here we are adding the columns with the new names, changing the code to use them over the old columns, but also support data in the old columns. 

Future PRs will be raised to migrate existing data in the old columns to the new columns, dropping support for using the columns and the dropping the columns all together.

This also adds an additional "delivered_at" column to represent the timestamp for when a successful deliver is made - useful for implementing our SLOs.