### PR TITLE
Stop consuming live_at date from form

### DIFF
--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -42,13 +42,12 @@ module Forms
     def set_form
       begin
         @form = Api::V1::FormSnapshotRepository.find_with_mode(id: params.require(:form_id), mode:)
-        return if @form.start_page && (mode.preview? || @form.live?)
       rescue ActiveResource::ResourceNotFound
         archived_form = Api::V1::FormSnapshotRepository.find_archived(id: params.require(:form_id))
         return render template: "forms/archived/show", locals: { form_name: archived_form.name }, status: :gone if archived_form.present?
       end
 
-      raise ActiveResource::ResourceNotFound, "Not Found"
+      raise ActiveResource::ResourceNotFound, "Not Found" unless @form.start_page
     end
 
     def set_locale(&action)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -14,17 +14,6 @@ class Form < ActiveResource::Base
     pages.find { |p| p.id == page_id.to_i }
   end
 
-  def live?(current_datetime = Time.zone.now)
-    return false if respond_to?(:live_at) && live_at.blank?
-    raise Date::Error, "invalid live_at time" if live_at_date.nil?
-
-    live_at_date < current_datetime.to_time
-  end
-
-  def live_at_date
-    try(:live_at).try(:to_time)
-  end
-
   def payment_url_with_reference(reference)
     return nil if payment_url.blank?
 

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     submission_email { Faker::Internet.email(domain: "example.gov.uk") }
     privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
     org { "test-org" }
-    live_at { nil }
     what_happens_next_markdown { nil }
     support_email { nil }
     support_phone { nil }
@@ -38,7 +37,6 @@ FactoryBot.define do
 
     trait :live? do
       ready_for_live
-      live_at { Time.zone.now }
       has_draft_version { false }
       has_live_version { true }
     end

--- a/spec/factories/v2_form_document.rb
+++ b/spec/factories/v2_form_document.rb
@@ -58,7 +58,6 @@ FactoryBot.define do
 
     trait :live? do
       ready_for_live
-      live_at { Time.zone.now }
     end
   end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -12,121 +12,32 @@ RSpec.describe Form, type: :model do
     ]
   end
 
-  shared_examples "form snapshot" do
-    it "returns a simple form" do
-      expect(form).to have_attributes(id: 1, name: "form name", submission_email: "user@example.com")
-    end
-
-    describe "#pages" do
-      it "returns the pages for the form" do
-        pages = form.pages
-        expect(pages.length).to eq(2)
-        expect(pages[0]).to have_attributes(id: 9, next_page: 10, answer_type: "date", question_text: "Question one")
-        expect(pages[1]).to have_attributes(id: 10, answer_type: "address", question_text: "Question two")
-      end
-    end
-
-    describe "#payment_url_with_reference" do
-      let(:attributes) { { id: 1, name: "form name", payment_url:, start_page: 1 } }
-      let(:reference) { SecureRandom.base58(8).upcase }
-
-      context "when there is a payment_url" do
-        let(:payment_url) { "https://www.gov.uk/payments/test-service/pay-for-licence" }
-
-        it "returns a full payment link" do
-          expect(form.payment_url_with_reference(reference)).to eq("#{payment_url}?reference=#{reference}")
-        end
-      end
-
-      context "when there is no payment_url" do
-        let(:payment_url) { nil }
-
-        it "returns nil" do
-          expect(form.payment_url_with_reference(reference)).to be_nil
-        end
-      end
+  describe "#pages" do
+    it "returns the pages for the form" do
+      pages = form.pages
+      expect(pages.length).to eq(2)
+      expect(pages[0]).to have_attributes(id: 9, next_page: 10, answer_type: "date", question_text: "Question one")
+      expect(pages[1]).to have_attributes(id: 10, answer_type: "address", question_text: "Question two")
     end
   end
 
-  context "when mode is live" do
-    let(:attributes) { { id: 1, name: "form name", submission_email: "user@example.com", live_at: "2022-08-18 09:16:50Z", pages: } }
+  describe "#payment_url_with_reference" do
+    let(:attributes) { { id: 1, name: "form name", payment_url:, start_page: 1 } }
+    let(:reference) { SecureRandom.base58(8).upcase }
 
