### PR TITLE
Access `next_page_slug` from page inside Step class

### DIFF
--- a/app/lib/flow/step_factory.rb
+++ b/app/lib/flow/step_factory.rb
@@ -24,10 +24,9 @@ module Flow
       page = @form.pages.find { |p| p.id.to_s == page_slug }
       raise PageNotFoundError, "Can't find page #{page_slug}" if page.nil?
 
-      next_page_slug = page.has_next_page? ? page.next_page.to_s : CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG
       question = QuestionRegister.from_page(page)
 
-      step_class(page).new(question:, page:, next_page_slug:, page_slug:)
+      step_class(page).new(question:, page:, page_slug:)
     end
 
     def start_step

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,14 +1,13 @@
 class Step
   attr_accessor :page, :question
-  attr_reader :next_page_slug, :page_slug
+  attr_reader :page_slug
 
   GOTO_PAGE_ERROR_NAMES = %w[cannot_have_goto_page_before_routing_page goto_page_doesnt_exist].freeze
 
-  def initialize(page:, question:, next_page_slug:, page_slug:)
+  def initialize(page:, question:, page_slug:)
     @page = page
     @question = question
 
-    @next_page_slug = next_page_slug
     @page_slug = page_slug
   end
 
@@ -20,6 +19,10 @@ class Step
 
   def page_number
     page&.position
+  end
+
+  def next_page_slug
+    page.has_next_page? ? page.next_page.to_s : CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG
   end
 
   def routing_conditions

--- a/spec/factories/models/repeatable_steps.rb
+++ b/spec/factories/models/repeatable_steps.rb
@@ -3,8 +3,7 @@ FactoryBot.define do
     page { association :page }
     sequence(:page_slug) { |n| "page-#{n}" }
     question { build(:full_name_question) }
-    next_page_slug { nil }
 
-    initialize_with { new(question:, page:, next_page_slug:, page_slug:) }
+    initialize_with { new(question:, page:, page_slug:) }
   end
 end

--- a/spec/factories/models/steps.rb
+++ b/spec/factories/models/steps.rb
@@ -3,8 +3,7 @@ FactoryBot.define do
     page { association :page }
     sequence(:page_slug) { |n| "page-#{n}" }
     question { build(:full_name_question) }
-    next_page_slug { nil }
 
-    initialize_with { new(question:, page:, next_page_slug:, page_slug:) }
+    initialize_with { new(question:, page:, page_slug:) }
   end
 end

--- a/spec/models/repeatable_step_spec.rb
+++ b/spec/models/repeatable_step_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe RepeatableStep, type: :model do
-  subject(:repeatable_step) { described_class.new(question:, page:, next_page_slug: 2, page_slug: page.id) }
+  subject(:repeatable_step) { described_class.new(question:, page:, page_slug: page.id) }
 
   let(:form) { build :form, id: 1, form_slug: "form-slug", pages: [page, build(:page, id: 2)] }
   let(:page) { build :page }

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -5,13 +5,12 @@ RSpec.describe Step do
     described_class.new(
       question:,
       page:,
-      next_page_slug: "next-page",
       page_slug: "current-page",
     )
   end
 
   let(:question) { instance_double(Question::Text, serializable_hash: {}, attribute_names: %w[name], valid?: true, errors: []) }
-  let(:page) { build(:page, id: 2, position: 1, routing_conditions: []) }
+  let(:page) { build(:page, id: 2, position: 1, next_page: "next-page", routing_conditions: []) }
   let(:answer_store) { instance_double(Store::SessionAnswerStore) }
   let(:form) { build(:form, id: 3, form_slug: "test-form", pages: [page]) }
 
@@ -31,7 +30,6 @@ RSpec.describe Step do
       other_step = described_class.new(
         question:,
         page:,
-        next_page_slug: "next-page",
         page_slug: "current-page",
       )
       expect(step).to eq(other_step)
@@ -41,7 +39,6 @@ RSpec.describe Step do
       other_step = described_class.new(
         question:,
         page:,
-        next_page_slug: "other-page",
         page_slug: "other-current-page",
       )
       expect(step == other_step).to be false
@@ -53,7 +50,6 @@ RSpec.describe Step do
       expected_state = [
         step.page,
         step.question,
-        step.next_page_slug,
         step.page_slug,
       ]
 
@@ -126,16 +122,8 @@ RSpec.describe Step do
   end
 
   describe "#end_page?" do
-    context "when next_page_slug is nil" do
-      subject(:step) do
-        described_class.new(question:, page:, next_page_slug: nil, page_slug: "current-page")
-      end
-
-      it { is_expected.to be_end_page }
-    end
-
-    context "when next_page_slug is not nil" do
-      it { is_expected.not_to be_end_page }
+    it "returns false" do
+      expect(step.end_page?).to be(false)
     end
   end
 
@@ -144,7 +132,7 @@ RSpec.describe Step do
     let(:selection) { "Yes" }
     let(:question) { instance_double(Question::Selection, selection:) }
     let(:routing_conditions) { [] }
-    let(:page) { build(:page, id: 2, position: 1, routing_conditions:) }
+    let(:page) { build(:page, id: 2, position: 1, next_page: "next-page", routing_conditions:) }
 
     describe "basic routing" do
       context "without any routing conditions" do


### PR DESCRIPTION
This removes the seperate next_page_slug instance variable, which is passed into the initializer for Step via the StepFactory. As the original Page object is also passed in, we can reference is directly from that object. This help simplify the code and makes it easier for future refactoring.

This also changes the `end_page?` method to always return false, as Step initialised via the StepFactory would never have a "nil" next_page_slug anyways.