### PR TITLE
Delete all submissions after 30 days

### DIFF
--- a/app/jobs/delete_submissions_job.rb
+++ b/app/jobs/delete_submissions_job.rb
@@ -21,7 +21,7 @@ class DeleteSubmissionsJob < ApplicationJob
     files.each(&:delete_from_s3)
     submission.destroy!
 
-    EventLogger.log_form_event("submission_deleted")
+    EventLogger.log_form_event("submission_deleted", { delivery_status: submission.delivery_status })
     CloudWatchService.record_submission_deleted_metric(submission.delivery_status)
   rescue StandardError => e
     Rails.logger.warn("Error deleting submission - #{e.class.name}: #{e.message}")

--- a/app/jobs/delete_submissions_job.rb
+++ b/app/jobs/delete_submissions_job.rb
@@ -22,6 +22,7 @@ class DeleteSubmissionsJob < ApplicationJob
     submission.destroy!
 
     EventLogger.log_form_event("submission_deleted")
+    CloudWatchService.record_submission_deleted_metric(submission.delivery_status)
   rescue StandardError => e
     Rails.logger.warn("Error deleting submission - #{e.class.name}: #{e.message}")
     Sentry.capture_exception(e)

--- a/app/jobs/delete_submissions_job.rb
+++ b/app/jobs/delete_submissions_job.rb
@@ -6,12 +6,17 @@ class DeleteSubmissionsJob < ApplicationJob
     CurrentJobLoggingAttributes.job_class = self.class.name
     CurrentJobLoggingAttributes.job_id = job_id
 
-    delete_submissions_sent_before_time = Settings.retain_submissions_for_seconds.seconds.ago
-    submissions_to_delete = Submission
-      .where(last_delivery_attempt: ..delete_submissions_sent_before_time)
+    delete_not_bounced_submissions_sent_before_time = Settings.submissions.delete_not_bounced_after_seconds.seconds.ago
+    not_bounced_submissions_to_delete = Submission
+      .where(last_delivery_attempt: ..delete_not_bounced_submissions_sent_before_time)
       .not_bounced
 
-    submissions_to_delete.find_each { |submission| delete_submission_data(submission) }
+    delete_all_submissions_created_before_time = Settings.submissions.maximum_retention_seconds.seconds.ago
+    submissions_past_max_retention = Submission
+      .where(created_at: ..delete_all_submissions_created_before_time)
+
+    not_bounced_submissions_to_delete.find_each { |submission| delete_submission_data(submission) }
+    submissions_past_max_retention.find_each { |submission| delete_submission_data(submission) }
   end
 
   def delete_submission_data(submission)

--- a/app/services/cloud_watch_service.rb
+++ b/app/services/cloud_watch_service.rb
@@ -84,6 +84,28 @@ class CloudWatchService
     )
   end
 
+  def self.record_submission_deleted_metric(delivery_status)
+    return unless Settings.cloudwatch_metrics_enabled
+
+    cloudwatch_client.put_metric_data(
+      namespace: JOBS_METRICS_NAMESPACE,
+      metric_data: [
+        {
+          metric_name: "SubmissionDeleted",
+          dimensions: [
+            environment_dimension,
+            {
+              name: "DeliveryStatus",
+              value: delivery_status,
+            },
+          ],
+          value: 1,
+          unit: "Count",
+        },
+      ],
+    )
+  end
+
   def self.record_job_failure_metric(job_name)
     return unless Settings.cloudwatch_metrics_enabled
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -40,7 +40,9 @@ file_upload:
   poll_scan_status_wait_milliseconds: 500
   poll_scan_status_max_attempts: 20
 
-retain_submissions_for_seconds: 604800 # 7 days
+submissions:
+  delete_not_bounced_after_seconds: 604800 # 7 days
+  maximum_retention_seconds: 2592000 # 30 days
 
 maintenance_mode:
   # When set to true, All pages will render 'Maintenance mode' message

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -14,4 +14,6 @@ ses_submission_email:
 submission_status_api:
   secret: test_token
 
