### PR TITLE
Remove illegal characters from uploaded filenames

### DIFF
--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -57,7 +57,7 @@ module Question
 
       base_name_max_length = FILE_MAX_FILENAME_LENGTH - extension.length - filename_suffix.length
 
-      base_name = ::File.basename(original_filename, extension).truncate(base_name_max_length, omission: "")
+      base_name = ::File.basename(sanitized_filename, extension).truncate(base_name_max_length, omission: "")
 
       "#{base_name}#{filename_suffix}#{extension}"
     end
@@ -67,7 +67,7 @@ module Question
 
       base_name_max_length = FILE_MAX_FILENAME_LENGTH - extension.length - ReferenceNumberService::REFERENCE_LENGTH
 
-      base_name = ::File.basename(original_filename, extension).truncate(base_name_max_length, omission: "")
+      base_name = ::File.basename(sanitized_filename, extension).truncate(base_name_max_length, omission: "")
 
       "#{base_name}#{extension}"
     end
@@ -81,7 +81,7 @@ module Question
 
       base_name_max_length = FILE_MAX_FILENAME_LENGTH - submission_reference_with_underscore.length - extension.length - filename_suffix.length
 
-      base_name = ::File.basename(original_filename, extension).truncate(base_name_max_length, omission: "")
+      base_name = ::File.basename(sanitized_filename, extension).truncate(base_name_max_length, omission: "")
 
       self.email_filename = "#{base_name}#{filename_suffix}#{submission_reference_with_underscore}#{extension}"
     end
@@ -160,6 +160,10 @@ module Question
           file_type: file.content_type,
         }
       end
+    end
+
+    def sanitized_filename
+      original_filename.gsub(/[\/\\:*?"<>|]/, "")
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/gt6ZXZfW

The characters  /, \\, :, *, ?, ", <, >, and | are not allowed in filenames. When a file was uploaded with these characters, it caused a Aws::SESV2::Errors::BadRequestException error to be thrown when attempting to send the email.

This commit removes these characters from the uploaded filename before sending the email. This includes removing the characters from the filename in the CSV file, if one is attached to the email and also for submission to an S3 bucket.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
