### PR TITLE
Silence healthcheck requests in lograge

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,6 +39,7 @@ Rails.application.configure do
 
   # Prevent health checks from clogging up the logs.
   config.silence_healthcheck_path = "/up"
+  config.lograge.ignore_actions = "Rails::HealthController#show"
 
   # Replace the default in-process memory cache store with a durable alternative.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Since Rails 8, the health check controller logs are filtered out from the log stream by default [[1]]. All our apps are now using Rails 8 and have `config.silence_healthcheck_path` enabled [[2]], so we stopped filtering out log lines containing `/up` in our log forwarding configuration [[3]].

However, this doesn't appear to have worked, as we are now seeing logs from the healthcheck controller. This is probably because of how Lograge works; this commit adds an additional configuration line to tell Lograge to ignore logs for the healthcheck controller, matching the Rails default.

I've tested this in dev.

[1]: rails/rails#52789
[2]: https://guides.rubyonrails.org/configuring.html#config-silence-healthcheck-path
[3]: https://github.com/alphagov/forms-deploy/pull/1720

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?