### PR TITLE
Rebrand and restructure SES email template

### DIFF
--- a/app/lib/ses_email_formatter.rb
+++ b/app/lib/ses_email_formatter.rb
@@ -21,7 +21,7 @@ class SesEmailFormatter
 private
 
   def prep_question_title_html(page)
-    "<h2>#{prep_question_title_plain_text(page)}</h2>"
+    "<h3>#{prep_question_title_plain_text(page)}</h3>"
   end
 
   def prep_answer_text_html(page)

--- a/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
@@ -27,13 +27,11 @@
 
 <h2><%= I18n.t("mailer.submission.answers_submitted") %></h2>
 
-<%= @answer_content_html.html_safe %>
-
 <% if @csv_filename.present? %>
-  <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
-  <h2><%= I18n.t("mailer.submission.csv_file") %></h2>
-  <p><%= I18n.t("mailer.submission.file_attached", filename: @csv_filename) %></p>
+  <p><%= I18n.t("mailer.submission.csv_file", filename: @csv_filename) %></p>
 <% end %>
+
+<%= @answer_content_html.html_safe %>
 
 <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
 

--- a/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
@@ -1,11 +1,11 @@
-<p>
-  <%= if @mailer_options.is_preview
-        I18n.t("mailer.submission.title_preview", title: @mailer_options.title)
-      else
-        I18n.t("mailer.submission.title", title: @mailer_options.title)
-      end
-  %>
-</p>
+<% if @mailer_options.is_preview %>
+  <p>
+    <%= I18n.t("mailer.submission.preview") %>
+  </p>
+<% end %>
+
+<p><%= I18n.t("mailer.submission.title", title: @mailer_options.title) %></p>
+
 <p>
   <%= I18n.t("mailer.submission.time", time: @mailer_options.timestamp.strftime("%l:%M%P").strip, date: @mailer_options.timestamp.strftime("%-d %B %Y") ) %>
 </p>

--- a/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
@@ -25,6 +25,8 @@
 
 <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
 
+<h2><%= I18n.t("mailer.submission.answers_submitted") %></h2>
+
 <%= @answer_content_html.html_safe %>
 
 <% if @csv_filename.present? %>

--- a/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
@@ -1,16 +1,15 @@
-<%= if @mailer_options.is_preview
-      I18n.t("mailer.submission.title_preview", title: @mailer_options.title)
-    else
-      I18n.t("mailer.submission.title", title: @mailer_options.title)
-    end
-%>
+<% if @mailer_options.is_preview %>
+  <%= I18n.t("mailer.submission.preview") %>
+
+<% end %>
+<%= I18n.t("mailer.submission.title", title: @mailer_options.title) %>
 
 <%= I18n.t("mailer.submission.time", time: @mailer_options.timestamp.strftime("%l:%M%P").strip, date: @mailer_options.timestamp.strftime("%-d %B %Y") ) %>
 
 <%= I18n.t("mailer.submission.reference", submission_reference: @mailer_options.submission_reference) %>
 
 <% if @mailer_options.payment_url.present? %>
-<%= I18n.t("mailer.submission.payment") %>
+  <%= I18n.t("mailer.submission.payment") %>
 
 <% end %>
 <%= I18n.t("mailer.submission.check_before_using") %>
@@ -20,11 +19,11 @@
 <%= @answer_content_plain_text %>
 
 <% if @csv_filename.present? %>
----
+  ---
 
-<%= I18n.t("mailer.submission.csv_file") %>
+  <%= I18n.t("mailer.submission.csv_file") %>
 
-<%= I18n.t("mailer.submission.file_attached", filename: @csv_filename) %>
+  <%= I18n.t("mailer.submission.file_attached", filename: @csv_filename) %>
 <% end %>
 
 ---

--- a/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
@@ -17,15 +17,11 @@
 ---
 <%= I18n.t("mailer.submission.answers_submitted") %>
 
-<%= @answer_content_plain_text %>
-
 <% if @csv_filename.present? %>
-  ---
-
-  <%= I18n.t("mailer.submission.csv_file") %>
-
-  <%= I18n.t("mailer.submission.file_attached", filename: @csv_filename) %>
+  <%= I18n.t("mailer.submission.csv_file", filename: @csv_filename) %>
 <% end %>
+
+<%= @answer_content_plain_text %>
 
 ---
 

--- a/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.text.erb
@@ -15,6 +15,7 @@
 <%= I18n.t("mailer.submission.check_before_using") %>
 
 ---