-retain_submissions_for_seconds: 60
+submissions:
+  delete_not_bounced_after_seconds: 60
+  maximum_retention_seconds: 300

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :submission do
-    created_at { Faker::Time.between(from: Time.zone.local(2025, 1, 1), to: Time.zone.now) }
+    created_at { Time.zone.now - 2.minutes }
     updated_at { created_at }
-    last_delivery_attempt { created_at + 1.minute }
+    last_delivery_attempt { nil }
     reference { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
     form_id { 1 }
     answers do
@@ -21,6 +21,7 @@ FactoryBot.define do
 
     trait :sent do
       mail_message_id { Faker::Alphanumeric.alphanumeric }
+      last_delivery_attempt { created_at + 1.minute }
     end
 
     trait :bounced do

--- a/spec/jobs/delete_submissions_job_spec.rb
+++ b/spec/jobs/delete_submissions_job_spec.rb
@@ -23,42 +23,6 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
     }
   end
 
-  let!(:sent_submission_sent_8_days_ago) do
-    create :submission,
-           :sent,
-           reference: "SENT8DAYS",
-           form_id: form_with_file_upload.id,
-           form_document: form_with_file_upload,
-           last_delivery_attempt: 8.days.ago,
-           answers: form_with_file_upload_answers
-  end
-  let!(:sent_submission_sent_7_days_ago) do
-    create :submission,
-           :sent,
-           reference: "SENT7DAYS",
-           form_id: form_without_file_upload.id,
-           form_document: form_without_file_upload,
-           last_delivery_attempt: 7.days.ago
-  end
-  let!(:sent_submission_sent_6_days_ago) do
-    create :submission,
-           :sent,
-           reference: "SENT6DAYS",
-           form_id: form_without_file_upload.id,
-           form_document: form_without_file_upload,
-           last_delivery_attempt: 6.days.ago
-  end
-  let!(:bounced_submission) do
-    create :submission,
-           :sent,
-           reference: "BOUNCED",
-           form_id: form_without_file_upload.id,
-           form_document: form_without_file_upload,
-           last_delivery_attempt: 7.days.ago,
-           delivery_status: :bounced
-  end
-  let!(:unsent_submission) { create :submission, reference: "UNSENT", last_delivery_attempt: nil }
-
   let(:output) { StringIO.new }
   let(:logger) do
     ApplicationLogger.new(output).tap do |logger|
@@ -80,121 +44,195 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
     Rails.logger.stop_broadcasting_to logger
   end
 
