### PR TITLE
Remove submission confirmation email option from UI

### DIFF
--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -32,13 +32,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <%= form.govuk_radio_buttons_fieldset(:send_confirmation, legend: { size: 'm', tag: 'h2' }) do %>
-        <%= form.govuk_radio_button :send_confirmation, 'send_email', link_errors: :true do %>
-          <%= form.govuk_email_field :confirmation_email_address, autocomplete: 'email', spellcheck: false  %>
-        <% end %>
-        <%= form.govuk_radio_button :send_confirmation, 'skip_confirmation' %>
-      <% end %>
-
+      <%= form.hidden_field :send_confirmation, value: 'skip_confirmation' %>
       <%= form.hidden_field :confirmation_email_reference, id: 'confirmation-email-reference' %>
 
       <%if @current_context.form.declaration_text.present? %>

--- a/spec/features/email_confirmation_spec.rb
+++ b/spec/features/email_confirmation_spec.rb
@@ -25,21 +25,12 @@ feature "Email confirmation", type: :feature do
     end
   end
 
-  scenario "opting out of email submission returns the confirmation page without confirmation email text" do
+  scenario "form submission automatically skips email confirmation" do
     fill_in_form
-    choose "No", visible: false
+    expect(page).not_to have_text I18n.t("helpers.legend.email_confirmation_input.send_confirmation")
     click_button "Submit"
     expect(page.find("h1")).to have_text I18n.t("form.submitted.title")
     expect(page).not_to have_text I18n.t("form.submitted.email_sent")
-  end
-
-  scenario "opting in to email submission returns the confirmation page with confirmation email text" do
-    fill_in_form
-    choose "Yes", visible: false
-    fill_in "What email address do you want us to send your confirmation to?", with: "example@example.gov.uk"
-    click_button "Submit"
-    expect(page.find("h1")).to have_text I18n.t("form.submitted.title")
-    expect(page).to have_text I18n.t("form.submitted.email_sent")
   end
 
   def fill_in_form

--- a/spec/features/fill_in_and_submit_form_spec.rb
+++ b/spec/features/fill_in_and_submit_form_spec.rb
@@ -69,7 +69,7 @@ feature "Fill in and submit a form", type: :feature do
   end
 
   def when_i_opt_out_of_email_confirmation
-    choose "No"
+    # Email confirmation UI has been removed - form automatically skips confirmation
   end
 
   def and_i_submit_my_form

--- a/spec/features/fill_in_and_submit_form_with_csv_spec.rb
+++ b/spec/features/fill_in_and_submit_form_with_csv_spec.rb
@@ -69,7 +69,7 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
   end
 
   def when_i_opt_out_of_email_confirmation
-    choose "No"
+    # Email confirmation UI has been removed - form automatically skips confirmation
   end
 
   def and_i_submit_my_form

--- a/spec/features/fill_in_autocomplete_question_spec.rb
+++ b/spec/features/fill_in_autocomplete_question_spec.rb
@@ -85,7 +85,7 @@ feature "Fill in and submit a form with an autocomplete question", type: :featur
   end
 
   def when_i_opt_out_of_email_confirmation
-    choose "No"
+    # Email confirmation UI has been removed - form automatically skips confirmation
   end
 
   def and_i_submit_my_form

--- a/spec/features/fill_in_file_upload_question_spec.rb
+++ b/spec/features/fill_in_file_upload_question_spec.rb
@@ -142,7 +142,7 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
   end
 
   def when_i_opt_out_of_email_confirmation
-    choose "No"
+    # Email confirmation UI has been removed - form automatically skips confirmation
   end
 
   def and_i_submit_my_form

--- a/spec/features/fill_in_form_with_exit_page_spec.rb
+++ b/spec/features/fill_in_form_with_exit_page_spec.rb
@@ -87,7 +87,7 @@ feature "Fill in and submit a form with an exit page", type: :feature do
   end
 
   def when_i_opt_out_of_email_confirmation
-    choose "No"
+    # Email confirmation UI has been removed - form automatically skips confirmation
   end
 
   def and_i_submit_my_form

--- a/spec/features/fill_in_single_repeatable_form_spec.rb
+++ b/spec/features/fill_in_single_repeatable_form_spec.rb
@@ -109,7 +109,7 @@ feature "Fill in and submit a form with a single repeatable question", type: :fe
   end
 
   def when_i_opt_out_of_email_confirmation