-    it_behaves_like "form snapshot"
+    context "when there is a payment_url" do
+      let(:payment_url) { "https://www.gov.uk/payments/test-service/pay-for-licence" }
 
-    it "returns a live form" do
-      expect(form).to have_attributes(id: 1, name: "form name")
-      expect(form.live?).to be(true)
-    end
-
-    describe "#live?" do
-      let(:attributes) { { id: 1, name: "form name", live_at: }.compact }
-      let(:live_at) { "2022-08-18 09:16:50Z" }
-
-      context "when live_at is not set" do
-        let(:live_at) { nil }
-
-        it "raises an error" do
-          expect { form.live? }.to raise_error(Date::Error)
-        end
-      end
-
-      context "when live_at is set to empty string" do
-        let(:live_at) { "" }
-
-        it "returns false" do
-          expect(form.live?).to be false
-        end
-      end
-
-      context "when live_at is a string which isn't a valid date" do
-        let(:live_at) { "not a date!" }
-
-        it "raises an error" do
-          expect { form.live? }.to raise_error(Date::Error)
-        end
-      end
-
-      context "when live_at is not a string" do
-        let(:live_at) { 1 }
-
-        it "raises an error" do
-          expect { form.live? }.to raise_error(Date::Error)
-        end
-      end
-
-      context "when live_at is a date in the future" do
-        let(:live_at) { "2022-08-18 09:16:50Z" }
-
-        it "returns false" do
-          expect(form.live?("2022-01-01 10:00:00Z")).to be false
-        end
-      end
-
-      context "when live_at is a date in the past" do
-        let(:live_at) { "2022-08-18 09:16:50Z" }
-
-        it "returns true" do
-          expect(form.live?("2023-01-01 10:00:00Z")).to be true
-        end
-      end
-
-      context "when dates are the same" do
-        let(:live_at) { "2022-08-18 09:16:50Z" }
-
-        it "returns false" do
-          expect(form.live?("2022-08-18 09:16:50Z")).to be false
-        end
+      it "returns a full payment link" do
+        expect(form.payment_url_with_reference(reference)).to eq("#{payment_url}?reference=#{reference}")
       end
     end
 
-    context "when mode is draft" do
-      let(:attributes) { { id: 1, name: "form name", submission_email: "user@example.com", live_at: nil, pages: } }
+    context "when there is no payment_url" do
+      let(:payment_url) { nil }
 
-      it_behaves_like "form snapshot"
-
-      it "returns a draft form" do
-        expect(form).to have_attributes(id: 1, name: "form name")
-        expect(form.live?).to be(false)
+      it "returns nil" do
+        expect(form.payment_url_with_reference(reference)).to be_nil
       end
     end
   end

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe ErrorsController, type: :request do
         id: 2,
         name: "Form name",
         form_slug: "form-name",
-        live_at: "2022-08-18 09:16:50 +0100",
         submission_email: "submission@email.com",
         start_page: 1,
         steps: [

--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Forms::BaseController, type: :request do
       :v2_form_document,
       :with_support,
       id: 2,
-      live_at:,
       start_page:,
       privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
       what_happens_next_markdown: "Good things come to those that wait",
@@ -18,7 +17,6 @@ RSpec.describe Forms::BaseController, type: :request do
     )
   end
   let(:start_page) { 1 }
-  let(:live_at) { "2022-08-18 09:16:50 +0100" }
   let(:language) { "en" }
 
   let(:no_data_found_response) do
@@ -390,7 +388,6 @@ RSpec.describe Forms::BaseController, type: :request do
             :v2_form_document,
             :with_support,
             id: 2,
-            live_at:,
             start_page:,
             privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
             what_happens_next_markdown: "Good things come to those that wait",

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
   let(:form_data) do
     build(:v2_form_document, :with_support,
           id: 2,
-          live_at:,
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Good things come to those that wait",
@@ -47,8 +46,6 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
       },
     }
   end