-  context "when deleting uploaded files is successful" do
-    before do
-      allow(file_upload_s3_service_spy).to receive(:delete_from_s3)
+  describe "deleting not bounced submissions" do
+    let!(:sent_submission_sent_8_days_ago) do
+      create :submission,
+             :sent,
+             reference: "SENT8DAYS",
+             form_id: form_with_file_upload.id,
+             form_document: form_with_file_upload,
+             last_delivery_attempt: 8.days.ago,
+             answers: form_with_file_upload_answers
+    end
+    let!(:sent_submission_sent_7_days_ago) do
+      create :submission,
+             :sent,
+             reference: "SENT7DAYS",
+             form_id: form_without_file_upload.id,
+             form_document: form_without_file_upload,
+             last_delivery_attempt: 7.days.ago
+    end
+    let!(:sent_submission_sent_6_days_ago) do
+      create :submission,
+             :sent,
+             reference: "SENT6DAYS",
+             form_id: form_without_file_upload.id,
+             form_document: form_without_file_upload,
+             last_delivery_attempt: 6.days.ago
+    end
+    let!(:bounced_submission) do
+      create :submission,
+             :sent,
+             reference: "BOUNCED",
+             form_id: form_without_file_upload.id,
+             form_document: form_without_file_upload,
+             last_delivery_attempt: 7.days.ago,
+             delivery_status: :bounced
+    end
+    let!(:unsent_submission) { create :submission, reference: "UNSENT", last_delivery_attempt: nil }
+
+    context "when deleting uploaded files is successful" do
+      before do
+        allow(file_upload_s3_service_spy).to receive(:delete_from_s3)
+      end
+
+      it "deletes the files from S3" do
+        perform_enqueued_jobs
+        expect(file_upload_s3_service_spy).to have_received(:delete_from_s3).with("key1").once
+        expect(file_upload_s3_service_spy).to have_received(:delete_from_s3).with("key2").once
+      end
+
+      it "destroys the sent submissions updated more than 7 days ago" do
+        expect { perform_enqueued_jobs }.to change(Submission, :count).by(-2)
+        expect(Submission.exists?(sent_submission_sent_8_days_ago.id)).to be false
+        expect(Submission.exists?(sent_submission_sent_7_days_ago.id)).to be false
+      end
+
+      it "does not destroy the sent submission updated more recently than 7 days ago" do
+        perform_enqueued_jobs
+        expect(Submission.exists?(sent_submission_sent_6_days_ago.id)).to be true
+      end
+
+      it "does not destroy the submission that hasn't been sent" do
+        perform_enqueued_jobs
+        expect(Submission.exists?(unsent_submission.id)).to be true
+      end
+
+      it "does not destroy the submission that bounced" do
+        perform_enqueued_jobs
+        expect(Submission.exists?(bounced_submission.id)).to be true
+      end
+
+      it "logs deletion" do
+        perform_enqueued_jobs
+        expect(log_lines).to include(
+          hash_including(
+            "level" => "INFO",
+            "message" => "Form event",
+            "delivery_status" => "pending",
+            "event" => "form_submission_deleted",
+            "form_id" => form_with_file_upload.id,
+            "form_name" => form_with_file_upload.name,
+            "submission_reference" => sent_submission_sent_8_days_ago.reference,
+            "preview" => "false",
+            "job_id" => @job_id,
+            "job_class" => "DeleteSubmissionsJob",
+          ),
+          hash_including(
+            "level" => "INFO",
+            "message" => "Form event",
+            "delivery_status" => "pending",
+            "event" => "form_submission_deleted",
+            "form_id" => form_without_file_upload.id,
+            "form_name" => form_without_file_upload.name,
+            "submission_reference" => sent_submission_sent_7_days_ago.reference,
+            "preview" => "false",
+            "job_id" => @job_id,
+            "job_class" => "DeleteSubmissionsJob",
+          ),
+        )
+      end
+
+      it "sends cloudwatch metric for job being started" do
+        perform_enqueued_jobs
+        expect(CloudWatchService).to have_received(:record_job_started_metric).with("DeleteSubmissionsJob")
+      end
+
+      it "sends cloudwatch metric for each submission deleted" do
+        perform_enqueued_jobs
+        expect(CloudWatchService).to have_received(:record_submission_deleted_metric).twice.with("pending")
+      end
     end
 
-    it "deletes the files from S3" do
-      perform_enqueued_jobs
-      expect(file_upload_s3_service_spy).to have_received(:delete_from_s3).with("key1").once
-      expect(file_upload_s3_service_spy).to have_received(:delete_from_s3).with("key2").once
-    end
+    context "when deleting uploaded files fails" do
+      before do
+        allow(file_upload_s3_service_spy).to receive(:delete_from_s3).and_raise(StandardError, "Test error")
+        allow(Sentry).to receive(:capture_exception)
+      end
 
-    it "destroys the sent submissions updated more than 7 days ago" do
-      expect { perform_enqueued_jobs }.to change(Submission, :count).by(-2)
-      expect(Submission.exists?(sent_submission_sent_8_days_ago.id)).to be false
-      expect(Submission.exists?(sent_submission_sent_7_days_ago.id)).to be false
-    end
+      it "logs at warn level" do
+        perform_enqueued_jobs
+        expect(log_lines).to include(hash_including(
+                                       "level" => "WARN",
+                                       "message" => "Error deleting submission - StandardError: Test error",
+                                       "form_id" => form_with_file_upload.id,
+                                       "submission_reference" => sent_submission_sent_8_days_ago.reference,
+                                       "preview" => "false",
+                                       "job_id" => @job_id,
+                                       "job_class" => "DeleteSubmissionsJob",
+                                     ))
+      end
 
-    it "does not destroy the sent submission updated more recently than 7 days ago" do
-      perform_enqueued_jobs
-      expect(Submission.exists?(sent_submission_sent_6_days_ago.id)).to be true
-    end
+      it "sends error to Sentry" do
+        perform_enqueued_jobs
+        expect(Sentry).to have_received(:capture_exception)
+      end
 
