### PR TITLE
WIP: One login hacky test

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -3,6 +3,11 @@ class AuthController < ApplicationController
     # We come here after one login
     # We will need to restore, form_id, mode and form_slug, which we should have saved before sending
     if session["return_to"].present?
+
+      # We need to do something to get the user's email here.
+      #
+      # We then need to set the email in the session somewhere
+      session["one_login_email"] = "example@example.org"
       redirect_to session["return_to"]
     end
   end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,0 +1,9 @@
+class AuthController < ApplicationController
+  def callback
+    # We come here after one login
+    # We will need to restore, form_id, mode and form_slug, which we should have saved before sending
+    if session["return_to"].present?
+      redirect_to session["return_to"]
+    end
+  end
+end

--- a/app/controllers/fake_onelogin_controller.rb
+++ b/app/controllers/fake_onelogin_controller.rb
@@ -1,0 +1,8 @@
+class FakeOneloginController < ApplicationController
+  def show
+  end
+
+  def create
+    redirect_to auth_callback_path(mode: "preview-draft", form_id: 14, form_slug: "testing-none-of-the-above")
+  end
+end

--- a/app/input_objects/email_confirmation_input.rb
+++ b/app/input_objects/email_confirmation_input.rb
@@ -8,7 +8,7 @@ class EmailConfirmationInput
   before_validation :strip_email_whitespace
 
   validates :send_confirmation, presence: true
-  validates :send_confirmation, inclusion: { in: %w[send_email skip_confirmation] }
+  validates :send_confirmation, inclusion: { in: %w[send_email skip_confirmation onelogin] }
   validates :confirmation_email_address, presence: true, if: :validate_email?
   validates :confirmation_email_address, email_address: { message: :invalid_email }, allow_blank: true, if: :validate_email?
 

--- a/app/views/fake_onelogin/show.html.erb
+++ b/app/views/fake_onelogin/show.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_tag onelogin_create_url, method: :POST do %>
+      <%= label_tag(:email, "Enter the email address, this will be totally ignored anyway") %>
+      <%= text_field_tag(:email) %>
+      <%= submit_tag("Finish login") %>
+    <% end %>
+  </div>
+

--- a/app/views/forms/check_your_answers/show.html.erb
+++ b/app/views/forms/check_your_answers/show.html.erb
@@ -25,6 +25,7 @@
         <%= form.govuk_radio_button :send_confirmation, 'send_email', link_errors: :true do %>
           <%= form.govuk_email_field :confirmation_email_address, autocomplete: 'email', spellcheck: false  %>
         <% end %>
+        <%= form.govuk_radio_button :send_confirmation, 'onelogin' %>
         <%= form.govuk_radio_button :send_confirmation, 'skip_confirmation' %>
       <% end %>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -412,6 +412,7 @@ cy:
       email_confirmation_input:
         confirmation_email_address: Pa gyfeiriad e-bost ydych chi eisiau i ni anfon eich cadarnhad ato?
         send_confirmation_options:
+          onelogin: Yes, send a confirmation email with answers to my one login account
           send_email: Ydw
           skip_confirmation: Na
       remove_input:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -412,6 +412,7 @@ en:
       email_confirmation_input:
         confirmation_email_address: What email address do you want us to send your confirmation to?
         send_confirmation_options:
+          onelogin: Yes, send a confirmation email with answers to my one login account
           send_email: 'Yes'
           skip_confirmation: 'No'
       remove_input:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,12 @@ Rails.application.routes.draw do
     form_slug: Form::FORM_SLUG_REGEX,
   }
 
+  get "/auth-callback" => "auth#callback", as: :auth_callack
+
+  # Fake routes for testing
+  get "/onelogin" => "fake_onelogin#show", as: :onelogin
+  post "/onelogin" => "fake_onelogin#create", as: :onelogin_create
+
   # If we make changes to allowed mode values, update the WAF rules first
   scope "/:mode", mode: /preview-draft|preview-archived|preview-live|form/ do
     get "/:form_id" => "forms/base#redirect_to_friendly_url_start", as: :form_id, constraints: form_id_constraints
@@ -29,6 +35,8 @@ Rails.application.routes.draw do
       get "/" => "forms/base#redirect_to_friendly_url_start", as: :form
       get "/#{CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG}" => "forms/check_your_answers#show", as: :check_your_answers
       post "/#{CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG}" => "forms/check_your_answers#submit_answers", as: :form_submit_answers
+      get "/#{CheckYourAnswersStep::CHECK_YOUR_ANSWERS_PAGE_SLUG}/auth" => "forms/check_your_answers#auth_callback", as: :auth_callback
+
       get "/submitted" => "forms/submitted#submitted", as: :form_submitted
       get "/privacy" => "forms/privacy_page#show", as: :form_privacy
 


### PR DESCRIPTION
This is a hastily dashed off test of adding an extra step for getting an email address for sending a confirmation address.

add a mock "one-login page"
add an extra option for the check your answers page to use an email with login
redirect users through the fake login saving/restoring the URL we need