### PR TITLE
Access page_slug from page inside Step class

### DIFF
--- a/app/controllers/forms/add_another_answer_controller.rb
+++ b/app/controllers/forms/add_another_answer_controller.rb
@@ -4,7 +4,7 @@ module Forms
 
     def show
       @rows = rows
-      back_link(@step.page_slug)
+      back_link(@step.id)
       @add_another_answer_input = AddAnotherAnswerInput.new
     end
 
@@ -13,7 +13,7 @@ module Forms
 
       if @add_another_answer_input.invalid?
         @rows = rows
-        back_link(@step.page_slug)
+        back_link(@step.id)
         return render :show
       end
 
@@ -28,18 +28,18 @@ module Forms
 
     def add_another_path
       if changing_existing_answer
-        form_change_answer_path(@form.id, @form.form_slug, @step.page_slug, answer_index: @step.next_answer_index)
+        form_change_answer_path(@form.id, @form.form_slug, @step.id, answer_index: @step.next_answer_index)
       else
-        form_page_path(@form.id, @form.form_slug, @step.page_slug, answer_index: @step.next_answer_index)
+        form_page_path(@form.id, @form.form_slug, @step.id, answer_index: @step.next_answer_index)
       end
     end
 
     def rows
       @step.questions.map.with_index(1) do |question, answer_index|
-        actions = [{ text: t("forms.add_another_answer.rows.change"), href: form_change_answer_path(@form.id, @form.form_slug, @step.page_slug, answer_index:), visually_hidden_text: I18n.t("forms.add_another_answer.rows.action_hidden_text", answer_index:) }]
+        actions = [{ text: t("forms.add_another_answer.rows.change"), href: form_change_answer_path(@form.id, @form.form_slug, @step.id, answer_index:), visually_hidden_text: I18n.t("forms.add_another_answer.rows.action_hidden_text", answer_index:) }]
 
         unless @step.min_answers?
-          actions << { text: t("forms.add_another_answer.rows.remove"), href: form_remove_answer_path(@form.id, @form.form_slug, @step.page_slug, answer_index:, changing_existing_answer:), visually_hidden_text: I18n.t("forms.add_another_answer.rows.action_hidden_text", answer_index:) }
+          actions << { text: t("forms.add_another_answer.rows.remove"), href: form_remove_answer_path(@form.id, @form.form_slug, @step.id, answer_index:, changing_existing_answer:), visually_hidden_text: I18n.t("forms.add_another_answer.rows.action_hidden_text", answer_index:) }
         end
 
         {
@@ -61,9 +61,9 @@ module Forms
     def redirect_if_not_repeating
       unless @step.is_a?(RepeatableStep)
         if changing_existing_answer
-          redirect_to form_change_answer_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug)
+          redirect_to form_change_answer_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id)
         else
-          redirect_to form_page_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug)
+          redirect_to form_page_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id)
         end
       end
     end

--- a/app/controllers/forms/check_your_answers_controller.rb
+++ b/app/controllers/forms/check_your_answers_controller.rb
@@ -100,7 +100,7 @@ module Forms
       previous_step = current_context.previous_step(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG)
 
       if previous_step.present?
-        previous_step.repeatable? ? add_another_answer_path(form_id: current_context.form.id, form_slug: current_context.form.form_slug, page_slug: previous_step.page_slug) : form_page_path(current_context.form.id, current_context.form.form_slug, previous_step.page_id)
+        previous_step.repeatable? ? add_another_answer_path(form_id: current_context.form.id, form_slug: current_context.form.form_slug, page_slug: previous_step.id) : form_page_path(current_context.form.id, current_context.form.form_slug, previous_step.page_id)
       end
     end
   end

--- a/app/controllers/forms/exit_pages_controller.rb
+++ b/app/controllers/forms/exit_pages_controller.rb
@@ -1,9 +1,9 @@
 module Forms
   class ExitPagesController < PageController
     def show
-      return redirect_to form_page_path(@form.id, @form.form_slug, current_context.next_page_slug) unless current_context.can_visit?(@step.page_slug)
+      return redirect_to form_page_path(@form.id, @form.form_slug, current_context.next_page_slug) unless current_context.can_visit?(@step.id)
 
