### PR TITLE
Change day of week for dependabot gem updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "tuesday"
     open-pull-requests-limit: 10
     allow:
       - dependency-type: "direct"


### PR DESCRIPTION
We want to trial automatic updates for ruby packages.

Currently, we have dependabot gem updates on Sundays, when no one is working.

This commit changes the day of week for dependabot gem updates from Sunday to Tuesday.

The next Tuesday which is a holiday is [boxing day 2027](https://www.gov.uk/bank-holidays).

This change should keep us going until then whilst we refine how the updates are scheduled.

See the [dependabot
documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#day) for more information.

