### PR TITLE
Replace context spec for navigating the journey with unit tests

### DIFF
--- a/app/lib/flow/journey.rb
+++ b/app/lib/flow/journey.rb
@@ -48,12 +48,6 @@ module Flow
       completed_steps.last&.next_step_slug_after_routing || @step_factory.start_step.id
     end
 
-    def next_step
-      return nil if completed_steps.last&.end_page?
-
-      find_or_create(completed_steps.last&.next_step_slug_after_routing) || @step_factory.start_step
-    end
-
     def can_visit?(step_slug)
       (completed_steps.map(&:id).include? step_slug) || step_slug == next_step_slug
     end

--- a/spec/lib/flow/context_spec.rb
+++ b/spec/lib/flow/context_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 
-# rubocop:disable RSpec/InstanceVariable
 RSpec.describe Flow::Context do
   before do
     ActiveResource::HttpMock.disable_net_connection!
@@ -20,74 +19,6 @@ RSpec.describe Flow::Context do
           what_happens_next_markdown: "Good things come to those that wait",
           declaration_text: "agree to the declaration",
           steps:)
-  end
-
-  [
-    ["no input", { answers: [], request_step: 1 }, { next_step_slug: "2", start_id: 1, next_incomplete_page_id: "1", current_step_id: "1", previous_step_id: nil }],
-    ["first question complete, request second step", { answers: [{ text: "q1 answer" }], request_step: 2 }, { next_step_slug: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_STEP_SLUG, start_id: 1, previous_step_id: "1", next_incomplete_page_id: "2", current_step_id: "2" }],
-    ["first question complete, request first step", { answers: [{ text: "q1 answer" }], request_step: 1 }, { next_step_slug: "2", start_id: 1, previous_step_id: nil, next_incomplete_page_id: "2", current_step_id: "1" }],
-    ["all questions complete, request second step", { answers: [{ text: "q1 answer" }, { text: "q2 answer" }], request_step: 2 }, { next_step_slug: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_STEP_SLUG, start_id: 1, previous_step_id: "1", next_incomplete_page_id: CheckYourAnswersStep::CHECK_YOUR_ANSWERS_STEP_SLUG, current_step_id: "2" }],
-  ].each do |variation, input, expected_output|
-    context "with #{variation}" do
-      before do
-        store = {}
-        @context = described_class.new(form:, store:)
-
-        current_step = @context.find_or_create(@context.next_step_slug)
-
-        input[:answers].each do |answer|
-          current_step.assign_question_attributes(answer)
-          @context.save_step(current_step)
-          next_step_slug = current_step.next_step_slug
-          break if next_step_slug.nil?
-
-          current_step = @context.find_or_create(next_step_slug)
-        end
-        @context = described_class.new(form:, store:)
-        @step = @context.find_or_create(input[:request_step])
-      end
-
-      it "can visit the start form_document_step" do
-        expect(@context.can_visit?("1")).to be true
-      end
-
-      it "has the correct previous step" do
-        expect(@context.previous_step(@step.id)&.id).to eq(expected_output[:previous_step_id])
-      end
-
-      it "has the correct next incomplete step" do
-        expect(@context.next_step_slug).to eq(expected_output[:next_incomplete_page_id])
-      end
-
-      describe "step" do
-        it "has the right id" do
-          expect(@step.id).to eq(expected_output[:current_step_id])
-        end
-
-        it "has the correct next_step_slug" do
-          expect(@step.next_step_slug).to eq(expected_output[:next_step_slug])
-        end
-      end
-    end
-  end
-
-  context "with a step which changes question type mid-journey" do
-    it "does not throw an error if the question type changes when an answer has already been submitted" do
-      store = {}
-
-      # submit an answer
-      context1 = described_class.new(form:, store:)
-      current_step = context1.find_or_create("1")
-      current_step.assign_question_attributes({ text: "This is a text answer" })
-      context1.save_step(current_step)
-
-      # change the step's answer_type to another value
-      form.form_document_steps[0].data.answer_type = "number"
-
-      # build another context with the previous answers
-      context2 = described_class.new(form:, store:)
-      expect(context2.find_or_create("1").show_answer).to eq("")
-    end
   end
 
   describe "submission details" do
