### PR TITLE
Fix retry failed submission task

### DIFF
--- a/lib/tasks/submissions.rake
+++ b/lib/tasks/submissions.rake
@@ -52,7 +52,7 @@ namespace :submissions do
     usage_message = "usage: rake submissions:retry_failed_send_job[<job_id>]"
     abort usage_message if job_id.blank?
 
-    job = SolidQueue::Job.find_by(active_job_id: job_id)
+    job = SolidQueue::Job.where(active_job_id: job_id).last
 
     abort "Job with job_id #{job_id} not found" unless job
 

--- a/spec/lib/tasks/submissions.rake_spec.rb
+++ b/spec/lib/tasks/submissions.rake_spec.rb
@@ -222,7 +222,10 @@ RSpec.describe "submissions.rake" do
         .tap(&:reenable)
     end
 
-    let(:job) { create :solid_queue_job }
+    # If a job is retried, there are multiple jobs with the same active_job_id but the failed execution is only
+    # attached to the final one. Create another job with the same active_job_id first to simulate this.
+    let(:first_job) { create :solid_queue_job }
+    let(:job) { create :solid_queue_job, active_job_id: first_job.active_job_id }
 
     context "with valid arguments" do
       let(:valid_args) { [job.active_job_id] }


### PR DESCRIPTION
### What problem does this pull request solve?

The task was assuming that there would be only one SolidQueue::Job with the given active_record_id. However, if a job is retried, there will be a SolidQueue::Job per retry. There will only be a SolidQueue::FailedExecution for the Job for the the final retry.

Fix the rake task to get the last Job with the given active_record_id.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
