### PR TITLE
Disallow period at end of email address

### DIFF
--- a/lib/notifications_utils/recipient_validation/email_address.rb
+++ b/lib/notifications_utils/recipient_validation/email_address.rb
@@ -14,7 +14,7 @@ require "notifications_utils/recipient_validation/errors"
 HOSTNAME_PART = Regexp.compile("^(xn|[a-z0-9]+)(-?-[a-z0-9]+)*$", Regexp::IGNORECASE)
 TLD_PART = Regexp.compile("^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$", Regexp::IGNORECASE)
 VALID_LOCAL_CHARS = "a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\-"
-EMAIL_REGEX_PATTERN = /^[#{VALID_LOCAL_CHARS}]+@([^.@][^@\s]+)$/
+EMAIL_REGEX_PATTERN = /^[#{VALID_LOCAL_CHARS}]+@([^.@][^@\s]+[^.@\s])$/
 
 module NotificationsUtils
   module RecipientValidation

--- a/spec/lib/notifications_utils/recipient_validation/email_address_spec.rb
+++ b/spec/lib/notifications_utils/recipient_validation/email_address_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe NotificationsUtils::RecipientValidation::EmailAddress do
     '"quoted@domain.com"',
     "lots-of-dots@domain..gov..uk",
     "two-dots..in-local@domain.com",
+    "dot-at-end@domain.com.",
     "multiple@domains@domain.com",
     "spaces in local@domain.com",
     "spaces-in-domain@dom ain.com",


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ly9fJyad

The email address validation was allowing email addresses which end with a `.` which is not valid. This was causing an error to be thrown by ActionMailer when trying to send confirmation emails to users.

Disallow email addresses which end with a `.`.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