@@ -181,4 +112,3 @@ RSpec.describe Flow::Context do
     end
   end
 end
-# rubocop:enable RSpec/InstanceVariable

--- a/spec/lib/flow/journey_spec.rb
+++ b/spec/lib/flow/journey_spec.rb
@@ -48,40 +48,40 @@ RSpec.describe Flow::Journey do
     context "when answers are loaded from the session" do
       let(:answer_store) { Store::SessionAnswerStore.new(store, form.id) }
 
-      context "when no pages have been completed" do
+      context "when no steps have been completed" do
         it "is empty" do
           expect(journey.completed_steps).to eq []
         end
       end
 
-      context "when some of the pages have been completed" do
+      context "when some of the steps have been completed" do
         let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" } } } } }
 
-        it "includes only the pages that have been completed" do
+        it "includes only the steps that have been completed" do
           expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey].to_json
         end
 
-        it "includes the answer data in the question pages" do
+        it "includes the answer data in the steps" do
           expect(journey.completed_steps.map(&:question)).to all be_answered
         end
       end
 
-      context "when there is a gap in the pages that have been completed" do
+      context "when there is a gap in the steps that have been completed" do
         let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, third_step_id => { text: "More example text" } } } } }
 
-        it "includes only the pages that have been completed before the gap" do
+        it "includes only the steps that have been completed before the gap" do
           expect(journey.completed_steps.to_json).to eq [first_step_in_journey].to_json
         end
       end
 
-      context "when all pages have been completed" do
+      context "when all steps have been completed" do
         let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" }, third_step_id => { text: "More example text" } } } } }
 
-        it "includes all pages" do
+        it "includes all steps" do
           expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
         end
 
-        it "includes the answer data in the question pages" do
+        it "includes the answer data in the question steps" do
           expect(journey.completed_steps.map(&:question)).to all be_answered
         end
       end
@@ -97,7 +97,7 @@ RSpec.describe Flow::Journey do
         context "and all questions have been answered" do
           let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" }, third_step_id => { text: "More example text" } } } } }
 
-          it "includes all pages" do
+          it "includes all steps" do
             expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
           end
         end
@@ -105,7 +105,7 @@ RSpec.describe Flow::Journey do
         context "and the optional question has not been visited" do
           let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, third_step_id => { text: "More example text" } } } } }
 
-          it "includes only pages that have been completed before the optional question" do
+          it "includes only steps that have been completed before the optional question" do
             expect(journey.completed_steps.to_json).to eq [first_step_in_journey].to_json
           end
         end
@@ -113,7 +113,7 @@ RSpec.describe Flow::Journey do
         context "and the optional question has a blank answer" do
           let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "" }, third_step_id => { text: "More example text" } } } } }
 
-          it "includes all pages" do
+          it "includes all steps" do
             expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
           end
         end
@@ -127,21 +127,21 @@ RSpec.describe Flow::Journey do
                 next_step_id: third_step_id
         end
 
-        context "when all pages have been completed" do
+        context "when all steps have been completed" do
           let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => [{ text: "Example text" }], third_step_id => { text: "More example text" } } } } }
 
-          it "includes all pages" do
+          it "includes all steps" do
             expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
           end
 
-          it "includes the answer data in the question pages" do
+          it "includes the answer data in the question steps" do
             expect(journey.completed_steps.map(&:question)).to all be_answered
           end
 
           context "and the repeatable question has been answered more than once" do
             let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => [{ text: "Example text" }, { text: "Different example text" }], third_step_id => { text: "More example text" } } } } }
 
-            it "includes all pages once each" do
+            it "includes all steps once each" do
               expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
             end
           end
@@ -149,7 +149,7 @@ RSpec.describe Flow::Journey do
           context "but the answer store does not have data in the format expected for the repeatable question" do
             let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" }, third_step_id => { text: "More example text" } } } } }
 
-            it "includes only pages before the repeatable question" do
+            it "includes only steps before the repeatable question" do
               expect(journey.completed_steps.to_json).to eq [first_step_in_journey].to_json
             end
           end
@@ -160,18 +160,18 @@ RSpec.describe Flow::Journey do
         context "and the form_document_step answer matches the routing condition" do
           let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 1" }, third_step_id => { text: "More example text" } } } } }
 
