### PR TITLE
Use localhost for test database connections

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -40,6 +40,9 @@ test:
   primary: &primary_test
     <<: *default
     database: forms_runner_test
+    username: postgres
+    password: postgres
+    host: localhost
   queue:
     <<: *primary_test
     database: forms_runner_test_queue


### PR DESCRIPTION
This fixes an issue if using psql container in docker and running the tests on the host machine. By specifying "localhost" this ensures the connection is done via TCP rather than sockets, which is needed to connect to the container.