### PR TITLE
Stop use of "mail_status" and "sent_at" in Submissions model

### DIFF
--- a/app/jobs/delete_submissions_job.rb
+++ b/app/jobs/delete_submissions_job.rb
@@ -8,8 +8,7 @@ class DeleteSubmissionsJob < ApplicationJob
 
     delete_submissions_sent_before_time = Settings.retain_submissions_for_seconds.seconds.ago
     submissions_to_delete = Submission
-      .where(sent_at: ..delete_submissions_sent_before_time)
-      .or(Submission.where(last_delivery_attempt: ..delete_submissions_sent_before_time))
+      .where(last_delivery_attempt: ..delete_submissions_sent_before_time)
       .not_bounced
 
     submissions_to_delete.find_each { |submission| delete_submission_data(submission) }

--- a/app/jobs/send_submission_job.rb
+++ b/app/jobs/send_submission_job.rb
@@ -24,9 +24,7 @@ class SendSubmissionJob < ApplicationJob
 
     submission.update!(
       mail_message_id: message_id,
-      mail_status: :pending,
-      delivery_status: :delivery_pending,
-      sent_at: Time.zone.now,
+      delivery_status: :pending,
       last_delivery_attempt: Time.zone.now,
     )
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,35 +1,14 @@
 class Submission < ApplicationRecord
+  self.ignored_columns += %w[mail_status sent_at]
+
   delegate :preview?, to: :mode_object
 
   encrypts :answers
 
