### PR TITLE
Add EMAIL environment variable to review app

### DIFF
--- a/.review_apps/ecs_task_definition.tf
+++ b/.review_apps/ecs_task_definition.tf
@@ -47,6 +47,7 @@ locals {
   forms_admin_env_vars = [
     { name = "DATABASE_URL", value = "postgres://postgres:postgres@127.0.0.1:5432" },
     { name = "GOVUK_APP_DOMAIN", value = "publishing.service.gov.uk" },
+    { name = "EMAIL", value = "review-app-submissions@review.forms.service.gov.uk" },
     { name = "PORT", value = "3000" },
     { name = "RAILS_DEVELOPMENT_HOSTS", value = local.admin_app_hostname },
     { name = "RAILS_ENV", value = "production" },


### PR DESCRIPTION
When seeding the database, the seed needs to draw an email from either the EMAIL environment variable, or from the user's git login - which isn't available in review apps. We need to set an EMAIL env var when setting up a review app so that it can populate the db accordingly.

### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