-      @back_link = form_page_path(@form.id, @form.form_slug, @step.page_slug)
+      @back_link = form_page_path(@form.id, @form.form_slug, @step.id)
       @condition = @step.routing_conditions.first
     end
   end

--- a/app/controllers/forms/page_controller.rb
+++ b/app/controllers/forms/page_controller.rb
@@ -9,10 +9,10 @@ module Forms
     end
 
     def show
-      return redirect_to form_page_path(@form.id, @form.form_slug, current_context.next_page_slug) unless current_context.can_visit?(@step.page_slug)
+      return redirect_to form_page_path(@form.id, @form.form_slug, current_context.next_page_slug) unless current_context.can_visit?(@step.id)
       return redirect_to review_file_page if answered_file_question?
 
-      back_link(@step.page_slug)
+      back_link(@step.id)
       setup_instance_vars_for_view
     end
 
@@ -53,7 +53,7 @@ module Forms
 
     def setup_instance_vars_for_view
       @is_question = true
-      @question_edit_link = "#{Settings.forms_admin.base_url}/forms/#{@form.id}/pages/#{@step.page_slug}/edit/question"
+      @question_edit_link = "#{Settings.forms_admin.base_url}/forms/#{@form.id}/pages/#{@step.id}/edit/question"
       @save_url = save_url
     end
 
@@ -67,20 +67,20 @@ module Forms
       if changing_existing_answer
         @back_link = check_your_answers_path(form_id: current_context.form.id)
       elsif previous_step
-        @back_link = previous_step.repeatable? ? add_another_answer_path(form_id: current_context.form.id, form_slug: current_context.form.form_slug, page_slug: previous_step.page_slug) : form_page_path(@form.id, @form.form_slug, previous_step.page_id)
+        @back_link = previous_step.repeatable? ? add_another_answer_path(form_id: current_context.form.id, form_slug: current_context.form.form_slug, page_slug: previous_step.id) : form_page_path(@form.id, @form.form_slug, previous_step.page_id)
       end
     end
 
     def redirect_post_save
       return redirect_to review_file_page, success: t("banner.success.file_uploaded") if answered_file_question?
-      return redirect_to exit_page_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug) if @step.exit_page_condition_matches?
+      return redirect_to exit_page_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id) if @step.exit_page_condition_matches?
 
       redirect_to next_page
     end
 
     def redirect_if_not_answered_file_question
       unless @step.question.is_a?(Question::File) && @step.question.file_uploaded?
-        redirect_to form_page_path(@form.id, @form.form_slug, @step.page_slug)
+        redirect_to form_page_path(@form.id, @form.form_slug, @step.id)
       end
     end
 
@@ -89,7 +89,7 @@ module Forms
     end
 
     def review_file_page
-      review_file_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
+      review_file_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id, changing_existing_answer:)
     end
 
     def next_page
@@ -102,7 +102,7 @@ module Forms
 
     def next_step_path
       if should_show_add_another?(@step)
-        return add_another_answer_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug)
+        return add_another_answer_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id)
       end
 
       next_step_in_form_path
@@ -110,7 +110,7 @@ module Forms
 
     def next_step_changing
       if should_show_add_another?(@step)
-        return change_add_another_answer_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug)
+        return change_add_another_answer_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id)
       end
 
       check_answers_path
@@ -160,7 +160,7 @@ module Forms
     end
 
     def is_first_page?
-      current_context.form.start_page == @step.id
+      current_context.form.start_page.to_s == @step.id
     end
 
     def save_url

--- a/app/controllers/forms/remove_answer_controller.rb
+++ b/app/controllers/forms/remove_answer_controller.rb
@@ -31,9 +31,9 @@ module Forms
 
     def next_page_after_removing
       if @step.question.is_optional? && @step.show_answer.blank?
-        form_page_path(@form.id, @form.form_slug, @step.page_slug, changing_existing_answer:)
+        form_page_path(@form.id, @form.form_slug, @step.id, changing_existing_answer:)
       else
-        add_another_answer_path(@form.id, @form.form_slug, @step.page_slug, changing_existing_answer:)
+        add_another_answer_path(@form.id, @form.form_slug, @step.id, changing_existing_answer:)
       end
     end
   end

--- a/app/controllers/forms/remove_file_controller.rb
+++ b/app/controllers/forms/remove_file_controller.rb
@@ -21,7 +21,7 @@ module Forms
         return redirect_to redirect_after_delete_path, success: t("banner.success.file_removed")
       end
 