-
-  let(:live_at) { "2022-08-18 09:16:50 +0100" }
 
   let(:steps_data) do
     [
@@ -383,17 +380,6 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
 
         include_examples "for notification references"
       end
-
-      context "and a form has a live_at value in the future" do
-        let(:live_at) { "2023-01-01 09:00:00 +0100" }
-
-        it "does not return 404" do
-          travel_to timestamp_of_request do
-            get check_your_answers_path(mode: "preview-draft", form_id: 2, form_slug: form_data.form_slug)
-          end
-          expect(response).not_to have_http_status(:not_found)
-        end
-      end
     end
 
     context "with preview mode off" do
@@ -415,17 +401,6 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
         end
 
         include_examples "for notification references"
-      end
-
-      context "and a form has a live_at value in the future" do
-        let(:live_at) { "2023-01-01 09:00:00 +0100" }
-
-        it "returns 404" do
-          travel_to timestamp_of_request do
-            get check_your_answers_path(mode:, form_id: 2, form_slug: form_data.form_slug)
-            expect(response).to have_http_status(:not_found)
-          end
-        end
       end
     end
   end

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -7,14 +7,12 @@ RSpec.describe Forms::PageController, type: :request do
   let(:form_data) do
     build(:v2_form_document, :with_support,
           id: 2,
-          live_at:,
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Good things come to those that wait",
           declaration_text: "agree to the declaration",
           steps: steps_data)
   end
-  let(:live_at) { "2022-08-18 09:16:50 +0100" }
 
   let(:first_step_in_form) do
     build :v2_question_page_step, :with_text_settings,
@@ -68,7 +66,6 @@ RSpec.describe Forms::PageController, type: :request do
     let(:form_data) do
       build(:form, :with_support,
             id: 200,
-            live_at:,
             start_page: page_id,
             declaration_text: "agree to the declaration",
             steps: [
@@ -221,18 +218,6 @@ RSpec.describe Forms::PageController, type: :request do
       it_behaves_like "page with footer"
 
       it_behaves_like "question page"
-
-      context "and a form has a live_at value in the future" do
-        let(:live_at) { "2023-01-01 09:00:00 +0100" }
-
-        it "returns 404" do
-          travel_to timestamp_of_request do
-            get form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1)
-          end
-
-          expect(response).to have_http_status(:not_found)
-        end
-      end
     end
 
     context "when viewing a live form with no routing_conditions" do
@@ -496,17 +481,6 @@ RSpec.describe Forms::PageController, type: :request do
         it "does not clear the submission reference from the session" do
           expect_any_instance_of(Flow::Context).not_to receive(:clear_submission_details)
           post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 2), params: { question: { text: "answer text" } }
-        end
-      end
-
-      context "and a form has a live_at value in the future" do
-        let(:live_at) { "2023-01-01 09:00:00 +0100" }
-
-        it "does not return 404" do
-          travel_to timestamp_of_request do
-            post save_form_page_path(mode:, form_id: 2, form_slug: form_data.form_slug, page_slug: 1), params: { question: { text: "answer text" }, changing_existing_answer: false }
-          end
-          expect(response).not_to have_http_status(:not_found)
         end
       end
     end

--- a/spec/resources/api/v2/form_document_resource_spec.rb
+++ b/spec/resources/api/v2/form_document_resource_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Api::V2::FormDocumentResource do
       "what_happens_next_markdown" => "Test",
       "payment_url" => nil,
       "start_page" => 1,
-      "live_at" => "2024-09-05T06:25:25.637Z",
       "steps" =>
       [{ "id" => 1,
          "position" => 1,
@@ -190,7 +189,7 @@ RSpec.describe Api::V2::FormDocumentResource do
     end
 
     context "when tag is live" do
-      let(:response_data) { { id: 1, name: "form name", steps: [], live_at: "2022-08-18 09:16:50Z" } }
+      let(:response_data) { { id: 1, name: "form name", steps: [] } }
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
@@ -209,7 +208,7 @@ RSpec.describe Api::V2::FormDocumentResource do
     end
 
     context "when tag is draft" do
-      let(:response_data) { { id: 1, name: "form name", steps: [], live_at: nil } }
+      let(:response_data) { { id: 1, name: "form name", steps: [] } }
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|
@@ -228,7 +227,7 @@ RSpec.describe Api::V2::FormDocumentResource do
     end
 
     context "when mode is archived" do
-      let(:response_data) { { id: 1, name: "form name", steps: [], live_at: "2022-08-18 09:16:50Z" } }
+      let(:response_data) { { id: 1, name: "form name", steps: [] } }
 
       before do
         ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/services/api/v1/form_snapshot_repository_spec.rb
+++ b/spec/services/api/v1/form_snapshot_repository_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Api::V1::FormSnapshotRepository do
       "what_happens_next_markdown" => "Test",
       "payment_url" => nil,
       "start_page" => 1,
-      "live_at" => "2024-09-05T06:25:25.637Z",
       "steps" =>
       [{ "id" => 1,
          "position" => 1,
@@ -166,9 +165,9 @@ RSpec.describe Api::V1::FormSnapshotRepository do
   describe ".find_with_mode" do
     before do
       ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/api/v2/forms/1/draft", req_headers, api_v2_response_data.merge("live_at": nil).to_json, 200
-        mock.get "/api/v2/forms/1/live", req_headers, api_v2_response_data.to_json, 200
-        mock.get "/api/v2/forms/1/archived", req_headers, api_v2_response_data.to_json, 200
+        mock.get "/api/v2/forms/1/draft", req_headers, api_v2_response_data.merge(name: "Draft form").to_json, 200
+        mock.get "/api/v2/forms/1/live", req_headers, api_v2_response_data.merge(name: "Live form").to_json, 200
+        mock.get "/api/v2/forms/1/archived", req_headers, api_v2_response_data.merge(name: "Archived form").to_json, 200
         mock.get "/api/v2/forms/2/live", req_headers, nil, 404
         mock.get "/api/v2/forms/2/archived", req_headers, api_v2_response_data.to_json, 200
         mock.get "/api/v2/forms/Alpha123/draft", req_headers, api_v2_response_data.merge("id": "Alpha123").to_json, 200
@@ -196,8 +195,7 @@ RSpec.describe Api::V1::FormSnapshotRepository do
       it "returns a live form" do
         form = described_class.find_with_mode(id: 1, mode: Mode.new("live"))
 
-        expect(form).to have_attributes(id: 1, name: "All question types form")
-        expect(form).to be_live
+        expect(form).to have_attributes(id: 1, name: "Live form")
       end
     end
 
@@ -205,8 +203,7 @@ RSpec.describe Api::V1::FormSnapshotRepository do
       it "returns a draft form" do
         form = described_class.find_with_mode(id: 1, mode: Mode.new("preview-draft"))
 
-        expect(form).to have_attributes(id: 1, name: "All question types form")
-        expect(form).not_to be_live
+        expect(form).to have_attributes(id: 1, name: "Draft form")
       end
     end
 
@@ -214,8 +211,7 @@ RSpec.describe Api::V1::FormSnapshotRepository do
       it "returns an archived form" do
         form = described_class.find_with_mode(id: 1, mode: Mode.new("preview-archived"))
 
-        expect(form).to have_attributes(id: 1, name: "All question types form")
-        expect(form).to be_live
+        expect(form).to have_attributes(id: 1, name: "Archived form")
       end
     end
 
@@ -223,8 +219,7 @@ RSpec.describe Api::V1::FormSnapshotRepository do
       it "returns a live form" do
         form = described_class.find_with_mode(id: 1, mode: Mode.new("preview-live"))
 
-        expect(form).to have_attributes(id: 1, name: "All question types form")
-        expect(form).to be_live
+        expect(form).to have_attributes(id: 1, name: "Live form")
       end
     end
 
@@ -265,7 +260,6 @@ RSpec.describe Api::V1::FormSnapshotRepository do
         form = described_class.find_archived(id: form_id)
 
         expect(form).to have_attributes(id: form_id, name: "All question types form")
-        expect(form).to be_live
       end
     end
 


### PR DESCRIPTION
This isn't necessary since moving to the V2 API, as we attempt to retrieve form documents by their tag, rather than inferring whether they're live from the live_at value. If we attempt to get a live form that isn't live, we'll get a 404 instead.

### What problem does this pull request solve?

Trello card: https://trello.com/c/T44nnWv3/2461-add-code-to-create-form-document-from-form-model-to-forms-admin

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