-          it "includes only pages in the matched route" do
+          it "includes only steps in the matched route" do
             expect(journey.completed_steps.to_json).to eq [first_step_in_journey, third_step_in_journey].to_json
           end
 
-          it "includes the answer data in the question pages" do
+          it "includes the answer data in the question steps" do
             expect(journey.completed_steps.map(&:question)).to all be_answered
           end
 
           context "when there are answers to questions not in the matched route" do
             let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 1" }, second_step_id => { text: "Example text" }, third_step_id => { text: "More example text" } } } } }
 
-            it "includes only pages in the matched route" do
+            it "includes only steps in the matched route" do
               expect(journey.completed_steps.to_json).to eq [first_step_in_journey, third_step_in_journey].to_json
             end
           end
@@ -181,11 +181,11 @@ RSpec.describe Flow::Journey do
       context "when the answer store has data that does not match the type expected by the question" do
         let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" }, third_step_id => { selection: "Option 1" } } } } }
 
-        it "includes only pages before the answer with the wrong type" do
+        it "includes only steps before the answer with the wrong type" do
           expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey].to_json
         end
 
-        it "includes the answer data in the question pages" do
+        it "includes the answer data in the question steps" do
           expect(journey.completed_steps.map(&:question)).to all be_answered
         end
       end
@@ -280,14 +280,14 @@ RSpec.describe Flow::Journey do
     context "when answers are loaded from the database" do
       let(:answer_store) { Store::DatabaseAnswerStore.new(answers) }
 