-  enum :mail_status, {
+  enum :delivery_status, {
     pending: "pending",
     bounced: "bounced",
   }
-
-  enum :delivery_status, {
-    delivery_pending: "pending",
-    delivery_bounced: "bounced",
-  }
-
-  def pending?
-    mail_status == "pending" || delivery_status == "delivery_pending"
-  end
-
-  def bounced?
-    mail_status == "bounced" || delivery_status == "delivery_bounced"
-  end
-
-  scope :not_bounced, -> { where.not(mail_status: :bounced).and(where.not(delivery_status: :delivery_bounced)) }
-  scope :not_pending, -> { where.not(mail_status: :pending).where.not(delivery_status: :delivery_pending) }
-
-  scope :pending, -> { where(mail_status: :pending, delivery_status: :delivery_pending) }
-  scope :bounced, -> { where(mail_status: :bounced).or(where(delivery_status: :delivery_bounced)) }
-
-  def pending!
-    update(mail_status: "pending", delivery_status: "delivery_pending")
-  end
 
   def journey
     @journey ||= Flow::Journey.new(answer_store:, form:)

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -16,8 +16,7 @@ FactoryBot.define do
     end
     mode { "live" }
     form_document { build :v2_form_document }
-    mail_status { :pending }
-    delivery_status { :delivery_pending }
+    delivery_status { :pending }
 
     trait :sent do
       mail_message_id { Faker::Alphanumeric.alphanumeric }

--- a/spec/jobs/delete_submissions_job_spec.rb
+++ b/spec/jobs/delete_submissions_job_spec.rb
@@ -48,31 +48,6 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
            form_document: form_without_file_upload,
            last_delivery_attempt: 6.days.ago
   end
-  let!(:sent_submission_sent_at_7_days_ago) do
-    create :submission,
-           :sent,
-           reference: "SENT7DAYS",
-           form_id: form_without_file_upload.id,
-           form_document: form_without_file_upload,
-           sent_at: 7.days.ago
-  end
-  let!(:sent_submission_sent_at_6_days_ago) do
-    create :submission,
-           :sent,
-           reference: "SENT6DAYS",
-           form_id: form_without_file_upload.id,
-           form_document: form_without_file_upload,
-           sent_at: 6.days.ago
-  end
-  let!(:bounced_submission_mail_status) do
-    create :submission,
-           :sent,
-           reference: "BOUNCED",
-           form_id: form_without_file_upload.id,
-           form_document: form_without_file_upload,
-           last_delivery_attempt: 7.days.ago,
-           mail_status: :bounced
-  end
   let!(:bounced_submission) do
     create :submission,
            :sent,
@@ -80,9 +55,9 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
            form_id: form_without_file_upload.id,
            form_document: form_without_file_upload,
            last_delivery_attempt: 7.days.ago,
-           delivery_status: :delivery_bounced
+           delivery_status: :bounced
   end
-  let!(:unsent_submission) { create :submission, reference: "UNSENT", sent_at: nil }
+  let!(:unsent_submission) { create :submission, reference: "UNSENT", last_delivery_attempt: nil }
 
   let(:output) { StringIO.new }
   let(:logger) do
@@ -117,16 +92,14 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
     end
 
     it "destroys the sent submissions updated more than 7 days ago" do
-      expect { perform_enqueued_jobs }.to change(Submission, :count).by(-3)
+      expect { perform_enqueued_jobs }.to change(Submission, :count).by(-2)
       expect(Submission.exists?(sent_submission_sent_8_days_ago.id)).to be false
       expect(Submission.exists?(sent_submission_sent_7_days_ago.id)).to be false
-      expect(Submission.exists?(sent_submission_sent_at_7_days_ago.id)).to be false
     end
 
     it "does not destroy the sent submission updated more recently than 7 days ago" do
       perform_enqueued_jobs
       expect(Submission.exists?(sent_submission_sent_6_days_ago.id)).to be true
-      expect(Submission.exists?(sent_submission_sent_at_6_days_ago.id)).to be true
     end
 
     it "does not destroy the submission that hasn't been sent" do
@@ -137,11 +110,6 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
     it "does not destroy the submission that bounced" do
       perform_enqueued_jobs
       expect(Submission.exists?(bounced_submission.id)).to be true
-    end
-
-    it "does not destroy the submission that marked bounced under mail status" do
-      perform_enqueued_jobs
-      expect(Submission.exists?(bounced_submission_mail_status.id)).to be true
     end
 
     it "logs deletion" do
@@ -208,9 +176,8 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
     end
 
     it "continues to delete the next submission" do
-      expect { perform_enqueued_jobs }.to change(Submission, :count).by(-2)
+      expect { perform_enqueued_jobs }.to change(Submission, :count).by(-1)
       expect(Submission.exists?(sent_submission_sent_7_days_ago.id)).to be false
-      expect(Submission.exists?(sent_submission_sent_at_7_days_ago.id)).to be false
     end
 
     it "sends cloudwatch metric" do

--- a/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
+++ b/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
   let(:mail_message_id) { "mail-message-id" }
   let(:reference) { "submission-reference" }
   let!(:submission) { create :submission, mail_message_id:, reference:, form_id: form_with_file_upload.id, form_document: form_with_file_upload, answers: form_with_file_upload_answers }
-  let!(:other_submission) { create :submission, mail_message_id: "abc", delivery_status: :delivery_pending, reference: "other-submission-reference", form_id: 2, answers: form_with_file_upload_answers }
+  let!(:other_submission) { create :submission, mail_message_id: "abc", delivery_status: :pending, reference: "other-submission-reference", form_id: 2, answers: form_with_file_upload_answers }
 
   let(:output) { StringIO.new }
   let(:logger) do

--- a/spec/jobs/receive_submission_deliveries_job_spec.rb
+++ b/spec/jobs/receive_submission_deliveries_job_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
   let(:mail_message_id) { "mail-message-id" }
   let(:reference) { "submission-reference" }
   let!(:submission) { create :submission, created_at: Time.zone.parse("2025-05-09T10:25:35.001Z"), mail_message_id:, reference:, form_id: form_with_file_upload.id, form_document: form_with_file_upload, answers: form_with_file_upload_answers }
-  let!(:other_submission) { create :submission, created_at: Time.zone.parse("2025-05-09T10:25:35.001Z"), mail_message_id: "abc", delivery_status: :delivery_bounced, reference: "other-submission-reference", form_id: 2, answers: form_with_file_upload_answers }
+  let!(:other_submission) { create :submission, created_at: Time.zone.parse("2025-05-09T10:25:35.001Z"), mail_message_id: "abc", delivery_status: :bounced, reference: "other-submission-reference", form_id: 2, answers: form_with_file_upload_answers }
 
   let(:output) { StringIO.new }
   let(:logger) do

--- a/spec/jobs/send_submission_job_spec.rb
+++ b/spec/jobs/send_submission_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SendSubmissionJob, type: :job do
   include ActiveJob::TestHelper
 
   let(:submission_created_at) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
-  let(:submission) { create :submission, form_document: form, delivery_status: :delivery_pending, created_at: submission_created_at }
+  let(:submission) { create :submission, form_document: form, delivery_status: :pending, created_at: submission_created_at }
   let(:form) { build(:form, id: 1, name: "Form 1") }
   let(:question) { build :text, question_text: "What is the meaning of life?", text: "42" }
   let(:step) { build :step, question: }
@@ -53,7 +53,7 @@ RSpec.describe SendSubmissionJob, type: :job do
     end
 
     it "updates the sent at time" do
-      expect(submission.reload.sent_at).to be_within(1.second).of(@job_ran_at)
+      expect(submission.reload.last_delivery_attempt).to be_within(1.second).of(@job_ran_at)
     end
 
     it "sends cloudwatch metric for the submission being sent" do

--- a/spec/lib/tasks/submissions.rake_spec.rb
+++ b/spec/lib/tasks/submissions.rake_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "submissions.rake" do
     end
 
     before do
-      create :submission, :sent, delivery_status: :delivery_pending, reference: "test_ref"
+      create :submission, :sent, delivery_status: :pending, reference: "test_ref"
     end
 
     it "displays submission data when found" do
@@ -41,11 +41,11 @@ RSpec.describe "submissions.rake" do
     before do
       create :submission,
              :sent,
-             delivery_status: :delivery_pending
+             delivery_status: :pending
 
       create_list :submission, 2,
                   :sent,
-                  delivery_status: :delivery_bounced
+                  delivery_status: :bounced
     end
 
     it "logs how many submissions there are for each mail status" do
@@ -69,20 +69,20 @@ RSpec.describe "submissions.rake" do
       create :submission,
              :sent,
              form_id:,
-             delivery_status: :delivery_bounced
+             delivery_status: :bounced
     end
     let!(:pending_submission) do
       create :submission,
              :sent,
              form_id:,
-             delivery_status: :delivery_pending
+             delivery_status: :pending
     end
 
     before do
       create :submission,
              :sent,
              form_id: other_form_id,
-             delivery_status: :delivery_pending
+             delivery_status: :pending
     end
 
     context "with valid arguments" do
@@ -146,7 +146,7 @@ RSpec.describe "submissions.rake" do
     end
 
     let(:form_id) { 1 }
-    let(:delivery_status) { :delivery_bounced }
+    let(:delivery_status) { :bounced }
     let(:reference) { "submission-reference" }
     let(:args) { [reference] }
 
@@ -188,7 +188,7 @@ RSpec.describe "submissions.rake" do
       end
 
       context "when the submission has not bounced" do
-        let(:delivery_status) { :delivery_pending }
+        let(:delivery_status) { :pending }
 
         it "logs that there the submission hasn't bounced" do
           allow(Rails.logger).to receive(:info)

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe Submission, type: :model do
 
     describe "validations" do
       it "is valid for a submission's delivery_status to be pending" do
-        submission.delivery_pending!
+        submission.pending!
         expect(submission).to be_valid
       end
 
       it "is valid for a submission's delivery_status to be bounced" do
-        submission.delivery_bounced!
+        submission.bounced!
         expect(submission).to be_valid
       end
 
@@ -46,35 +46,8 @@ RSpec.describe Submission, type: :model do
 
     describe "delivery_status enum" do
       it "returns a list of delivery statuses" do
-        expect(described_class.delivery_statuses.keys).to eq(%w[delivery_pending delivery_bounced])
+        expect(described_class.delivery_statuses.keys).to eq(%w[pending bounced])
         expect(described_class.delivery_statuses.values).to eq(%w[pending bounced])
-      end
-    end
-  end
-
-  describe "mail_status" do
-    let(:submission) { create :submission }
-
-    describe "validations" do
-      it "is valid for a submission's mail_status to be pending" do
-        submission.pending!
-        expect(submission).to be_valid
-      end
-
-      it "is valid for a submission's mail_status to be bounced" do
-        submission.bounced!
-        expect(submission).to be_valid
-      end
-
-      it "is not valid for a submission's mail_status to be something else" do
-        expect { submission.mail_status = "some other string" }.to raise_error(ArgumentError).with_message(/is not a valid mail_status/)
-      end
-    end
-
-    describe "mail_status enum" do
-      it "returns a list of mail statuses" do
-        expect(described_class.mail_statuses.keys).to eq(%w[pending bounced])
-        expect(described_class.mail_statuses.values).to eq(%w[pending bounced])
       end
     end
   end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe FormSubmissionService do
 
           expect(Submission.last).to have_attributes(reference:, form_id: form.id, answers: answers.deep_stringify_keys,
                                                      mode: "form", mail_message_id: nil, form_document: form_document,
-                                                     sent_at: nil)
+                                                     last_delivery_attempt: nil)
         end
 
         context "when the job fails to enqueue" do


### PR DESCRIPTION
These columns had be deprecated and the existing data replicated into the new columns "delivery_status" and "last_delivery_attempt".

This removes the use of the columns from the code base in preparation for the column to be dropped. 