-      redirect_to review_file_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
+      redirect_to review_file_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id, changing_existing_answer:)
     end
 
   private
@@ -32,15 +32,15 @@ module Forms
 
     def redirect_after_delete_path
       if changing_existing_answer
-        return form_change_answer_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug)
+        return form_change_answer_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id)
       end
 
-      form_page_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug)
+      form_page_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id)
     end
 
     def setup_urls
-      @back_link = review_file_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
-      @remove_file_url = remove_file_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
+      @back_link = review_file_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id, changing_existing_answer:)
+      @remove_file_url = remove_file_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id, changing_existing_answer:)
     end
   end
 end

--- a/app/controllers/forms/review_file_controller.rb
+++ b/app/controllers/forms/review_file_controller.rb
@@ -3,9 +3,9 @@ module Forms
     before_action :redirect_if_not_answered_file_question
 
     def show
-      back_link(@step.page_slug)
-      @remove_file_confirmation_url = remove_file_confirmation_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
-      @continue_url = review_file_continue_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug, changing_existing_answer:)
+      back_link(@step.id)
+      @remove_file_confirmation_url = remove_file_confirmation_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id, changing_existing_answer:)
+      @continue_url = review_file_continue_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id, changing_existing_answer:)
     end
 
     def continue

--- a/app/lib/flow/journey.rb
+++ b/app/lib/flow/journey.rb
@@ -29,12 +29,12 @@ module Flow
     end
 
     def find_or_create(page_slug)
-      step = completed_steps.find { |s| s.page_slug == page_slug }
+      step = completed_steps.find { |s| s.id == page_slug }
       step || @step_factory.create_step(page_slug)
     end
 
     def previous_step(page_slug)
-      index = completed_steps.find_index { |step| step.page_slug == page_slug }
+      index = completed_steps.find_index { |step| step.id == page_slug }
       return nil if completed_steps.empty? || index&.zero?
 
       return completed_steps.last if index.nil?
@@ -45,7 +45,7 @@ module Flow
     def next_page_slug
       return nil if completed_steps.last&.end_page?
 
-      completed_steps.last&.next_page_slug_after_routing || @step_factory.start_step.page_slug
+      completed_steps.last&.next_page_slug_after_routing || @step_factory.start_step.id
     end
 
     def next_step
@@ -55,7 +55,7 @@ module Flow
     end
 
     def can_visit?(page_slug)
-      (completed_steps.map(&:page_slug).include? page_slug) || page_slug == next_page_slug
+      (completed_steps.map(&:id).include? page_slug) || page_slug == next_page_slug
     end
 
     def all_steps
@@ -111,7 +111,7 @@ module Flow
           break if visited_page_slugs.include?(next_page_slug)
 
           yielder << current_step
-          visited_page_slugs << current_step.page_slug
+          visited_page_slugs << current_step.id
 
           break if next_page_slug.nil?
 

--- a/app/lib/flow/step_factory.rb
+++ b/app/lib/flow/step_factory.rb
@@ -26,7 +26,7 @@ module Flow
 
       question = QuestionRegister.from_page(page)
 
-      step_class(page).new(question:, page:, page_slug:)
+      step_class(page).new(question:, page:)
     end
 
     def start_step

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,20 +1,17 @@
 class Step
   attr_accessor :page, :question
-  attr_reader :page_slug
 
   GOTO_PAGE_ERROR_NAMES = %w[cannot_have_goto_page_before_routing_page goto_page_doesnt_exist].freeze
 
-  def initialize(page:, question:, page_slug:)
+  def initialize(page:, question:)
     @page = page
     @question = question
-
-    @page_slug = page_slug
   end
 
   alias_attribute :id, :page_id
 
   def page_id
-    page&.id
+    page&.id.to_s
   end
 
   def page_number

--- a/app/services/log_event_service.rb
+++ b/app/services/log_event_service.rb
@@ -59,6 +59,6 @@ private
   end
 
   def is_starting_form?
-    @current_context.form.start_page == @step.id
+    @current_context.form.start_page.to_s == @step.id
   end
 end

--- a/app/views/forms/add_another_answer/show.html.erb
+++ b/app/views/forms/add_another_answer/show.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 <% end %>
 