-    choose "No"
+    # Email confirmation UI has been removed - form automatically skips confirmation
   end
 
   def and_i_submit_my_form

--- a/spec/views/forms/check_your_answers/show.html.erb_spec.rb
+++ b/spec/views/forms/check_your_answers/show.html.erb_spec.rb
@@ -55,9 +55,9 @@ describe "forms/check_your_answers/show.html.erb" do
     expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop h1")
   end
 
-  it "displays the email confirmation form at two-thirds width" do
-    expect(rendered).not_to have_css(".govuk-grid-column-full input[type='radio']")
-    expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop input[type='radio']")
+  it "displays the hidden email confirmation field at two-thirds width" do
+    expect(rendered).not_to have_css(".govuk-grid-column-full input[type='hidden'][name*='send_confirmation']", visible: :hidden)
+    expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop input[type='hidden'][name*='send_confirmation']", visible: :hidden)
   end
 
   context "when full_width is true" do
@@ -73,9 +73,9 @@ describe "forms/check_your_answers/show.html.erb" do
       expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop h1")
     end
 
-    it "displays the email confirmation form at two-thirds width" do
-      expect(rendered).not_to have_css(".govuk-grid-column-full input[type='radio']")
-      expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop input[type='radio']")
+    it "displays the hidden email confirmation field at two-thirds width" do
+      expect(rendered).not_to have_css(".govuk-grid-column-full input[type='hidden'][name*='send_confirmation']", visible: :hidden)
+      expect(rendered).to have_css(".govuk-grid-column-two-thirds-from-desktop input[type='hidden'][name*='send_confirmation']", visible: :hidden)
     end
   end
 
@@ -88,49 +88,15 @@ describe "forms/check_your_answers/show.html.erb" do
   end
 
   describe "email confirmation" do
-    it "renders an email confirmation form" do
-      expect(rendered).to have_css "form .govuk-fieldset", text: "Do you want to get an email confirming your form has been submitted?"
+    it "contains a hidden field defaulting to skip confirmation" do
+      expect(rendered).to have_field("email_confirmation_input[send_confirmation]", type: "hidden", with: "skip_confirmation")
     end
 
-    it "displays the email radio buttons" do
-      expect(rendered).to have_text(I18n.t("helpers.legend.email_confirmation_input.send_confirmation"))
-      expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_input.send_confirmation_options.send_email"))
-      expect(rendered).to have_field(I18n.t("helpers.label.email_confirmation_input.send_confirmation_options.skip_confirmation"))
-    end
-
-    it "displays the email field" do
-      expect(rendered).to have_field(
-        I18n.t("helpers.label.email_confirmation_input.confirmation_email_address"),
-        type: "email",
-      )
-    end
-
-    it "email field has correct atttributes set" do
-      expect(rendered).to have_selector("input[name='email_confirmation_input[confirmation_email_address]'][autocomplete='email'][spellcheck='false']")
-    end
-
-    context "when there is an error" do
-      let(:email_confirmation_input) do
-        email_confirmation_input = build(:email_confirmation_input)
-        email_confirmation_input.validate
-        email_confirmation_input
-      end
-
-      it "renders an error message" do
-        expect(rendered).to have_text "Select yes if you want to get an email confirming your form has been submitted"
-      end
-
-      it "renders an error summary" do
-        expect(rendered).to have_css ".govuk-error-summary"
-      end
-
-      it "links from the error summary to the first radio button" do
-        page = Capybara.string(rendered.html)
-        error_summary_link = page.find_link "Select yes if you want to get an email confirming your form has been submitted"
-        first_radio_button = page.first :field, type: :radio
-
-        expect(error_summary_link["href"]).to eq "##{first_radio_button['id']}"
-      end
+    it "does not display the email confirmation UI elements" do
+      expect(rendered).not_to have_css "form .govuk-fieldset", text: "Do you want to get an email confirming your form has been submitted?"
+      expect(rendered).not_to have_field(I18n.t("helpers.label.email_confirmation_input.send_confirmation_options.send_email"))
+      expect(rendered).not_to have_field(I18n.t("helpers.label.email_confirmation_input.send_confirmation_options.skip_confirmation"))
+      expect(rendered).not_to have_field(I18n.t("helpers.label.email_confirmation_input.confirmation_email_address"), type: "email")
     end
   end
 


### PR DESCRIPTION
Replace radio button fieldset with hidden field defaulting to skip confirmation. Backend functionality remains intact for processing the parameter.

Use this in-case we need to switch off this.