### PR TITLE
Update configuration for API requests

### DIFF
--- a/.review_apps/ecs_task_definition.tf
+++ b/.review_apps/ecs_task_definition.tf
@@ -22,7 +22,6 @@ locals {
     { name = "SETTINGS__ANALYTICS_ENABLED", value = "false" },
     { name = "SETTINGS__CLOUDWATCH_METRICS_ENABLED", value = "false" },
     { name = "SETTINGS__FORMS_ADMIN__BASE_URL", value = "https://${local.admin_app_hostname}" },
-    { name = "SETTINGS__FORMS_API__AUTH_KEY", value = "unsecured_api_key_for_review_apps_only" },
     { name = "SETTINGS__FORMS_API__BASE_URL", value = "http://localhost:9292" },
     { name = "SETTINGS__FORMS_ENV", value = "review" },
 
@@ -40,7 +39,6 @@ locals {
     { name = "RAILS_DEVELOPMENT_HOSTS", value = "localhost:9292" },
     { name = "RAILS_ENV", value = "production" },
     { name = "SECRET_KEY_BASE", value = "unsecured_secret_key_material" },
-    { name = "SETTINGS__FORMS_API__AUTH_KEY", value = "unsecured_api_key_for_review_apps_only" },
     { name = "SETTINGS__FORMS_ENV", value = "review" },
   ]
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "tzinfo-data"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
-# For forms-api
+# For requests to the forms-admin API
 gem "activeresource"
 
 # Use postgresql as the database for Active Record

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ or run the rails server:
 npm run dev
 ```
 
-You will also need to run the [forms-api service](https://github.com/alphagov/forms-api), as this app needs the API to create and access forms.
+You will also need to run the [forms-admin service](https://github.com/alphagov/forms-admin), as this app needs the API to create and access forms.
 
 #### Getting AWS credentials
 

--- a/app/resources/api/v2/form_document_resource.rb
+++ b/app/resources/api/v2/form_document_resource.rb
@@ -3,7 +3,6 @@ class Api::V2::FormDocumentResource < ActiveResource::Base
   self.site = Settings.forms_api.base_url
   self.prefix = "/api/v2/"
   self.include_format_in_path = false
-  headers["X-API-Token"] = Settings.forms_api.auth_key
 
   class Step < ActiveResource::Base
     self.site = Settings.forms_api.base_url

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,8 +8,8 @@ forms_admin:
 forms_api:
   # Authentication key to authenticate forms-runner to forms-api
   auth_key: development_key
-  # URL to form-api endpoints
-  base_url: http://localhost:9292
+  # URL to form-admin API endpoints
+  base_url: http://localhost:3000
 
 # Settings for GOV.UK Notify api & email templates
 govuk_notify:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,8 +6,6 @@ forms_admin:
   base_url: http://localhost:3000
 
 forms_api:
-  # Authentication key to authenticate forms-runner to forms-api
-  auth_key: development_key
   # URL to form-admin API endpoints
   base_url: http://localhost:3000
 

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -30,7 +30,7 @@ describe "Settings" do
     forms_api = settings[:forms_api]
 
     include_examples expected_value_test, :auth_key, forms_api, "development_key"
-    include_examples expected_value_test, :base_url, forms_api, "http://localhost:9292"
+    include_examples expected_value_test, :base_url, forms_api, "http://localhost:3000"
   end
 
   describe ".govuk_notify" do

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -29,7 +29,6 @@ describe "Settings" do
   describe ".forms_api" do
     forms_api = settings[:forms_api]
 
-    include_examples expected_value_test, :auth_key, forms_api, "development_key"
     include_examples expected_value_test, :base_url, forms_api, "http://localhost:3000"
   end
 

--- a/spec/features/email_confirmation_spec.rb
+++ b/spec/features/email_confirmation_spec.rb
@@ -6,18 +6,8 @@ feature "Email confirmation", type: :feature do
   let(:question_text) { Faker::Lorem.question }
   let(:text_answer) { Faker::Lorem.sentence }
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
-  let(:post_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Content-Type" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
+  let(:post_headers) { { "Content-Type" => "application/json" } }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/features/fill_in_and_submit_form_spec.rb
+++ b/spec/features/fill_in_and_submit_form_spec.rb
@@ -7,19 +7,8 @@ feature "Fill in and submit a form", type: :feature do
   let(:answer_text) { "Answer text" }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
-
-  let(:post_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Content-Type" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
+  let(:post_headers) { { "Content-Type" => "application/json" } }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/features/fill_in_and_submit_form_with_csv_spec.rb
+++ b/spec/features/fill_in_and_submit_form_with_csv_spec.rb
@@ -9,12 +9,7 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
   end
   let(:form) { build :v2_form_document, :live?, id: 1, name: "Fill in this form", steps:, start_page: steps.first.id, submission_type: "email_with_csv" }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/features/fill_in_autocomplete_question_spec.rb
+++ b/spec/features/fill_in_autocomplete_question_spec.rb
@@ -8,19 +8,8 @@ feature "Fill in and submit a form with an autocomplete question", type: :featur
   let(:answer_text) { "Answer 1" }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
-
-  let(:post_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Content-Type" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
+  let(:post_headers) { { "Content-Type" => "application/json" } }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/features/fill_in_file_upload_question_spec.rb
+++ b/spec/features/fill_in_file_upload_question_spec.rb
@@ -9,19 +9,8 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
   let(:answer_text) { "Answer 1" }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
-
-  let(:post_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Content-Type" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
+  let(:post_headers) { { "Content-Type" => "application/json" } }
 
   let(:test_file) { "tmp/a-file.txt" }
   let(:test_file_content) { "some content" }

--- a/spec/features/fill_in_form_with_exit_page_spec.rb
+++ b/spec/features/fill_in_form_with_exit_page_spec.rb
@@ -7,19 +7,8 @@ feature "Fill in and submit a form with an exit page", type: :feature do
   let(:question_text) { Faker::Lorem.question }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
-
-  let(:post_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Content-Type" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
+  let(:post_headers) { { "Content-Type" => "application/json" } }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/features/fill_in_single_repeatable_form_spec.rb
+++ b/spec/features/fill_in_single_repeatable_form_spec.rb
@@ -9,19 +9,8 @@ feature "Fill in and submit a form with a single repeatable question", type: :fe
   let(:second_answer_text) { "7" }
   let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
-
-  let(:post_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Content-Type" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
+  let(:post_headers) { { "Content-Type" => "application/json" } }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -50,12 +50,7 @@ RSpec.describe ErrorsController, type: :request do
       )
     end
 
-    let(:req_headers) do
-      {
-        "X-API-Token" => Settings.forms_api.auth_key,
-        "Accept" => "application/json",
-      }
-    end
+    let(:req_headers) { { "Accept" => "application/json" } }
 
     before do
       ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/requests/forms/add_another_answer_controller_spec.rb
+++ b/spec/requests/forms/add_another_answer_controller_spec.rb
@@ -20,12 +20,7 @@ RSpec.describe Forms::AddAnotherAnswerController, type: :request do
     build :v2_question_page_step, :with_text_settings, id: 2
   end
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
 
   let(:api_url_suffix) { "/draft" }
 

--- a/spec/requests/forms/base_controller_spec.rb
+++ b/spec/requests/forms/base_controller_spec.rb
@@ -41,12 +41,7 @@ RSpec.describe Forms::BaseController, type: :request do
     ]
   end
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
 
   let(:api_url_suffix) { "/live" }
 

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -73,12 +73,7 @@ RSpec.describe Forms::CheckYourAnswersController, type: :request do
     ]
   end
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
 
   let(:api_url_suffix) { "/live" }
   let(:mode) { "form" }

--- a/spec/requests/forms/page_controller_spec.rb
+++ b/spec/requests/forms/page_controller_spec.rb
@@ -39,12 +39,7 @@ RSpec.describe Forms::PageController, type: :request do
 
   let(:is_optional) { false }
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
 
   let(:api_url_suffix) { "/live" }
   let(:mode) { "form" }

--- a/spec/requests/forms/privacy_page_controller_spec.rb
+++ b/spec/requests/forms/privacy_page_controller_spec.rb
@@ -37,12 +37,7 @@ RSpec.describe Forms::PrivacyPageController, type: :request do
     ]
   end
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
 
   describe "#show" do
     before do

--- a/spec/requests/forms/remove_answer_controller_spec.rb
+++ b/spec/requests/forms/remove_answer_controller_spec.rb
@@ -22,12 +22,7 @@ RSpec.describe Forms::RemoveAnswerController, type: :request do
     build :v2_question_page_step, :with_text_settings, id: 2
   end
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
 
   let(:api_url_suffix) { "/draft" }
 

--- a/spec/requests/forms/remove_file_controller_spec.rb
+++ b/spec/requests/forms/remove_file_controller_spec.rb
@@ -25,12 +25,7 @@ RSpec.describe Forms::RemoveFileController, type: :request do
 
   let(:steps_data) { [file_upload_step, text_question_step] }
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
 
   let(:api_url_suffix) { "/live" }
   let(:mode) { "form" }

--- a/spec/requests/forms/review_file_controller_spec.rb
+++ b/spec/requests/forms/review_file_controller_spec.rb
@@ -25,12 +25,7 @@ RSpec.describe Forms::ReviewFileController, type: :request do
 
   let(:steps_data) { [file_upload_step, text_question_step] }
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
 
   let(:api_url_suffix) { "/live" }
   let(:mode) { "form" }

--- a/spec/requests/forms/submitted_controller_spec.rb
+++ b/spec/requests/forms/submitted_controller_spec.rb
@@ -48,12 +48,7 @@ RSpec.describe Forms::SubmittedController, type: :request do
     }
   end
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
 
   describe "#submitted" do
     before do

--- a/spec/resources/api/v2/form_document_resource_spec.rb
+++ b/spec/resources/api/v2/form_document_resource_spec.rb
@@ -154,12 +154,7 @@ RSpec.describe Api::V2::FormDocumentResource do
          "routing_conditions" => [] }] }
   end
 
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|

--- a/spec/services/api/v1/form_snapshot_repository_spec.rb
+++ b/spec/services/api/v1/form_snapshot_repository_spec.rb
@@ -1,12 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::FormSnapshotRepository do
-  let(:req_headers) do
-    {
-      "X-API-Token" => Settings.forms_api.auth_key,
-      "Accept" => "application/json",
-    }
-  end
+  let(:req_headers) { { "Accept" => "application/json" } }
 
   let(:form_id) { 1 }
   let(:api_v2_response_data) do

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -130,12 +130,7 @@ RSpec.describe FormSubmissionService do
         let(:aws_ses_submission_service_spy) { instance_double(AwsSesSubmissionService) }
         let(:mail_message_id) { "1234" }
 
-        let(:req_headers) do
-          {
-            "X-API-Token" => Settings.forms_api.auth_key,
-            "Accept" => "application/json",
-          }
-        end
+        let(:req_headers) { { "Accept" => "application/json" } }
 
         before do
           ActiveResource::HttpMock.respond_to do |mock|


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/AiSEhwAu

Update configuration to talk to forms-admin rather than forms-api locally.

Stop sending the API key with requests and remove the configuration setting as forms-runner now makes requests to forms-admin rather than forms-api.

forms-admin does not require an API key for requests as the /api/ endpoints are only accessible from within the VPC in our deployed environments.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