-      context "when some of the pages have been completed" do
+      context "when some of the steps have been completed" do
         let(:answers) { { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" } } }
 
-        it "includes only the pages that have been completed" do
+        it "includes only the steps that have been completed" do
           expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey].to_json
         end
 
-        it "includes the answer data in the question pages" do
+        it "includes the answer data in the question steps" do
           expect(journey.completed_steps.map(&:question)).to all be_answered
         end
       end

--- a/spec/lib/flow/journey_spec.rb
+++ b/spec/lib/flow/journey_spec.rb
@@ -27,22 +27,16 @@ RSpec.describe Flow::Journey do
 
   let(:validation_errors) { [] }
 
-  let(:second_step) do
-    build :v2_question_step, :with_text_settings,
-          id: second_step_id,
-          next_step_id: third_step_id
-  end
+  let(:second_step) { build :v2_question_step, :with_text_settings, id: second_step_id, next_step_id: third_step_id }
+  let(:third_step) { build :v2_question_step, :with_text_settings, id: third_step_id, next_step_id: fourth_step_id }
+  let(:fourth_step) { build :v2_question_step, :with_text_settings, id: fourth_step_id }
 
-  let(:third_step) do
-    build :v2_question_step, :with_text_settings,
-          id: third_step_id
-  end
-
-  let(:form_document_steps) { [first_step, second_step, third_step] }
+  let(:form_document_steps) { [first_step, second_step, third_step, fourth_step] }
 
   let(:first_step_in_journey) { step_factory.create_step(first_step.id).load_from_store(answer_store) }
   let(:second_step_in_journey) { step_factory.create_step(second_step.id).load_from_store(answer_store) }
   let(:third_step_in_journey) { step_factory.create_step(third_step.id).load_from_store(answer_store) }
+  let(:fourth_step_in_journey) { step_factory.create_step(fourth_step_id).load_from_store(answer_store) }
 
   describe "#completed_steps" do
     context "when answers are loaded from the session" do
@@ -302,8 +296,11 @@ RSpec.describe Flow::Journey do
         let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" } } } } }
 
         it "creates steps for the unanswered questions" do
-          expect(journey.all_steps.length).to eq(3)
-          expect(journey.all_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
+          expect(journey.all_steps.length).to eq(4)
+          expect(journey.all_steps.to_json).to eq [first_step_in_journey,
+                                                   second_step_in_journey,
+                                                   third_step_in_journey,
+                                                   fourth_step_in_journey].to_json
         end
       end
     end
@@ -315,8 +312,11 @@ RSpec.describe Flow::Journey do
         let(:answers) { { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" } } }
 
         it "creates steps for the unanswered questions" do
-          expect(journey.all_steps.length).to eq(3)
-          expect(journey.all_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
+          expect(journey.all_steps.length).to eq(4)
+          expect(journey.all_steps.to_json).to eq [first_step_in_journey,
+                                                   second_step_in_journey,
+                                                   third_step_in_journey,
+                                                   fourth_step_in_journey].to_json
         end
       end
     end
@@ -349,6 +349,98 @@ RSpec.describe Flow::Journey do
       expect(completed_file_upload_questions.length).to eq 2
       expect(completed_file_upload_questions.first.uploaded_file_key).to eq "key1"
       expect(completed_file_upload_questions.second.uploaded_file_key).to eq "key2"
+    end
+  end
+
+  describe "journey navigation methods" do
+    let(:answer_store) { Store::SessionAnswerStore.new(store, form.id) }
+
+    context "when no questions have been answered" do
+      it "can visit the first step" do
+        expect(journey.can_visit?(first_step_id)).to be true
+      end
+
+      it "cannot visit the second step" do
+        expect(journey.can_visit?(second_step_id)).to be false
+      end
+
+      it "cannot visit the check your answers step" do
+        expect(journey.can_visit?(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_STEP_SLUG)).to be false
+      end
+
+      it "has no previous step" do
+        expect(journey.previous_step(first_step_id)).to be_nil
+      end
+
+      it "has the next step slug as the first step" do
+        expect(journey.next_step_slug).to eq first_step_id
+      end
+    end
+
+    context "when some of the questions has been answered" do
+      let(:store) do
+        {
+          answers: {
+            form.id.to_s => { first_step_id => { selection: "Option 2" },
+                              second_step_id => { text: "Example text" } },
+          },
+        }
+      end
+
+      it "can visit the completed steps" do
+        expect(journey.can_visit?(first_step_id)).to be true
+        expect(journey.can_visit?(second_step_id)).to be true
+      end
+
+      it "can visit the next incomplete step" do
+        expect(journey.can_visit?(third_step_id)).to be true
+      end
+
+      it "cannot visit steps after the next incomplete step" do
+        expect(journey.can_visit?(fourth_step_id)).to be false
+      end
+
+      it "cannot visit the check your answers step" do
+        expect(journey.can_visit?(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_STEP_SLUG)).to be false
+      end
+
+      it "has the correct previous steps for the completed steps" do
+        expect(journey.previous_step(first_step_id)).to be_nil
+        expect(journey.previous_step(second_step_id).id).to eq first_step_id
+        expect(journey.previous_step(third_step_id).id).to eq second_step_id
+      end
+
+      it "has the next step slug as the next incomplete step" do
+        expect(journey.next_step_slug).to eq third_step_id
+      end
+    end
+
+    context "when all questions have been answered" do
+      let(:store) do
+        {
+          answers: {
+            form.id.to_s => { first_step_id => { selection: "Option 2" },
+                              second_step_id => { text: "Example text" },
+                              third_step_id => { text: "More example text" },
+                              fourth_step_id => { text: "Even more example text" } },
+          },
+        }
+      end
+
+      it "can visit all steps" do
+        expect(journey.can_visit?(first_step_id)).to be true
+        expect(journey.can_visit?(second_step_id)).to be true
+        expect(journey.can_visit?(third_step_id)).to be true
+        expect(journey.can_visit?(fourth_step_id)).to be true
+      end
+
+      it "can visit the check your answers step" do
+        expect(journey.can_visit?(CheckYourAnswersStep::CHECK_YOUR_ANSWERS_STEP_SLUG)).to be true
+      end
+
+      it "has the next step slug as the check your answers step" do
+        expect(journey.next_step_slug).to eq CheckYourAnswersStep::CHECK_YOUR_ANSWERS_STEP_SLUG
+      end
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/02H0xEqG

The methods for navigating the form journey previously lived in the `Context` class, but the specs for them were never moved.

Remove the test from `Context` and replace with more focused unit tests for methods in the `Journey` class.

The previous test dealt with saving answers, which is already sufficiently tested so the replacement tests just load the answers from a mocked AnswerStore.

There was also a test for the answer type in the store being different to the answer type for the step definition, but this is already covered by a test for `Journey#completed_steps` so this has been removed.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
