### PR TITLE
Add DISABLE_SOLID_QUEUE environment variable

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -41,4 +41,4 @@ pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
 # this is to prevent 502s
 persistent_timeout ENV.fetch("RAILS_PERSISTENT_TIMEOUT", 75)
 
-plugin :solid_queue if Rails.env.production?
+plugin :solid_queue if Rails.env.production? && ENV.fetch("DISABLE_SOLID_QUEUE", "false") != "true"


### PR DESCRIPTION
Allow disabling solid queue puma plugin via environment variable.
By default loads solid queue plugin in production mode unless
DISABLE_SOLID_QUEUE is set to "true".

This is used to disable the solid queue supervisor process from
our web server ECS tasks. This allows us to test these changes
in non-production environments. This is part of work moving the
solid queue workers into a separate ECS task.