+<%= I18n.t("mailer.submission.answers_submitted") %>
 
 <%= @answer_content_plain_text %>
 

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -9,7 +9,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta content="telephone=no" name="format-detection"> <!-- need to add formatting for real phone numbers -->
     <meta name="viewport" content="width=device-width">
-    <title>{{ subject }}</title>
+    <title><%= @subject %></title>
 
     <style>
       @media only screen and (min-device-width: 581px) {

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,5 +1,7 @@
 <!-- BEGIN app/views/layouts/mailer.html.erb -->
 
+<%# Based on Notify's email template: https://github.com/alphagov/notifications-utils/blob/main/notifications_utils/jinja_templates/email_template.jinja2 %>
+
 <!DOCTYPE html>
 <html lang="en">
 

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -17,6 +17,14 @@
           width: 580px !important;
         }
       }
+      @media only print {
+        .logo__crown { display: none !important; }
+        .logo__text, .logo__dot { color: #000000 !important; }
+        .brand__banner {
+          border-bottom: solid 1pt #000000 !important;
+          background-color: unset !important;
+        }
+      }
       body { margin:0 !important; }
       div[style*="margin: 16px 0"] { margin:0 !important; }
     </style>
@@ -38,7 +46,7 @@
   <body style="font-family: Helvetica, Arial, sans-serif;font-size: 16px;margin: 0;color:#0b0c0c;">
     <table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="100%" height="53" bgcolor="#0b0c0c">
+        <td width="100%" height="60" bgcolor="#1d70b8" class="brand__banner">
           <!--[if (gte mso 9)|(IE)]>
             <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 580px;">
               <tr>
@@ -46,114 +54,117 @@
           <![endif]-->
           <table role="presentation" width="100%" style="border-collapse: collapse;max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
             <tr>
-              <td width="70" bgcolor="#0b0c0c" valign="middle">
-                <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" style="text-decoration: none;">
-                  <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
-                    <tr>
-                      <td style="padding-left: 10px">
-                        <img src="https://static.notifications.service.gov.uk/images/govuk-logotype-tudor-crown.png"
-                                                alt=""
-                                                height="32"
-                                                border="0"
-                                                style="Margin-top: 2px;"
-                                                >
-                      </td>
-                      <td style="font-size: 28px; line-height: 1.315789474; Margin-top: 4px; padding-left: 8px;">
-                        <span style="
-                                                font-family: Helvetica, Arial, sans-serif;
-                                                font-weight: 700;
-                                                color: #ffffff;
-                                                text-decoration: none;
-                                                vertical-align:middle;
-                                                display: inline-block;
-                                                ">GOV.UK</span>
-                      </td>
-                    </tr>
-                  </table>
-                </a>
+              <!--[if mso]>
+                <td width="70" valign="middle">
+                  <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" style="text-decoration: none;">
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
+                      <tr>
+                        <td style="padding-left: 10px">
+                          <img src="https://static.notifications.service.gov.uk/images/govuk-logotype-tudor-crown.png" alt="" height="32" border="0" style="Margin-top: 2px;">
+                        </td>
+                        <td style="font-size: 28px; line-height: 1.315789474; padding-left: 8px; padding-bottom: 8px">
+                          <span style="
+                                font-family: Helvetica, Arial, sans-serif;
+                                font-weight: 700;
+                                color: #ffffff;
+                                text-decoration: none;
+                                vertical-align:middle;
+                                display: inline-block"
+                                >GOV<span style="
+                                color: #00ffe0;
+                                font-family: Georgia, Times New Roman, sans-serif;
+                                font-size: 32px;
+                                mso-text-raise:7px">.</span>UK</span>
+                        </td>
+                      </tr>
+                    </table>
+                  </a>
+                </td>
+              <![endif]-->
+              <!--[if !mso]><!-->
+                    <td width="70" valign="bottom">
+                      <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" style="text-decoration: none;color: #fff">
+                        <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
+                          <tr>
+                            <td style="font-size: 28px; line-height: 2; padding-left: 10px" valign="bottom" height="60" class="logo__crown">
+                              <img
+                                src="https://static.notifications.service.gov.uk/images/govuk-logotype-tudor-crown.png"
+                                alt=""
+                                height="32"
+                                border="0"
+                                style="Margin-top: 2px; max-height: 32px"
+                                aria-hidden="true"
+                                >
+                            </td>
+                            <td style="font-size: 28px; line-height: 2.1428571429; padding-left: 8px;" valign="bottom" height="60" class="logo__text">
+                              <span aria-label="GOV.UK" style="
+                                font-family: Helvetica, Arial, 'Noto Sans', sans-serif;
+                                font-weight: 700;
+                                text-decoration: none;
+                                vertical-align:middle;
+                                display: inline-block;
+                                ">GOV<span style="
+                                font-family: Georgia, Times New Roman, Times, sans-serif;
+                                color: #00ffe0;
+                                display: inline-block;
+                                text-indent: 0.04em;
+                                font-size: 32px;
+                                line-height: 1.35;
+                                vertical-align: top;
+                                margin-right: 0.05em;" class="logo__dot">.</span>UK</span>
+                            </td>
+                          </tr>
+                        </table>
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+                <!--[if (gte mso 9)|(IE)]>
               </td>
             </tr>
           </table>
-          <!--[if (gte mso 9)|(IE)]>
-          </td>
-        </tr>
-      </table>
           <![endif]-->
-        </td>
-      </tr>
-    </table>
-    <table
-         role="presentation"
-         class="content"
-         align="center"
-         cellpadding="0"
-         cellspacing="0"
-         border="0"
-         style="border-collapse: collapse;max-width: 580px; width: 100% !important;"
-         width="100%"
-         >
-      <tr>
-        <td width="10" height="10" valign="middle"></td>
-        <td>
-          <!--[if (gte mso 9)|(IE)]>
-            <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 560px;">
-              <tr>
-                <td height="10">
-          <![endif]-->
-          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
-            <tr>
-              <td bgcolor="#1D70B8" width="100%" height="10"></td>
+              </td>
             </tr>
           </table>
-          <!--[if (gte mso 9)|(IE)]>
-          </td>
-        </tr>
-      </table>
-          <![endif]-->
-        </td>
-        <td width="10" valign="middle" height="10"></td>
-      </tr>
-    </table>
-    <table
-         role="presentation"
-         class="content"
-         align="center"
-         cellpadding="0"
-         cellspacing="0"
-         border="0"
-         style="border-collapse: collapse;max-width: 580px; width: 100% !important;"
-         width="100%"
-         >
-      <tr>
-        <td height="30"><br>
-        </td>
-      </tr>
-      <tr>
-        <td width="10" valign="middle"><br>
-        </td>
-        <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474; max-width: 560px;">
-          <!--[if (gte mso 9)|(IE)]>
-            <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 560px;">
-              <tr>
-                <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474;">
-          <![endif]-->
-
-          <%= yield %>
-
-          <!--[if (gte mso 9)|(IE)]>
-          </td>
-        </tr>
-      </table>
-          <![endif]-->
-        </td>
-        <td width="10" valign="middle"><br>
-        </td>
-      </tr>
-      <tr>
-        <td height="30"><br>
-        </td>
-      </tr>
-    </table>
-  </body>
-</html>
-<!-- END app/views/layouts/mailer.html.erb -->
+          <table
+      role="presentation"
+      class="content"
+      align="center"
+      cellpadding="0"
+      cellspacing="0"
+      border="0"
+      style="border-collapse: collapse;max-width: 580px; width: 100% !important;"
+      width="100%"
+      >
+            <tr>
+              <td height="30"><br>
+              </td>
+            </tr>
+            <tr>
+              <td width="10" valign="middle"><br>
+              </td>
+              <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474; max-width: 560px;">
+                <!--[if (gte mso 9)|(IE)]>
+                  <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 560px;">
+                    <tr>
+                      <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474;">
+                <![endif]-->
+                <%= yield %>
+                <!--[if (gte mso 9)|(IE)]>
+                </td>
+              </tr>
+            </table>
+                <![endif]-->
+              </td>
+              <td width="10" valign="middle"><br>
+              </td>
+            </tr>
+            <tr>
+              <td height="30"><br>
+              </td>
+            </tr>
+          </table>
+        </body>
+      </html>
+      <!-- END app/views/layouts/mailer.html.erb -->

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -431,7 +431,7 @@ cy:
         contact_forms_team_plain: If you’re experiencing a technical issue with this form, contact the GOV.​UK Forms team (https://www.forms.service.gov.uk/support) with details of the issue and the form it relates to.
         heading: You cannot reply to this email
       check_before_using: Check that this data looks safe before you use it
-      csv_file: CSV file of these answers
+      csv_file: 'A CSV file of these answers is attached to this email in a file named: %{filename}'
       file_attached: "%{filename} (attached to this email)"
       from: GOV.UK Forms <%{email_address}>
       payment: You can check that a payment has been made by using this reference number to search transactions within GOV.​UK Pay.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -423,6 +423,7 @@ cy:
     skip_link: Neidio i’r prif gynnwys
   mailer:
     submission:
+      answers_submitted: Answers submitted
       cannot_reply:
         contact_form_filler_html: "<p>If you need to contact the person who completed this form, you’ll need to contact them directly.</p>"
         contact_form_filler_plain: If you need to contact the person who completed this form, you’ll need to contact them directly.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -430,7 +430,7 @@ cy:
         contact_forms_team_html: <p>If you’re experiencing a technical issue with this form, <a href="https://www.forms.service.gov.uk/support">contact the GOV.​UK Forms team</a> with details of the issue and the form it relates to.</p>
         contact_forms_team_plain: If you’re experiencing a technical issue with this form, contact the GOV.​UK Forms team (https://www.forms.service.gov.uk/support) with details of the issue and the form it relates to.
         heading: You cannot reply to this email
-      check_before_using: Check that this data looks safe before you use it
+      check_before_using: Check that these answers look safe before you use them
       csv_file: 'A CSV file of these answers is attached to this email in a file named: %{filename}'
       file_attached: "%{filename} (attached to this email)"
       from: GOV.UK Forms <%{email_address}>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -438,8 +438,8 @@ cy:
       reference: 'GOV.​UK Forms reference number: %{submission_reference}'
       subject: 'Form submission: %{form_title} - reference: %{reference}'
       subject_preview: 'TEST FORM SUBMISSION: %{form_title} - reference: %{reference}'
-      time: This form was submitted at %{time} on %{date}
-      title: This is a completed “%{title}” form.
+      time: 'Submitted at: %{time} on %{date}'
+      title: 'Form name: “%{title}”'
       title_preview: This is a test of the “%{title}” form.
     submission_confirmation:
       default_support_contact_details: The form’s contact details for support will appear here once they’ve been added.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -434,13 +434,13 @@ cy:
       file_attached: "%{filename} (attached to this email)"
       from: GOV.UK Forms <%{email_address}>
       payment: You can check that a payment has been made by using this reference number to search transactions within GOV.​UK Pay.
+      preview: This is a test submission from a preview of this form.
       question_skipped: This question was skipped
       reference: 'GOV.​UK Forms reference number: %{submission_reference}'
       subject: 'Form submission: %{form_title} - reference: %{reference}'
       subject_preview: 'TEST FORM SUBMISSION: %{form_title} - reference: %{reference}'
       time: 'Submitted at: %{time} on %{date}'
       title: 'Form name: “%{title}”'
-      title_preview: This is a test of the “%{title}” form.
     submission_confirmation:
       default_support_contact_details: The form’s contact details for support will appear here once they’ve been added.
       default_what_happens_next: The form’s information about what happens next will appear here once it has been added.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -438,8 +438,8 @@ en:
       reference: 'GOV.​UK Forms reference number: %{submission_reference}'
       subject: 'Form submission: %{form_title} - reference: %{reference}'
       subject_preview: 'TEST FORM SUBMISSION: %{form_title} - reference: %{reference}'
-      time: This form was submitted at %{time} on %{date}
-      title: This is a completed “%{title}” form.
+      time: 'Submitted at: %{time} on %{date}'
+      title: 'Form name: “%{title}”'
       title_preview: This is a test of the “%{title}” form.
     submission_confirmation:
       default_support_contact_details: The form’s contact details for support will appear here once they’ve been added.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -431,7 +431,7 @@ en:
         contact_forms_team_plain: If you’re experiencing a technical issue with this form, contact the GOV.​UK Forms team (https://www.forms.service.gov.uk/support) with details of the issue and the form it relates to.
         heading: You cannot reply to this email
       check_before_using: Check that this data looks safe before you use it
-      csv_file: CSV file of these answers
+      csv_file: 'A CSV file of these answers is attached to this email in a file named: %{filename}'
       file_attached: "%{filename} (attached to this email)"
       from: GOV.UK Forms <%{email_address}>
       payment: You can check that a payment has been made by using this reference number to search transactions within GOV.​UK Pay.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -430,7 +430,7 @@ en:
         contact_forms_team_html: <p>If you’re experiencing a technical issue with this form, <a href="https://www.forms.service.gov.uk/support">contact the GOV.​UK Forms team</a> with details of the issue and the form it relates to.</p>
         contact_forms_team_plain: If you’re experiencing a technical issue with this form, contact the GOV.​UK Forms team (https://www.forms.service.gov.uk/support) with details of the issue and the form it relates to.
         heading: You cannot reply to this email
-      check_before_using: Check that this data looks safe before you use it
+      check_before_using: Check that these answers look safe before you use them
       csv_file: 'A CSV file of these answers is attached to this email in a file named: %{filename}'
       file_attached: "%{filename} (attached to this email)"
       from: GOV.UK Forms <%{email_address}>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -423,6 +423,7 @@ en:
     skip_link: Skip to main content
   mailer:
     submission:
+      answers_submitted: Answers submitted
       cannot_reply:
         contact_form_filler_html: "<p>If you need to contact the person who completed this form, you’ll need to contact them directly.</p>"
         contact_form_filler_plain: If you need to contact the person who completed this form, you’ll need to contact them directly.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -434,13 +434,13 @@ en:
       file_attached: "%{filename} (attached to this email)"
       from: GOV.UK Forms <%{email_address}>
       payment: You can check that a payment has been made by using this reference number to search transactions within GOV.​UK Pay.
+      preview: This is a test submission from a preview of this form.
       question_skipped: This question was skipped
       reference: 'GOV.​UK Forms reference number: %{submission_reference}'
       subject: 'Form submission: %{form_title} - reference: %{reference}'
       subject_preview: 'TEST FORM SUBMISSION: %{form_title} - reference: %{reference}'
       time: 'Submitted at: %{time} on %{date}'
       title: 'Form name: “%{title}”'
-      title_preview: This is a test of the “%{title}” form.
     submission_confirmation:
       default_support_contact_details: The form’s contact details for support will appear here once they’ve been added.
       default_what_happens_next: The form’s information about what happens next will appear here once it has been added.

--- a/spec/lib/ses_email_formatter_spec.rb
+++ b/spec/lib/ses_email_formatter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SesEmailFormatter do
     context "when there is one step" do
       it "returns question and and answer HTML" do
         question_answers = described_class.new.build_question_answers_section_html(completed_steps)
-        expect(question_answers).to eq("<h2>What is the meaning of life?</h2><p>42</p>")
+        expect(question_answers).to eq("<h3>What is the meaning of life?</h3><p>42</p>")
       end
     end
 
@@ -20,7 +20,7 @@ RSpec.describe SesEmailFormatter do
 
       it "inserts line breaks between answer attributes" do
         question_answers = described_class.new.build_question_answers_section_html(completed_steps)
-        expect(question_answers).to eq("<h2>What is your name?</h2><p>First name: #{name_question.first_name}<br/><br/>Last name: #{name_question.last_name}</p>")
+        expect(question_answers).to eq("<h3>What is your name?</h3><p>First name: #{name_question.first_name}<br/><br/>Last name: #{name_question.last_name}</p>")
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe SesEmailFormatter do
 
       it "returns the blank answer text" do
         question_answers = described_class.new.build_question_answers_section_html(completed_steps)
-        expect(question_answers).to eq("<h2>What is the meaning of life?</h2><p>[This question was skipped]</p>")
+        expect(question_answers).to eq("<h3>What is the meaning of life?</h3><p>[This question was skipped]</p>")
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe SesEmailFormatter do
 
       it "returns all question an answers separated by a horizontal rule" do
         question_answers = described_class.new.build_question_answers_section_html(completed_steps)
-        expect(question_answers).to eq("<h2>What is the meaning of life?</h2><p>42</p><hr style=\"border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;\"><h2>What is your name?</h2><p>First name: #{name_question.first_name}<br/><br/>Last name: #{name_question.last_name}</p>")
+        expect(question_answers).to eq("<h3>What is the meaning of life?</h3><p>42</p><hr style=\"border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;\"><h3>What is your name?</h3><p>First name: #{name_question.first_name}<br/><br/>Last name: #{name_question.last_name}</p>")
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe SesEmailFormatter do
           text_question.text = test_case[:input]
 
           question_answers = described_class.new.build_question_answers_section_html(completed_steps)
-          expect(question_answers).to eq("<h2>What is the meaning of life?</h2><p>#{test_case[:output]}</p>")
+          expect(question_answers).to eq("<h3>What is the meaning of life?</h3><p>#{test_case[:output]}</p>")
         end
       end
     end

--- a/spec/mailers/aws_ses_form_submission_mailer_preview.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_preview.rb
@@ -1,7 +1,7 @@
 class AwsSesFormSubmissionMailerPreview < ActionMailer::Preview
   def submission_email
-    AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
-                                                answer_content_plain_text: "## What's your email address?\n\nforms@example.gov.uk",
+    AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h3>What's your email address?</h3><p>forms@example.gov.uk</p>",
+                                                answer_content_plain_text: "What's your email address?\n\nforms@example.gov.uk",
                                                 submission_email_address: "testing@gov.uk",
                                                 mailer_options: FormSubmissionService::MailerOptions.new(title: "Form 1",
                                                                                                          is_preview: false,
@@ -12,8 +12,8 @@ class AwsSesFormSubmissionMailerPreview < ActionMailer::Preview
   end
 
   def preview_submission_email
-    AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
-                                                answer_content_plain_text: "## What's your email address?\n\nforms@example.gov.uk",
+    AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h3>What's your email address?</h3><p>forms@example.gov.uk</p>",
+                                                answer_content_plain_text: "What's your email address?\n\nforms@example.gov.uk",
                                                 submission_email_address: "testing@gov.uk",
                                                 mailer_options: FormSubmissionService::MailerOptions.new(title: "Form 1",
                                                                                                          is_preview: true,
@@ -24,8 +24,8 @@ class AwsSesFormSubmissionMailerPreview < ActionMailer::Preview
   end
 
   def submission_email_with_payment_link
-    AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
-                                                answer_content_plain_text: "## What's your email address?\n\nforms@example.gov.uk",
+    AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h3>What's your email address?</h3><p>forms@example.gov.uk</p>",
+                                                answer_content_plain_text: "What's your email address?\n\nforms@example.gov.uk",
                                                 submission_email_address: "testing@gov.uk",
                                                 mailer_options: FormSubmissionService::MailerOptions.new(title: "Form 1",
                                                                                                          is_preview: true,
@@ -36,8 +36,8 @@ class AwsSesFormSubmissionMailerPreview < ActionMailer::Preview
   end
 
   def submission_email_with_csv
-    AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h2>What's your email address?</h2><p>forms@example.gov.uk</p>",
-                                                answer_content_plain_text: "## What's your email address?\n\nforms@example.gov.uk",
+    AwsSesFormSubmissionMailer.submission_email(answer_content_html: "<h3>What's your email address?</h3><p>forms@example.gov.uk</p>",
+                                                answer_content_plain_text: "What's your email address?\n\nforms@example.gov.uk",
                                                 submission_email_address: "testing@gov.uk",
                                                 mailer_options: FormSubmissionService::MailerOptions.new(title: "Form 1",
                                                                                                          is_preview: true,

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -227,24 +227,16 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
       describe "the html part" do
         let(:part) { mail.html_part }
 
-        it "includes a heading about an answers CSV file" do
-          expect(part.body).to have_css("h2", text: I18n.t("mailer.submission.csv_file"))
-        end
-
-        it "includes the CSV filename" do
-          expect(part.body).to have_css("p", text: I18n.t("mailer.submission.file_attached", filename: csv_filename))
+        it "includes text about the CSV filename" do
+          expect(part.body).to have_css("p", text: I18n.t("mailer.submission.csv_file", filename: csv_filename))
         end
       end
 
       describe "the plaintext part" do
         let(:part) { mail.text_part }
 
-        it "includes text about an answers CSV file" do
-          expect(part.body).to have_text(I18n.t("mailer.submission.csv_file"))
-        end
-
-        it "includes the CSV filename" do
-          expect(part.body).to have_text(I18n.t("mailer.submission.file_attached", filename: csv_filename))
+        it "includes text about the CSV filename" do
+          expect(part.body).to have_text(I18n.t("mailer.submission.csv_file", filename: csv_filename))
         end
       end
     end
@@ -253,24 +245,16 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
       describe "the html part" do
         let(:part) { mail.html_part }
 
-        it "does not include a heading about an answers CSV file" do
-          expect(part.body).not_to have_css("h2", text: I18n.t("mailer.submission.csv_file"))
-        end
-
-        it "does not include the CSV filename" do
-          expect(part.body).not_to have_css("p", text: I18n.t("mailer.submission.file_attached", filename: csv_filename))
+        it "does not include text about the CSV filename" do
+          expect(part.body).not_to have_css("p", text: I18n.t("mailer.submission.csv_file", filename: csv_filename))
         end
       end
 
       describe "the plaintext part" do
         let(:part) { mail.text_part }
 
-        it "does not include text about an answers CSV file" do
-          expect(part.body).not_to have_text(I18n.t("mailer.submission.csv_file"))
-        end
-
-        it "does not include the CSV filename" do
-          expect(part.body).not_to have_text(I18n.t("mailer.submission.file_attached", filename: csv_filename))
+        it "does not include text about the CSV filename" do
+          expect(part.body).not_to have_text(I18n.t("mailer.submission.csv_file", filename: csv_filename))
         end
       end
     end

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -65,6 +65,10 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
           expect(part.body).to have_css("p", text: I18n.t("mailer.submission.check_before_using"))
         end
 
+        it "includes the answers submitted heading" do
+          expect(part.body).to have_css("h2", text: I18n.t("mailer.submission.answers_submitted"))
+        end
+
         it "includes the warning about not replying" do
           expect(part.body).to have_css("h2", text: I18n.t("mailer.submission.cannot_reply.heading"))
           expect(part.body).to include(I18n.t("mailer.submission.cannot_reply.contact_form_filler_html"))
@@ -115,6 +119,10 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
 
         it "includes text about checking the answers" do
           expect(part.body).to have_text(I18n.t("mailer.submission.check_before_using"))
+        end
+
+        it "includes the answers submitted heading" do
+          expect(part.body).to have_text(I18n.t("mailer.submission.answers_submitted"))
         end
 
         it "includes the warning about not replying" do

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -33,6 +33,10 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
       describe "the html part" do
         let(:part) { mail.html_part }
 
+        it "has the email subject as its title" do
+          expect(part.body).to have_title(mail.subject)
+        end
+
         it "has a link to GOV.UK" do
           expect(part.body).to have_link("GOV.UK", href: "https://www.gov.uk")
         end

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -49,6 +49,10 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
           expect(part.body).to have_css("p", text: I18n.t("mailer.submission.title", title:))
         end
 
+        it "does not include the form preview text" do
+          expect(part.body).not_to have_css("p", text: I18n.t("mailer.submission.preview"))
+        end
+
         it "includes text about the submission time" do
           expect(part.body).to have_css("p", text: I18n.t("mailer.submission.time", time: submission_timestamp.strftime("%l:%M%P").strip, date: submission_timestamp.strftime("%-d %B %Y")))
         end
@@ -95,6 +99,10 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
 
         it "includes the form title text" do
           expect(part.body).to have_text(I18n.t("mailer.submission.title", title:))
+        end
+
+        it "does not include the form preview text" do
+          expect(part.body).not_to have_text(I18n.t("mailer.submission.preview"))
         end
 
         it "includes text about the submission time" do
@@ -146,7 +154,11 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
         let(:part) { mail.html_part }
 
         it "includes the form title text" do
-          expect(part.body).to have_css("p", text: I18n.t("mailer.submission.title_preview", title:))
+          expect(part.body).to have_css("p", text: I18n.t("mailer.submission.title", title:))
+        end
+
+        it "includes the form preview text" do
+          expect(part.body).to have_css("p", text: I18n.t("mailer.submission.preview"))
         end
       end
 
@@ -154,7 +166,11 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
         let(:part) { mail.text_part }
 
         it "includes the form title text" do
-          expect(part.body).to have_text(I18n.t("mailer.submission.title_preview", title:))
+          expect(part.body).to have_text(I18n.t("mailer.submission.title", title:))
+        end
+
+        it "includes the form preview text" do
+          expect(part.body).to have_text(I18n.t("mailer.submission.preview"))
         end
       end
     end

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -72,7 +72,7 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
             let(:submission_timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0).in_time_zone(submission_timezone) }
 
             it "includes the date and time the user submitted the form" do
-              expect(part.body).to match("This form was submitted at 9:00am on 14 September 2022")
+              expect(part.body).to match("Submitted at: 9:00am on 14 September 2022")
             end
           end
 
@@ -80,7 +80,7 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
             let(:submission_timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0).in_time_zone(submission_timezone) }
 
             it "includes the date and time the user submitted the form" do
-              expect(part.body).to match("This form was submitted at 1:00pm on 14 December 2022")
+              expect(part.body).to match("Submitted at: 1:00pm on 14 December 2022")
             end
           end
         end
@@ -120,7 +120,7 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
             let(:submission_timestamp) { Time.utc(2022, 9, 14, 8, 0o0, 0o0).in_time_zone(submission_timezone) }
 
             it "includes the date and time the user submitted the form" do
-              expect(part.body).to match("This form was submitted at 9:00am on 14 September 2022")
+              expect(part.body).to match("Submitted at: 9:00am on 14 September 2022")
             end
           end
 
@@ -128,7 +128,7 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
             let(:submission_timestamp) { Time.utc(2022, 12, 14, 13, 0o0, 0o0).in_time_zone(submission_timezone) }
 
             it "includes the date and time the user submitted the form" do
-              expect(part.body).to match("This form was submitted at 1:00pm on 14 December 2022")
+              expect(part.body).to match("Submitted at: 1:00pm on 14 December 2022")
             end
           end
         end

--- a/spec/services/aws_ses_submission_service_spec.rb
+++ b/spec/services/aws_ses_submission_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe AwsSesSubmissionService do
           service.submit
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-            { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
+            { answer_content_html: "<h3>What is the meaning of life?</h3><p>42</p>",
               answer_content_plain_text: "What is the meaning of life?\n\n42",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
@@ -103,7 +103,7 @@ RSpec.describe AwsSesSubmissionService do
           service.submit
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-            { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.email_filename)}</p>",
+            { answer_content_html: "<h3>#{question.question_text}</h3><p>#{I18n.t('mailer.submission.file_attached', filename: question.email_filename)}</p>",
               answer_content_plain_text: "#{question.question_text}\n\n#{I18n.t('mailer.submission.file_attached', filename: question.email_filename)}",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
@@ -154,7 +154,7 @@ RSpec.describe AwsSesSubmissionService do
           expected_csv_content = "Reference,Submitted at,What is the meaning of life?\n#{submission_reference},2022-09-14T08:00:00Z,42\n"
 
           expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-            { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
+            { answer_content_html: "<h3>What is the meaning of life?</h3><p>42</p>",
               answer_content_plain_text: "What is the meaning of life?\n\n42",
               submission_email_address: submission_email,
               mailer_options: instance_of(FormSubmissionService::MailerOptions),
@@ -185,7 +185,7 @@ RSpec.describe AwsSesSubmissionService do
               expected_csv_content = "Reference,Submitted at,#{question.question_text}\n#{submission_reference},2022-09-14T08:00:00Z,#{question.email_filename}\n"
 
               expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-                { answer_content_html: "<h2>#{question.question_text}</h2><p>#{I18n.t('mailer.submission.file_attached', filename: question.email_filename)}</p>",
+                { answer_content_html: "<h3>#{question.question_text}</h3><p>#{I18n.t('mailer.submission.file_attached', filename: question.email_filename)}</p>",
                   answer_content_plain_text: "#{question.question_text}\n\n#{I18n.t('mailer.submission.file_attached', filename: question.email_filename)}",
                   submission_email_address: submission_email,
                   mailer_options: instance_of(FormSubmissionService::MailerOptions),
@@ -212,7 +212,7 @@ RSpec.describe AwsSesSubmissionService do
             service.submit
 
             expect(AwsSesFormSubmissionMailer).to have_received(:submission_email).with(
-              { answer_content_html: "<h2>What is the meaning of life?</h2><p>42</p>",
+              { answer_content_html: "<h3>What is the meaning of life?</h3><p>42</p>",
                 answer_content_plain_text: "What is the meaning of life?\n\n42",
                 submission_email_address: submission_email,
                 mailer_options: instance_of(FormSubmissionService::MailerOptions),


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/c47REcDy/2400-apply-govuk-rebrand-to-ses-email-templates and https://trello.com/c/cq3w8qdB/2965-implement-structure-improvements-to-the-completed-form-email-and-let-users-know

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Copies across the rebrand changes from the Notify template and also makes various other structural improvements aimed at make processing forms easier. See individual commit messages for details.


### Screenshots

#### Preview, without CSV
 
##### Before
<img width="1076" height="734" alt="image" src="https://github.com/user-attachments/assets/0e30a406-ee96-4d18-93f1-7e92f0b77429" />

##### After
<img width="1076" height="784" alt="image" src="https://github.com/user-attachments/assets/ab961a79-b7ef-4a4c-8052-169547a96944" />

#### Live form, with CSV
##### Before
<img width="1076" height="928" alt="image" src="https://github.com/user-attachments/assets/4477d156-da82-4164-b68e-f768a05b0db6" />

##### After
<img width="1076" height="882" alt="image" src="https://github.com/user-attachments/assets/456743d0-d101-413c-8b24-744099d87a5d" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
