### PR TITLE
Ensure carriage returns are counted as 1 character for validation

### DIFF
--- a/app/models/question/text.rb
+++ b/app/models/question/text.rb
@@ -5,12 +5,20 @@ module Question
     validates :text, length: { maximum: 499, message: I18n.t("activemodel.errors.models.question/text.attributes.text.single_line_too_long") }, if: :is_single_line?
     validates :text, length: { maximum: 4999, message: I18n.t("activemodel.errors.models.question/text.attributes.text.long_text_too_long") }, unless: :is_single_line?
 
+    before_validation :strip_carriage_returns!, unless: :is_single_line?
+
     def is_single_line?
       answer_settings.input_type == "single_line"
     end
 
     def has_long_answer?
       !is_single_line?
+    end
+
+  private
+
+    def strip_carriage_returns!
+      text.gsub!(/\r\n?/, "\n") if text.present?
     end
   end
 end

--- a/spec/models/question/text_spec.rb
+++ b/spec/models/question/text_spec.rb
@@ -109,7 +109,13 @@ RSpec.describe Question::Text, type: :model do
     end
 
     it "returns valid with text length under 5000 characters" do
-      question.text = "a" * rand(1..4999)
+      question.text = "a" * 4999
+      expect(question).to be_valid
+      expect(question.errors[:text]).to eq []
+    end
+
+    it "strips carriage returns before calculating the length" do
+      question.text = "#{'a' * 4000}\r\n#{'a' * 998}"
       expect(question).to be_valid
       expect(question.errors[:text]).to eq []
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/rWMe8Qd4

We’re counting line breaks in long text inputs as 2 characters due to carriage returns (CR) as well as line feed characters (LF) being sent in the HTTP request when the form is submitted for line breaks.

Fix this by stripping our carriage returns from the input before doing the length validation.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