-<%= form_with(model: @add_another_answer_input , method: :post, url: add_another_answer_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug, changing_existing_answer: @changing_existing_answer)) do |f| %>
+<%= form_with(model: @add_another_answer_input , method: :post, url: add_another_answer_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id, changing_existing_answer: @changing_existing_answer)) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <% if @add_another_answer_input&.errors.any? %>

--- a/app/views/forms/remove_answer/show.html.erb
+++ b/app/views/forms/remove_answer/show.html.erb
@@ -1,8 +1,8 @@
 <% content_for :back_link do %>
-  <%= link_to t("forms.back"), add_another_answer_path(@form.id, @form.form_slug, @step.page_slug), class: "govuk-back-link" %>
+  <%= link_to t("forms.back"), add_another_answer_path(@form.id, @form.form_slug, @step.id), class: "govuk-back-link" %>
 <% end %>
 
-<%= form_with(model: @remove_input , method: :delete, url: delete_form_remove_answer_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.page_slug, answer_index: @step.answer_index, changing_existing_answer: @changing_existing_answer, mode: @mode)) do |f| %>
+<%= form_with(model: @remove_input , method: :delete, url: delete_form_remove_answer_path(form_id: @form.id, form_slug: @form.form_slug, page_slug: @step.id, answer_index: @step.answer_index, changing_existing_answer: @changing_existing_answer, mode: @mode)) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if @remove_input&.errors.any? %>

--- a/spec/factories/models/repeatable_steps.rb
+++ b/spec/factories/models/repeatable_steps.rb
@@ -1,9 +1,8 @@
 FactoryBot.define do
   factory :repeatable_step, class: "RepeatableStep" do
     page { association :page }
-    sequence(:page_slug) { |n| "page-#{n}" }
     question { build(:full_name_question) }
 
-    initialize_with { new(question:, page:, page_slug:) }
+    initialize_with { new(question:, page:) }
   end
 end

--- a/spec/factories/models/steps.rb
+++ b/spec/factories/models/steps.rb
@@ -1,9 +1,8 @@
 FactoryBot.define do
   factory :step, class: "Step" do
     page { association :page }
-    sequence(:page_slug) { |n| "page-#{n}" }
     question { build(:full_name_question) }
 
-    initialize_with { new(question:, page:, page_slug:) }
+    initialize_with { new(question:, page:) }
   end
 end

--- a/spec/lib/flow/context_spec.rb
+++ b/spec/lib/flow/context_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe Flow::Context do
   end
 
   [
-    ["no input", { answers: [], request_step: 1 }, { next_page_slug: "2", start_id: 1, next_incomplete_page_id: "1", current_step_id: 1, previous_step_id: nil }],
-    ["first question complete, request second step", { answers: [{ text: "q1 answer" }], request_step: 2 }, { next_page_slug: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG, start_id: 1, previous_step_id: 1, next_incomplete_page_id: "2", current_step_id: 2 }],
-    ["first question complete, request first step", { answers: [{ text: "q1 answer" }], request_step: 1 }, { next_page_slug: "2", start_id: 1, previous_step_id: nil, next_incomplete_page_id: "2", current_step_id: 1 }],
-    ["all questions complete, request second step", { answers: [{ text: "q1 answer" }, { text: "q2 answer" }], request_step: 2 }, { next_page_slug: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG, start_id: 1, previous_step_id: 1, next_incomplete_page_id: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG, current_step_id: 2 }],
+    ["no input", { answers: [], request_step: 1 }, { next_page_slug: "2", start_id: 1, next_incomplete_page_id: "1", current_step_id: "1", previous_step_id: nil }],
+    ["first question complete, request second step", { answers: [{ text: "q1 answer" }], request_step: 2 }, { next_page_slug: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG, start_id: 1, previous_step_id: "1", next_incomplete_page_id: "2", current_step_id: "2" }],
+    ["first question complete, request first step", { answers: [{ text: "q1 answer" }], request_step: 1 }, { next_page_slug: "2", start_id: 1, previous_step_id: nil, next_incomplete_page_id: "2", current_step_id: "1" }],
+    ["all questions complete, request second step", { answers: [{ text: "q1 answer" }, { text: "q2 answer" }], request_step: 2 }, { next_page_slug: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG, start_id: 1, previous_step_id: "1", next_incomplete_page_id: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG, current_step_id: "2" }],
   ].each do |variation, input, expected_output|
     context "with #{variation}" do
       before do
