### PR TITLE
Run actionlint only on workflow file changes

### DIFF
--- a/.github/workflows/lint_workflows.yml
+++ b/.github/workflows/lint_workflows.yml
@@ -3,6 +3,9 @@ name: "Lint Workflows"
 on:
   pull_request:
     branches: [main]
+    paths:
+      - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Optimize CI by triggering workflow linting only when .github/workflows
files are modified, reducing unnecessary runs on unrelated changes.
