### PR TITLE
Use JavaScript enhanced file upload component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,7 @@ GEM
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (>= 6, < 10)
       view_component (>= 4.0, < 4.3)
-    govuk_design_system_formbuilder (6.0.0)
+    govuk_design_system_formbuilder (6.1.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -861,7 +861,7 @@ CHECKSUMS
   googleapis-common-protos-types (1.22.0) sha256=f97492b77bd6da0018c860d5004f512fe7cd165554d7019a8f4df6a56fbfc4c7
   govuk-components (6.0.0) sha256=38feaed165ea2afe4c6f9f68bfcdfdb56426be133d2402912817e21830cbce81
   govuk-forms-markdown (0.8.0)
-  govuk_design_system_formbuilder (6.0.0) sha256=30025c64e05b71018a48b8618e6e9501efe4bf049d5e127d90e2fd48c0b60ea8
+  govuk_design_system_formbuilder (6.1.0) sha256=b0fdb3714e59665f1a522291840bcc89801cb4325f243e8717e0f9be87d1192c
   govuk_notify_rails (3.0.0) sha256=e0e1b8b0a7c47f90963034f290fb2982652aa8051a733c25c178680d44f2d7aa
   hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
   highline (3.1.2) sha256=67cbd34d19f6ef11a7ee1d82ffab5d36dfd5b3be861f450fc1716c7125f4bb4a

--- a/app/components/question/file_component/view.html.erb
+++ b/app/components/question/file_component/view.html.erb
@@ -7,5 +7,11 @@
                                     text: question.hint_text,
                                     class: "govuk-!-margin-bottom-7"
                                   },
-                                  accept: Question::File::FILE_TYPES.join(", ")
+                                  choose_files_button_text: t("govuk_design_system_formbuilder.govuk_file_field.choose_files_button_text"),
+                                  drop_instruction_text: t("govuk_design_system_formbuilder.govuk_file_field.drop_instruction_text"),
+                                  no_file_chosen_text: t("govuk_design_system_formbuilder.govuk_file_field.no_file_chosen_text"),
+                                  entered_drop_zone_text: t("govuk_design_system_formbuilder.govuk_file_field.entered_drop_zone_text"),
+                                  left_drop_zone_text: t("govuk_design_system_formbuilder.govuk_file_field.left_drop_zone_text"),
+                                  accept: Question::File::FILE_TYPES.join(", "),
+                                  javascript: true
 %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -412,6 +412,13 @@ cy:
   govuk_components:
     govuk_summary_list:
       change: Newid
+  govuk_design_system_formbuilder:
+    govuk_file_field:
+      choose_files_button_text: Dewis ffeil
+      drop_instruction_text: neu gollwng ffeil
+      entered_drop_zone_text: Wedi mynd i mewn i’r man gollwng
+      left_drop_zone_text: Wedi gadael y man gollwng
+      no_file_chosen_text: Ffeil heb ei ddewis
   helpers:
     error:
       message_prefix: Gwall

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -412,6 +412,13 @@ en:
   govuk_components:
     govuk_summary_list:
       change: Change
+  govuk_design_system_formbuilder:
+    govuk_file_field:
+      choose_files_button_text: Choose file
+      drop_instruction_text: or drop file
+      entered_drop_zone_text: Entered drop zone
+      left_drop_zone_text: Left drop zone
+      no_file_chosen_text: No file chosen
   helpers:
     error:
       message_prefix: Error

--- a/spec/features/fill_in_file_upload_question_spec.rb
+++ b/spec/features/fill_in_file_upload_question_spec.rb
@@ -116,11 +116,12 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
   end
 
   def then_i_see_the_file_upload_component
-    expect(page).to have_css("input[type=file]")
+    expect(page).to have_css("input[type=file]", visible: :hidden)
+    expect(page).to have_css("[data-module='govuk-file-upload']")
   end
 
   def when_i_upload_a_file
-    attach_file question_text, test_file
+    attach_file test_file, make_visible: true
   end
 
   def and_i_click_on_continue
@@ -177,6 +178,6 @@ feature "Fill in and submit a form with a file upload question", type: :feature 
 
   def then_i_see_an_error_message_that_the_file_contains_a_virus
     expect(page.find(".govuk-error-summary")).to have_text "The selected file contains a virus"
-    expect(page).to have_css("input[type=file]")
+    expect(page).to have_css("input[type=file]", visible: :hidden)
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/Nqxmi2b6

Pass in `javascript: true` to the file component to use the JavaScript enhanced file upload component.

Also pass in content for the text displayed in the JavaScript enhanced component. This allows the content to be translated into Welsh.

<img width="790" height="510" alt="Screenshot 2026-04-10 at 11 52 37" src="https://github.com/user-attachments/assets/eb0508e3-9d6a-46fc-92ab-2a50d2d6f3b3" />

<img width="790" height="510" alt="Screenshot 2026-04-10 at 11 52 41" src="https://github.com/user-attachments/assets/699cc899-28f7-49ad-9154-a6f741562942" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