-    it "does not destroy the submission that hasn't been sent" do
-      perform_enqueued_jobs
-      expect(Submission.exists?(unsent_submission.id)).to be true
-    end
+      it "does not destroy the submission that errored" do
+        perform_enqueued_jobs
+        expect(Submission.exists?(sent_submission_sent_8_days_ago.id)).to be true
+      end
 
-    it "does not destroy the submission that bounced" do
-      perform_enqueued_jobs
-      expect(Submission.exists?(bounced_submission.id)).to be true
-    end
+      it "continues to delete the next submission" do
+        expect { perform_enqueued_jobs }.to change(Submission, :count).by(-1)
+        expect(Submission.exists?(sent_submission_sent_7_days_ago.id)).to be false
+      end
 
-    it "logs deletion" do
-      perform_enqueued_jobs
-      expect(log_lines).to include(
-        hash_including(
-          "level" => "INFO",
-          "message" => "Form event",
-          "delivery_status" => "pending",
-          "event" => "form_submission_deleted",
-          "form_id" => form_with_file_upload.id,
-          "form_name" => form_with_file_upload.name,
-          "submission_reference" => sent_submission_sent_8_days_ago.reference,
-          "preview" => "false",
-          "job_id" => @job_id,
-          "job_class" => "DeleteSubmissionsJob",
-        ),
-        hash_including(
-          "level" => "INFO",
-          "message" => "Form event",
-          "delivery_status" => "pending",
-          "event" => "form_submission_deleted",
-          "form_id" => form_without_file_upload.id,
-          "form_name" => form_without_file_upload.name,
-          "submission_reference" => sent_submission_sent_7_days_ago.reference,
-          "preview" => "false",
-          "job_id" => @job_id,
-          "job_class" => "DeleteSubmissionsJob",
-        ),
-      )
-    end
+      it "sends cloudwatch metric for job being started" do
+        perform_enqueued_jobs
+        expect(CloudWatchService).to have_received(:record_job_started_metric).with("DeleteSubmissionsJob")
+      end
 
-    it "sends cloudwatch metric for job being started" do
-      perform_enqueued_jobs
-      expect(CloudWatchService).to have_received(:record_job_started_metric).with("DeleteSubmissionsJob")
-    end
-
-    it "sends cloudwatch metric for each submission deleted" do
-      perform_enqueued_jobs
-      expect(CloudWatchService).to have_received(:record_submission_deleted_metric).twice.with("pending")
+      it "sends cloudwatch metric for the deleted submission only" do
+        perform_enqueued_jobs
+        expect(CloudWatchService).to have_received(:record_submission_deleted_metric).once.with("pending")
+      end
     end
   end
 
-  context "when deleting uploaded files fails" do
-    before do
-      allow(file_upload_s3_service_spy).to receive(:delete_from_s3).and_raise(StandardError, "Test error")
-      allow(Sentry).to receive(:capture_exception)
+  describe "deleting bounced submissions" do
+    let!(:bounced_submission_created_29_days_ago) do
+      create :submission,
+             :sent,
+             reference: "BOUNCED_29_DAYS",
+             created_at: 31.days.ago,
+             delivery_status: :bounced
+    end
+    let!(:bounced_submission_created_31_days_ago) do
+      create :submission,
+             :sent,
+             reference: "BOUNCED_31_DAYS",
+             form_id: form_without_file_upload.id,
+             form_document: form_without_file_upload,
+             created_at: 31.days.ago,
+             delivery_status: :bounced
+    end
+    let!(:not_sent_submission_created_31_days_ago) do
+      create :submission,
+             reference: "NOT_SENT",
+             form_id: form_without_file_upload.id,
+             form_document: form_without_file_upload,
+             created_at: 31.days.ago
     end
 
