### PR TITLE
Save SES message delivery time to submission record

### DIFF
--- a/spec/jobs/receive_submission_deliveries_job_spec.rb
+++ b/spec/jobs/receive_submission_deliveries_job_spec.rb
@@ -111,6 +111,11 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
                                      ))
       end
 
+      it "saves the submission delivery time to the submission record" do
+        perform_enqueued_jobs
+        expect(submission.reload.delivered_at).to eq ses_delivery_timestamp
+      end
+
       it "sends cloudwatch metric for submission delivery time" do
         perform_enqueued_jobs
         # latency is ses_delivery_timestamp - submission.created_at


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Keep a record of the message delivery time in our database for reference, so it's clear when inspecting submissions with the Rake task whether or not a submission has been delivered.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?