### PR TITLE
Add a rake task to list old un-deleted submissions

### DIFF
--- a/lib/tasks/submissions.rake
+++ b/lib/tasks/submissions.rake
@@ -5,6 +5,17 @@ namespace :submissions do
     Rails.logger.info "#{Submission.bounced.count} bounced submissions"
   end
 
+  desc "List all submissions where delivery was last attempted more than 8 days ago"
+  task list_submissions_older_than_8_days: :environment do
+    submissions = Submission.where(last_delivery_attempt: ..8.days.ago)
+    Rails.logger.info "Found #{submissions.length} submissions older than 8 days", {
+      form_ids: submissions.map(&:form_id).uniq,
+    }
+    submissions.find_each do |submission|
+      Rails.logger.info "Submission reference: #{submission.reference}, form ID: #{submission.form_id}, delivery_status: #{submission.delivery_status}, last_delivery_attempt: #{submission.last_delivery_attempt}"
+    end
+  end
+
   desc "Fetch and display all data for a specific submission given a reference"
   task :inspect_submission_data, [:reference] => :environment do |_t, args|
     submission = Submission.find_by(reference: args.reference)

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :submission do
     created_at { Faker::Time.between(from: Time.zone.local(2025, 1, 1), to: Time.zone.now) }
     updated_at { created_at }
+    last_delivery_attempt { created_at + 1.minute }
     reference { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
     form_id { 1 }
     answers do


### PR DESCRIPTION
Add a rake task that will list all submissions where the last delivery attempt was over 8 days ago. This should help us identify where we haven't deleted submissions that we should have. This should only occur when a submission has bounced and we haven't re-attempted delivery or disregarded the bounce.