@@ -58,7 +58,7 @@ RSpec.describe Flow::Context do
       end
 
       it "has the correct previous step" do
-        expect(@context.previous_step(@step.page_slug)&.page_id).to eq(expected_output[:previous_step_id])
+        expect(@context.previous_step(@step.id)&.page_id).to eq(expected_output[:previous_step_id])
       end
 
       it "has the correct next incomplete step" do

--- a/spec/lib/flow/step_factory_spec.rb
+++ b/spec/lib/flow/step_factory_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Flow::StepFactory do
         expect(step).to be_a(Step)
         expect(step.question).to eq(question)
         expect(step.next_page_slug).to eq("page-2")
-        expect(step.page_slug).to eq("page-1")
+        expect(step.id).to eq("page-1")
       end
 
       context "when it is the last page" do
@@ -49,7 +49,7 @@ RSpec.describe Flow::StepFactory do
       end
 
       it "a RepeatingStep is created" do
-        step = factory.create_step(page.page_slug)
+        step = factory.create_step(page.id)
         expect(step).to be_a(RepeatableStep)
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe Flow::StepFactory do
       it "creates a step for the start page" do
         step = factory.create_step(Flow::StepFactory::START_PAGE)
         expect(step).to be_a(Step)
-        expect(step.page_slug).to eq("page-1")
+        expect(step.id).to eq("page-1")
       end
     end
   end

--- a/spec/models/repeatable_step_spec.rb
+++ b/spec/models/repeatable_step_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe RepeatableStep, type: :model do
-  subject(:repeatable_step) { described_class.new(question:, page:, page_slug: page.id) }
+  subject(:repeatable_step) { described_class.new(question:, page:) }
 
   let(:form) { build :form, id: 1, form_slug: "form-slug", pages: [page, build(:page, id: 2)] }
   let(:page) { build :page }

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Step do
     described_class.new(
       question:,
       page:,
-      page_slug: "current-page",
     )
   end
 
@@ -17,8 +16,7 @@ RSpec.describe Step do
   describe "#initialize" do
     it "sets the attributes correctly" do
       expect(step.question).to eq(question)
-      expect(step.page_id).to eq(2)
-      expect(step.page_slug).to eq("current-page")
+      expect(step.id).to eq("2")
       expect(step.next_page_slug).to eq("next-page")
       expect(step.page_number).to eq(1)
       expect(step.routing_conditions).to eq([])
@@ -30,7 +28,6 @@ RSpec.describe Step do
       other_step = described_class.new(
         question:,
         page:,
-        page_slug: "current-page",
       )
       expect(step).to eq(other_step)
     end
@@ -38,8 +35,7 @@ RSpec.describe Step do
     it "returns false for steps with different states" do
       other_step = described_class.new(
         question:,
-        page:,
-        page_slug: "other-current-page",
+        page: build(:page),
       )
       expect(step == other_step).to be false
     end
@@ -50,7 +46,6 @@ RSpec.describe Step do
       expected_state = [
         step.page,
         step.question,
-        step.page_slug,
       ]
 
       expect(step.state).to match_array(expected_state)

--- a/spec/services/log_event_service_spec.rb
+++ b/spec/services/log_event_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe LogEventService do
   describe "#log_page_save" do
     let(:changing_answers) { true }
     let(:step) { OpenStruct.new(id: step_id, question:) }
-    let(:step_id) { 2 }
+    let(:step_id) { "2" }
     let(:question) { OpenStruct.new(is_optional?: true, question_text: "question text") }
     let(:answers) { { "name": "John" } }
 
@@ -26,7 +26,7 @@ RSpec.describe LogEventService do
     end
 
     context "when the form is being started" do
-      let(:step_id) { 1 }
+      let(:step_id) { "1" }
 
       before do
         allow(EventLogger).to receive(:log_page_event).and_return(true)


### PR DESCRIPTION
This removes the separate page_slug instance variable, which was passed into the initializer for Step via the StepFactory. As the original Page object is also passed in, we can reference it directly from that object. 

This helps simplify the code and makes it easier for future refactoring.