### PR TITLE
Group Sentry events for submission bounced by the form ID

### DIFF
--- a/app/jobs/receive_submission_bounces_and_complaints_job.rb
+++ b/app/jobs/receive_submission_bounces_and_complaints_job.rb
@@ -101,12 +101,14 @@ private
     EventLogger.log_form_event("submission_bounced", ses_bounce: ses_bounce.merge(bounced_recipients:))
 
     unless submission.preview?
-      Sentry.capture_message("Submission email bounced for form #{submission.form_id} - #{self.class.name}:", extra: {
-        form_id: submission.form_id,
-        submission_reference: submission.reference,
-        job_id:,
-        ses_bounce:,
-      })
+      Sentry.capture_message("Submission email bounced for form #{submission.form_id} - #{self.class.name}:",
+                             fingerprint: ["{{ default }}", submission.form_id],
+                             extra: {
+                               form_id: submission.form_id,
+                               submission_reference: submission.reference,
+                               job_id:,
+                               ses_bounce:,
+                             })
     end
   end
 

--- a/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
+++ b/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
@@ -203,6 +203,7 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
           perform_enqueued_jobs
           expect(Sentry).to have_received(:capture_message).with(
             a_string_including("Submission email bounced"),
+            fingerprint: ["{{ default }}", submission.form_id],
             extra: hash_including(
               ses_bounce: hash_including(
                 bounce_type: "Permanent",


### PR DESCRIPTION
We tried adding the form ID to the Sentry event message in the hope of Sentry creating separate issues per form ID. We did this so that we can ignore the issues for certain forms where we know the bounce is not of concern to us - usually due to the inbox having auto-replies configured.

This didn't cause separate Sentry issues to be created because Sentry will use the Stack trace rather than the formatted message when grouping events. Giving the event a fingerprint that includes the form ID should cause the events to be grouped by the form ID.

Including "{{ default }}" in the fingerprint means that Sentry will use its default grouping rules first, but then further divide by the form_id we pass in.

See https://docs.sentry.io/platforms/javascript/enriching-events/fingerprinting/

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
