### PR TITLE
Don't enqueue submission job after fixing missing filenames

### DIFF
--- a/lib/tasks/submissions.rake
+++ b/lib/tasks/submissions.rake
@@ -254,6 +254,8 @@ namespace :submissions do
       submission.answers.each_pair do |question_id, answer|
         next unless answer.include?("original_filename") && answer["original_filename"].blank? && answer["uploaded_file_key"].present?
 
+        Rails.logger.info "Updating blank original_filename for answer to question #{question_id} in submission with reference #{submission.reference}"
+
         step = submission.journey.step_by_id(question_id)
         extension = ::File.extname(answer["uploaded_file_key"])
         filename = "#{step.step_number}-#{step.question_text.parameterize}#{extension}"
@@ -263,8 +265,9 @@ namespace :submissions do
       submission.save!
 
       if submission.answers_previously_changed?
-        Rails.logger.info "Re-delivering submission with reference #{submission.reference}"
-        SendSubmissionJob.perform_later(submission)
+        Rails.logger.info "Submission for reference #{submission.reference} has been updated, retry submission with jobs:retry_failed"
+      else
+        Rails.logger.info "No filenames missing, nothing to do"
       end
     end
   end

--- a/spec/lib/tasks/submissions.rake_spec.rb
+++ b/spec/lib/tasks/submissions.rake_spec.rb
@@ -779,11 +779,6 @@ RSpec.describe "submissions.rake" do
           "original_filename" => "1-upload-your-evidence.jpg",
         )
       end
-
-      it "reschedules the submission" do
-        task.invoke(submission.reference)
-        expect(SendSubmissionJob).to have_been_enqueued
-      end
     end
 
     context "when original filename is present" do


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

The dev running the task should retry the original failed job rather than enqueuing a new submission job. Otherwise the failed job will stay on the failed job queue and our alarms won't resolve.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