-    it "logs at warn level" do
-      perform_enqueued_jobs
-      expect(log_lines).to include(hash_including(
-                                     "level" => "WARN",
-                                     "message" => "Error deleting submission - StandardError: Test error",
-                                     "form_id" => form_with_file_upload.id,
-                                     "submission_reference" => sent_submission_sent_8_days_ago.reference,
-                                     "preview" => "false",
-                                     "job_id" => @job_id,
-                                     "job_class" => "DeleteSubmissionsJob",
-                                   ))
+    it "destroys the all submissions created more than 30 days ago" do
+      expect { perform_enqueued_jobs }.to change(Submission, :count).by(-2)
+      expect(Submission.exists?(bounced_submission_created_31_days_ago.id)).to be false
+      expect(Submission.exists?(not_sent_submission_created_31_days_ago.id)).to be false
     end
 
-    it "sends error to Sentry" do
-      perform_enqueued_jobs
-      expect(Sentry).to have_received(:capture_exception)
-    end
-
-    it "does not destroy the submission that errored" do
-      perform_enqueued_jobs
-      expect(Submission.exists?(sent_submission_sent_8_days_ago.id)).to be true
-    end
-
-    it "continues to delete the next submission" do
-      expect { perform_enqueued_jobs }.to change(Submission, :count).by(-1)
-      expect(Submission.exists?(sent_submission_sent_7_days_ago.id)).to be false
-    end
-
-    it "sends cloudwatch metric for job being started" do
-      perform_enqueued_jobs
-      expect(CloudWatchService).to have_received(:record_job_started_metric).with("DeleteSubmissionsJob")
-    end
-
-    it "sends cloudwatch metric for the deleted submission only" do
-      perform_enqueued_jobs
-      expect(CloudWatchService).to have_received(:record_submission_deleted_metric).once.with("pending")
+    it "does not destroy the bounced submissions created less than 30 days ago" do
+      expect(Submission.exists?(bounced_submission_created_29_days_ago.id)).to be true
     end
   end
 

--- a/spec/jobs/delete_submissions_job_spec.rb
+++ b/spec/jobs/delete_submissions_job_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
         hash_including(
           "level" => "INFO",
           "message" => "Form event",
+          "delivery_status" => "pending",
           "event" => "form_submission_deleted",
           "form_id" => form_with_file_upload.id,
           "form_name" => form_with_file_upload.name,
@@ -129,6 +130,7 @@ RSpec.describe DeleteSubmissionsJob, type: :job do
         hash_including(
           "level" => "INFO",
           "message" => "Form event",
+          "delivery_status" => "pending",
           "event" => "form_submission_deleted",
           "form_id" => form_without_file_upload.id,
           "form_name" => form_without_file_upload.name,

--- a/spec/services/cloud_watch_service_spec.rb
+++ b/spec/services/cloud_watch_service_spec.rb
@@ -199,6 +199,45 @@ RSpec.describe CloudWatchService do
     end
   end
 
+  describe ".record_submission_deleted_metric" do
+    let(:delivery_status) { "pending" }
+
+    context "when CloudWatch metrics are disabled" do
+      let(:cloudwatch_metrics_enabled) { false }
+
+      it "does not call the CloudWatch client with .put_metric_data" do
+        expect(cloudwatch_client).not_to receive(:put_metric_data)
+
+        described_class.record_submission_deleted_metric(form_id:)
+      end
+    end
+
+    it "calls the cloudwatch client with put_metric_data" do
+      expect(cloudwatch_client).to receive(:put_metric_data).once.with(
+        namespace: "Forms/Jobs",
+        metric_data: [
+          {
+            metric_name: "SubmissionDeleted",
+            dimensions: [
+              {
+                name: "Environment",
+                value: forms_env,
+              },
+              {
+                name: "DeliveryStatus",
+                value: delivery_status,
+              },
+            ],
+            value: 1,
+            unit: "Count",
+          },
+        ],
+      )
+
+      described_class.record_submission_deleted_metric(delivery_status)
+    end
+  end
+
   describe ".record_job_failure_metric" do
     context "when CloudWatch metrics are disabled" do
       let(:cloudwatch_metrics_enabled) { false }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/5qTHLaAN/

We already delete submissions 7 days after delivery was attempted if we have not received a notification that the email bounced.

We have a retention policy that we will only keep submission data for a maximum of 30 days, so we need to delete submissions after 30 days regardless of whether the email was delivered or not.

Also add a CloudWatch metric with a DeliveryStatus metric so we can see how many bounced submissions we're deleting.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
