### PR TITLE
Only consume StepResources when building the Journey

### DIFF
--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -1,6 +1,6 @@
 module Forms
   class BaseController < ApplicationController
-    prepend_before_action :set_form
+    prepend_before_action :prepare_context
     around_action :set_locale
 
     def redirect_to_friendly_url_start
@@ -15,7 +15,6 @@ module Forms
     end
 
     def error_repeat_submission
-      @current_context = Flow::Context.new(form: @form, store: session)
       render template: "errors/repeat_submission", locals: { form: @form }
     end
 
@@ -27,9 +26,7 @@ module Forms
 
   private
 
-    def current_context
-      @current_context ||= Flow::Context.new(form: @form, store: session)
-    end
+    attr_reader :current_context
 
     def mode
       @mode ||= Mode.new(params[:mode])
@@ -43,13 +40,15 @@ module Forms
       @available_languages = current_context.form.available_languages if current_context.form.multilingual?
     end
 
-    def set_form
+    def prepare_context
       form_document = Api::V2::FormDocumentRepository.find_with_mode(form_id:, mode:, language: locale)
 
       return handle_form_not_found if form_document.blank?
 
       @form = Form.new(form_document)
       raise ActiveResource::ResourceNotFound, "Form has no steps" unless @form.start_page
+
+      @current_context = Flow::Context.new(form: @form, form_document:, store: session)
     end
 
     def handle_form_not_found

--- a/app/controllers/forms/base_controller.rb
+++ b/app/controllers/forms/base_controller.rb
@@ -44,28 +44,36 @@ module Forms
     end
 
     def set_form
-      form_id = params.require(:form_id)
-      @form = Api::V2::FormDocumentRepository.find_with_mode(form_id:, mode:, language: locale)
+      form_document = Api::V2::FormDocumentRepository.find_with_mode(form_id:, mode:, language: locale)
 
-      if @form.blank?
-        I18n.with_locale(locale) do
-          if locale == "cy"
-            archived_welsh_version = Api::V2::FormDocumentRepository.find(form_id:, tag: :archived, language: :cy)
-            live_english_version = Api::V2::FormDocumentRepository.find(form_id:, tag: :live, language: :en)
+      return handle_form_not_found if form_document.blank?
 
-            if archived_welsh_version.present? && live_english_version.present?
-              return render template: "forms/archived_welsh/show",
-                            locals: { form: live_english_version },
-                            status: :not_found
-            end
+      @form = Form.new(form_document)
+      raise ActiveResource::ResourceNotFound, "Form has no steps" unless @form.start_page
+    end
+
+    def handle_form_not_found
+      I18n.with_locale(locale) do
+        if locale == "cy"
+          archived_welsh_form_document = Api::V2::FormDocumentRepository.find(form_id:, tag: :archived, language: :cy)
+          live_english_form_document = Api::V2::FormDocumentRepository.find(form_id:, tag: :live, language: :en)
+
+          if archived_welsh_form_document.present? && live_english_form_document.present?
+            return render template: "forms/archived_welsh/show",
+                          locals: { form: Form.new(live_english_form_document) },
+                          status: :not_found
           end
-
-          archived_form = Api::V2::FormDocumentRepository.find(form_id:, tag: :archived)
-          return render template: "forms/archived/show", locals: { form_name: archived_form.name }, status: :not_found if archived_form.present?
         end
+
+        archived_form_document = Api::V2::FormDocumentRepository.find(form_id:, tag: :archived)
+        return render template: "forms/archived/show", locals: { form_name: archived_form_document.name }, status: :not_found if archived_form_document.present?
       end
 
-      raise ActiveResource::ResourceNotFound, "Not Found" unless @form.present? && @form.start_page
+      raise ActiveResource::ResourceNotFound, "Not Found"
+    end
+
+    def form_id
+      params.require(:form_id)
     end
   end
 end

--- a/app/controllers/forms/step_controller.rb
+++ b/app/controllers/forms/step_controller.rb
@@ -51,7 +51,7 @@ module Forms
     def prepare_step
       step_slug = params.require(:step_slug)
       begin
-        @step = current_context.find_or_create(step_slug)
+        @step = current_context.step_by_id(step_slug)
       rescue Flow::StepFactory::StepNotFoundError
         return redirect_to form_step_path(@form.id, @form.form_slug, current_context.next_step_slug)
       end
@@ -185,7 +185,7 @@ module Forms
       EventLogger.log_page_event(event_name, @step.question.question_text, nil)
 
       routes_page_id = first_condition_with_error.check_page_id
-      routes_page = @current_context.find_or_create(routes_page_id)
+      routes_page = @current_context.step_by_id(routes_page_id)
 
       render template: "errors/goto_page_routing_error", locals: {
         error_name: first_goto_error_name,

--- a/app/lib/flow/context.rb
+++ b/app/lib/flow/context.rb
@@ -10,7 +10,7 @@ module Flow
     end
 
     delegate :support_details, to: :form
-    delegate :find_or_create, :previous_step, :next_step_slug, :next_step, :can_visit?, :completed_steps, :all_steps, to: :journey
+    delegate :step_by_id, :previous_step, :next_step_slug, :next_step, :can_visit?, :completed_steps, :all_steps, to: :journey
     delegate :clear_stored_answer, :clear, :form_submitted?, :answers, :locales_used, to: :answer_store
     delegate :save_submission_details, :get_submission_reference, :requested_email_confirmation?, :clear_submission_details, :save_copy_of_answers_preference, :wants_copy_of_answers?, to: :confirmation_details_store
 

--- a/app/lib/flow/context.rb
+++ b/app/lib/flow/context.rb
@@ -2,11 +2,11 @@ module Flow
   class Context
     attr_reader :form, :journey
 
-    def initialize(form:, store:)
+    def initialize(form:, form_document:, store:)
       @form = form
       @answer_store = Store::SessionAnswerStore.new(store, form.id)
       @confirmation_details_store = Store::ConfirmationDetailsStore.new(store, form.id)
-      @journey = Journey.new(answer_store: @answer_store, form:)
+      @journey = Journey.new(answer_store: @answer_store, form_document:)
     end
 
     delegate :support_details, to: :form

--- a/app/lib/flow/errors.rb
+++ b/app/lib/flow/errors.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Flow
+  module Errors
+    class StepNotFoundError < StandardError
+      def initialize(msg = "Step not found.")
+        super
+      end
+    end
+  end
+end

--- a/app/lib/flow/journey.rb
+++ b/app/lib/flow/journey.rb
@@ -21,10 +21,10 @@ module Flow
 
     attr_reader :completed_steps, :all_steps
 
-    def initialize(answer_store:, form:)
+    def initialize(answer_store:, form_document:)
       @answer_store = answer_store
-      @form = form
-      @step_factory = StepFactory.new(form:)
+      @form_document = form_document
+      @step_factory = StepFactory.new(form_document:)
       # generate completed_steps first to load answers only for steps that will be visited taking routing into account
       @completed_steps = generate_completed_steps
       @all_steps = generate_all_steps
@@ -126,7 +126,7 @@ module Flow
     end
 
     def generate_all_steps
-      @form.form_document_steps.map { |form_document_step| find_or_create(form_document_step.id.to_s) }
+      @form_document.steps.map { |form_document_step| find_or_create(form_document_step.id.to_s) }
     end
 
     def find_or_create(step_slug)

--- a/app/lib/flow/journey.rb
+++ b/app/lib/flow/journey.rb
@@ -17,20 +17,23 @@ module Flow
   # array will be empty.
 
   class Journey
-    attr_reader :completed_steps
+    include Flow::Errors
+
+    attr_reader :completed_steps, :all_steps
 
     def initialize(answer_store:, form:)
       @answer_store = answer_store
       @form = form
       @step_factory = StepFactory.new(form:)
+      # generate completed_steps first to load answers only for steps that will be visited taking routing into account
       @completed_steps = generate_completed_steps
+      @all_steps = generate_all_steps
 
       populate_file_suffixes
     end
 
-    def find_or_create(step_slug)
-      step = completed_steps.find { |s| s.id == step_slug }
-      step || @step_factory.create_step(step_slug)
+    def step_by_id(id)
+      @all_steps.find { |s| s.id.to_s == id.to_s } || raise(StepNotFoundError, "Can't find step #{id}")
     end
 
     def previous_step(step_slug)
@@ -50,10 +53,6 @@ module Flow
 
     def can_visit?(step_slug)
       (completed_steps.map(&:id).include? step_slug) || step_slug == next_step_slug
-    end
-
-    def all_steps
-      @form.form_document_steps.map { |form_document_step| find_or_create(form_document_step.id.to_s) }
     end
 
     def completed_file_upload_questions
@@ -124,6 +123,15 @@ module Flow
       rescue ActiveModel::UnknownAttributeError, ArgumentError
         original_step
       end
+    end
+
+    def generate_all_steps
+      @form.form_document_steps.map { |form_document_step| find_or_create(form_document_step.id.to_s) }
+    end
+
+    def find_or_create(step_slug)
+      step = completed_steps.find { |s| s.id == step_slug }
+      step || @step_factory.create_step(step_slug)
     end
   end
 end

--- a/app/lib/flow/step_factory.rb
+++ b/app/lib/flow/step_factory.rb
@@ -4,19 +4,19 @@ module Flow
 
     START_PAGE = "_start".freeze
 
-    def initialize(form:)
-      @form = form
+    def initialize(form_document:)
+      @form_document = form_document
     end
 
     def create_step(step_slug_or_start)
       # Normalize the id or constant passed in
-      step_slug = step_slug_or_start.to_s == START_PAGE ? @form.start_page : step_slug_or_start
+      step_slug = step_slug_or_start.to_s == START_PAGE ? @form_document.start_page : step_slug_or_start
       step_slug = step_slug.to_s
 
       return CheckYourAnswersStep.new if step_slug == CheckYourAnswersStep::CHECK_YOUR_ANSWERS_STEP_SLUG
 
       # for now, we use the step id as slug
-      form_document_step = @form.form_document_steps.find { |s| s.id.to_s == step_slug }
+      form_document_step = @form_document.steps.find { |s| s.id.to_s == step_slug }
       raise StepNotFoundError, "Can't find step #{step_slug}" if form_document_step.nil?
 
       question = QuestionRegister.from_form_document_step(form_document_step)

--- a/app/lib/flow/step_factory.rb
+++ b/app/lib/flow/step_factory.rb
@@ -1,12 +1,8 @@
 module Flow
   class StepFactory
-    START_PAGE = "_start".freeze
+    include Flow::Errors
 
-    class StepNotFoundError < StandardError
-      def initialize(msg = "Step not found.")
-        super
-      end
-    end
+    START_PAGE = "_start".freeze
 
     def initialize(form:)
       @form = form

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -5,7 +5,6 @@ class Form
     @form_document = form_document
   end
 
-  delegate :steps, to: :form_document, prefix: true
   delegate :declaration_text,
            :form_id,
            :form_slug,
@@ -31,10 +30,6 @@ class Form
 
   def document_json
     form_document.as_json
-  end
-
-  def step_by_id(step_id)
-    form_document_steps.find { |s| s.id == step_id }
   end
 
   def payment_url_with_reference(reference)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,10 +1,8 @@
 class Form
-  attr_reader :document_json
   private attr_reader :form_document
 
-  def initialize(form_document, form_document_json = nil)
+  def initialize(form_document)
     @form_document = form_document
-    @document_json = form_document_json
   end
 
   delegate :steps, to: :form_document, prefix: true
@@ -30,6 +28,10 @@ class Form
            to: :form_document
 
   alias_method :id, :form_id
+
+  def document_json
+    form_document.as_json
+  end
 
   def step_by_id(step_id)
     form_document_steps.find { |s| s.id == step_id }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -61,6 +61,6 @@ private
 
   def form_from_document
     form_document_resource = Api::V2::FormDocumentResource.new(form_document, true)
-    Form.new(form_document_resource, form_document)
+    Form.new(form_document_resource)
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -25,7 +25,7 @@ class Submission < ApplicationRecord
   encrypts :answers
 
   def journey
-    @journey ||= Flow::Journey.new(answer_store:, form:)
+    @journey ||= Flow::Journey.new(answer_store:, form_document: form_document_resource)
   end
 
   def form
@@ -60,7 +60,10 @@ private
   end
 
   def form_from_document
-    form_document_resource = Api::V2::FormDocumentResource.new(form_document, true)
     Form.new(form_document_resource)
+  end
+
+  def form_document_resource
+    @form_document_resource ||= Api::V2::FormDocumentResource.new(form_document, true)
   end
 end

--- a/app/services/api/v2/form_document_repository.rb
+++ b/app/services/api/v2/form_document_repository.rb
@@ -5,8 +5,7 @@ class Api::V2::FormDocumentRepository
 
       begin
         form_document_json = Api::V2::FormDocumentResource.get(form_id, tag, **options_for_language(language))
-        form_document = Api::V2::FormDocumentResource.new(form_document_json)
-        Form.new(form_document)
+        Api::V2::FormDocumentResource.new(form_document_json)
       rescue ActiveResource::ResourceNotFound
         nil
       end

--- a/app/services/api/v2/form_document_repository.rb
+++ b/app/services/api/v2/form_document_repository.rb
@@ -6,7 +6,7 @@ class Api::V2::FormDocumentRepository
       begin
         form_document_json = Api::V2::FormDocumentResource.get(form_id, tag, **options_for_language(language))
         form_document = Api::V2::FormDocumentResource.new(form_document_json)
-        Form.new(form_document, form_document_json)
+        Form.new(form_document)
       rescue ActiveResource::ResourceNotFound
         nil
       end

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -51,9 +51,11 @@ private
   end
 
   def fetch_english_language_form
-    @form = Api::V2::FormDocumentRepository.find_with_mode(form_id: form.id, mode:)
+    english_form_document = Api::V2::FormDocumentRepository.find_with_mode(form_id: form.id, mode:)
 
-    raise ActiveResource::ResourceNotFound.new(404, "Not Found") if @form.nil?
+    raise ActiveResource::ResourceNotFound.new(404, "Not Found") if english_form_document.nil?
+
+    @form = Form.new(english_form_document)
   end
 
   def validate_submission

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "Remote Code Execution",
       "warning_code": 24,
-      "fingerprint": "d37cd0288a3b85a9032f46a635b4dd408b16f1fe3cb2526711b575fb3f6697ae",
+      "fingerprint": "c6b22883be6751c7483928c55bb296e7ccc47d0bef983139a945d96a476cde7c",
       "check_name": "UnsafeReflection",
       "message": "Unsafe reflection method `const_get` called with parameter value",
       "file": "app/views/forms/step/show.html.erb",
       "line": 18,
       "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
-      "code": "Object.const_get(\"#{current_context.find_or_create(params.require(:step_slug)).question.class.name}Component::View\")",
+      "code": "Object.const_get(\"#{current_context.step_by_id(params.require(:step_slug)).question.class.name}Component::View\")",
       "render_path": [
         {
           "type": "controller",

--- a/lib/tasks/submissions.rake
+++ b/lib/tasks/submissions.rake
@@ -29,7 +29,7 @@ namespace :submissions do
   # Print attributes for a submission
   #
   # Given just a submission reference, it prints the whole submission record, with the answers filtered out.
-  # If you need to see the actual answer data, provide one or more step_slugs as well.
+  # If you need to see the actual answer data, provide one or more step_ids as well.
   #
   # Example:
   #
@@ -38,19 +38,19 @@ namespace :submissions do
   #
   desc "Fetch and display data for a specific submission given a reference"
   task :inspect_submission_data, [:reference] => :environment do |_t, args|
-    reference, *step_slugs = args.to_a
+    reference, *step_ids = args.to_a
 
     submission = Submission.find_by(reference: reference)
     abort "Submission with reference #{reference} not found" if submission.nil?
 
-    if step_slugs.empty?
+    if step_ids.empty?
       puts "Data for submission with reference #{reference}:"
       pp submission
     else
-      step_slugs.each do |slug|
-        question_text = submission.form.form_document_steps.find { it.id == slug }&.data&.question_text
-        puts "Answer(s) to #{slug} (#{question_text}) for submission with reference #{reference}"
-        pp submission.answers.slice(slug)
+      step_ids.each do |step_id|
+        question_text = submission.journey.step_by_id(step_id).question_text
+        puts "Answer(s) to #{step_id} (#{question_text}) for submission with reference #{reference}"
+        pp submission.answers.slice(step_id)
       end
     end
   end
@@ -254,9 +254,9 @@ namespace :submissions do
       submission.answers.each_pair do |question_id, answer|
         next unless answer.include?("original_filename") && answer["original_filename"].blank? && answer["uploaded_file_key"].present?
 
-        question = submission.form.step_by_id(question_id)
+        step = submission.journey.step_by_id(question_id)
         extension = ::File.extname(answer["uploaded_file_key"])
-        filename = "#{question.position}-#{question.question_text.parameterize}#{extension}"
+        filename = "#{step.step_number}-#{step.question_text.parameterize}#{extension}"
         answer["original_filename"] = filename
       end
 

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :form, class: "Form" do
-    initialize_with { new(build(:v2_form_document, **attributes), document_json) }
+    initialize_with { new(build(:v2_form_document, **attributes)) }
 
     form_id { Faker::Number.number(digits: 5) }
     sequence(:name) { |n| "Form #{n}" }
@@ -14,8 +14,6 @@ FactoryBot.define do
     support_url_text { nil }
     payment_url { nil }
     language { "en" }
-    document_json { nil }
-
     declaration_text { nil }
 
     submission_type { "email" }

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
       }
     end
     mode { is_preview ? "preview-live" : "form" }
-    form_document { build :v2_form_document, form_id: }
+    form_document { build :v2_form_document, :with_steps, form_id: }
     submission_locale { :en }
 
     transient do

--- a/spec/factories/v2_form_document.rb
+++ b/spec/factories/v2_form_document.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
     s3_bucket_region { nil }
     updated_at { Time.current.iso8601(3) }
     send_daily_submission_batch { false }
+    send_weekly_submission_batch { false }
 
     trait :with_steps do
       transient do

--- a/spec/factories/v2_form_document.rb
+++ b/spec/factories/v2_form_document.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
     steps { [] }
 
     declaration_text { nil }
-    declaration_section_completed { false }
     payment_url { nil }
     privacy_policy_url { nil }
     submission_email { nil }
@@ -18,7 +17,6 @@ FactoryBot.define do
     support_phone { nil }
     support_url { nil }
     support_url_text { nil }
-    question_section_completed { false }
     what_happens_next_markdown { nil }
     language { "en" }
     s3_bucket_aws_account_id { nil }
@@ -37,7 +35,6 @@ FactoryBot.define do
         Array.new(steps_count) { build(:v2_question_step) }
       end
 
-      question_section_completed { true }
       start_page { steps.first.id }
     end
 

--- a/spec/lib/flow/context_spec.rb
+++ b/spec/lib/flow/context_spec.rb
@@ -12,17 +12,18 @@ RSpec.describe Flow::Context do
     ]
   end
 
-  let(:form) do
-    build(:form, :with_support,
+  let(:form_document) do
+    build(:v2_form_document, :with_support,
           start_page: 1,
           privacy_policy_url: "http://www.example.gov.uk/privacy_policy",
           what_happens_next_markdown: "Good things come to those that wait",
           declaration_text: "agree to the declaration",
           steps:)
   end
+  let(:form) { Form.new(form_document) }
 
   describe "submission details" do
-    let(:context) { described_class.new(form:, store: {}) }
+    let(:context) { described_class.new(form:, form_document:, store: {}) }
     let(:reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
     let(:requested_email_confirmation) { true }
 
@@ -52,7 +53,7 @@ RSpec.describe Flow::Context do
   describe "#save_step" do
     let(:answer_store) { instance_double(Store::SessionAnswerStore) }
     let(:step) { instance_double(Step) }
-    let(:context_instance) { described_class.new(form:, store: {}) }
+    let(:context_instance) { described_class.new(form:, form_document:, store: {}) }
 
     before do
       allow(context_instance).to receive(:answer_store).and_return(answer_store)

--- a/spec/lib/flow/journey_spec.rb
+++ b/spec/lib/flow/journey_spec.rb
@@ -322,6 +322,19 @@ RSpec.describe Flow::Journey do
     end
   end
 
+  describe "#step_by_id" do
+    let(:answer_store) { Store::SessionAnswerStore.new(store, form.id) }
+
+    it "returns the step with the matching ID" do
+      step = journey.step_by_id(second_step_id)
+      expect(step.to_json).to eq second_step_in_journey.to_json
+    end
+
+    it "raises an error if no step is found matching the ID" do
+      expect { journey.step_by_id("non-existent-id") }.to raise_error(Flow::Journey::StepNotFoundError)
+    end
+  end
+
   describe "#completed_file_upload_questions" do
     let(:first_step) { build(:v2_question_step, answer_type: "file", id: first_step_id, next_step_id: second_step_id) }
     let(:second_step) { build(:v2_question_step, answer_type: "file", id: second_step_id, next_step_id: third_step_id) }

--- a/spec/lib/flow/journey_spec.rb
+++ b/spec/lib/flow/journey_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Flow::Journey do
-  subject(:journey) { described_class.new(answer_store:, form:) }
+  subject(:journey) { described_class.new(answer_store:, form_document:) }
 
   let(:store) { {} }
-  let(:step_factory) { Flow::StepFactory.new(form:) }
+  let(:step_factory) { Flow::StepFactory.new(form_document:) }
 
   let(:step_ids) { Array.new(4) { Faker::Alphanumeric.alphanumeric(number: 8) } }
   let(:first_step_id) { step_ids[0] }
@@ -12,8 +12,10 @@ RSpec.describe Flow::Journey do
   let(:third_step_id) { step_ids[2] }
   let(:fourth_step_id) { step_ids[3] }
 
-  let(:form) do
-    build(:form, :with_support,
+  let(:form_id) { Faker::Alphanumeric.alphanumeric(number: 8) }
+  let(:form_document) do
+    build(:v2_form_document, :with_support,
+          form_id:,
           start_page: first_step_id,
           steps: form_document_steps)
   end
@@ -40,7 +42,7 @@ RSpec.describe Flow::Journey do
 
   describe "#completed_steps" do
     context "when answers are loaded from the session" do
-      let(:answer_store) { Store::SessionAnswerStore.new(store, form.id) }
+      let(:answer_store) { Store::SessionAnswerStore.new(store, form_id) }
 
       context "when no steps have been completed" do
         it "is empty" do
@@ -49,7 +51,7 @@ RSpec.describe Flow::Journey do
       end
 
       context "when some of the steps have been completed" do
-        let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" } } } } }
+        let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" } } } } }
 
         it "includes only the steps that have been completed" do
           expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey].to_json
@@ -61,7 +63,7 @@ RSpec.describe Flow::Journey do
       end
 
       context "when there is a gap in the steps that have been completed" do
-        let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, third_step_id => { text: "More example text" } } } } }
+        let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 2" }, third_step_id => { text: "More example text" } } } } }
 
         it "includes only the steps that have been completed before the gap" do
           expect(journey.completed_steps.to_json).to eq [first_step_in_journey].to_json
@@ -69,7 +71,7 @@ RSpec.describe Flow::Journey do
       end
 
       context "when all steps have been completed" do
-        let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" }, third_step_id => { text: "More example text" } } } } }
+        let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" }, third_step_id => { text: "More example text" } } } } }
 
         it "includes all steps" do
           expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
@@ -89,7 +91,7 @@ RSpec.describe Flow::Journey do
         end
 
         context "and all questions have been answered" do
-          let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" }, third_step_id => { text: "More example text" } } } } }
+          let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" }, third_step_id => { text: "More example text" } } } } }
 
           it "includes all steps" do
             expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
@@ -97,7 +99,7 @@ RSpec.describe Flow::Journey do
         end
 
         context "and the optional question has not been visited" do
-          let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, third_step_id => { text: "More example text" } } } } }
+          let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 2" }, third_step_id => { text: "More example text" } } } } }
 
           it "includes only steps that have been completed before the optional question" do
             expect(journey.completed_steps.to_json).to eq [first_step_in_journey].to_json
@@ -105,7 +107,7 @@ RSpec.describe Flow::Journey do
         end
 
         context "and the optional question has a blank answer" do
-          let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "" }, third_step_id => { text: "More example text" } } } } }
+          let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "" }, third_step_id => { text: "More example text" } } } } }
 
           it "includes all steps" do
             expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
@@ -122,7 +124,7 @@ RSpec.describe Flow::Journey do
         end
 
         context "when all steps have been completed" do
-          let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => [{ text: "Example text" }], third_step_id => { text: "More example text" } } } } }
+          let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => [{ text: "Example text" }], third_step_id => { text: "More example text" } } } } }
 
           it "includes all steps" do
             expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
@@ -133,7 +135,7 @@ RSpec.describe Flow::Journey do
           end
 
           context "and the repeatable question has been answered more than once" do
-            let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => [{ text: "Example text" }, { text: "Different example text" }], third_step_id => { text: "More example text" } } } } }
+            let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => [{ text: "Example text" }, { text: "Different example text" }], third_step_id => { text: "More example text" } } } } }
 
             it "includes all steps once each" do
               expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey, third_step_in_journey].to_json
@@ -141,7 +143,7 @@ RSpec.describe Flow::Journey do
           end
 
           context "but the answer store does not have data in the format expected for the repeatable question" do
-            let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" }, third_step_id => { text: "More example text" } } } } }
+            let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" }, third_step_id => { text: "More example text" } } } } }
 
             it "includes only steps before the repeatable question" do
               expect(journey.completed_steps.to_json).to eq [first_step_in_journey].to_json
@@ -152,7 +154,7 @@ RSpec.describe Flow::Journey do
 
       context "when a form_document_step has a routing condition" do
         context "and the form_document_step answer matches the routing condition" do
-          let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 1" }, third_step_id => { text: "More example text" } } } } }
+          let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 1" }, third_step_id => { text: "More example text" } } } } }
 
           it "includes only steps in the matched route" do
             expect(journey.completed_steps.to_json).to eq [first_step_in_journey, third_step_in_journey].to_json
@@ -163,7 +165,7 @@ RSpec.describe Flow::Journey do
           end
 
           context "when there are answers to questions not in the matched route" do
-            let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 1" }, second_step_id => { text: "Example text" }, third_step_id => { text: "More example text" } } } } }
+            let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 1" }, second_step_id => { text: "Example text" }, third_step_id => { text: "More example text" } } } } }
 
             it "includes only steps in the matched route" do
               expect(journey.completed_steps.to_json).to eq [first_step_in_journey, third_step_in_journey].to_json
@@ -173,7 +175,7 @@ RSpec.describe Flow::Journey do
       end
 
       context "when the answer store has data that does not match the type expected by the question" do
-        let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" }, third_step_id => { selection: "Option 1" } } } } }
+        let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" }, third_step_id => { selection: "Option 1" } } } } }
 
         it "includes only steps before the answer with the wrong type" do
           expect(journey.completed_steps.to_json).to eq [first_step_in_journey, second_step_in_journey].to_json
@@ -201,7 +203,7 @@ RSpec.describe Flow::Journey do
                 is_optional: false
         end
 
-        let(:store) { { answers: { form.id.to_s => { first_step_id => { text: "Example text" }, second_step_id => { selection: second_step.routing_conditions.first.answer_value }, third_step_id => { text: "More example text" } } } } }
+        let(:store) { { answers: { form_id.to_s => { first_step_id => { text: "Example text" }, second_step_id => { selection: second_step.routing_conditions.first.answer_value }, third_step_id => { text: "More example text" } } } } }
 
         it "stops generating the completed_steps when it reaches the question with the error" do
           expect(journey.completed_steps.to_json).to eq [first_step_in_journey].to_json
@@ -217,7 +219,7 @@ RSpec.describe Flow::Journey do
         let(:store) do
           {
             answers: {
-              form.id.to_s =>
+              form_id.to_s =>
                 {
                   first_step_id => { uploaded_file_key: "key1", original_filename: "file1", filename_suffix: "" },
                   second_step_id => { uploaded_file_key: "key2", original_filename: "a different filename", filename_suffix: "" },
@@ -248,7 +250,7 @@ RSpec.describe Flow::Journey do
         let(:store) do
           {
             answers: {
-              form.id.to_s =>
+              form_id.to_s =>
                 {
                   first_step_id => { uploaded_file_key: "key1", original_filename: "this_is_an_incredibly_long_filename_that_will_surely_have_to_be_truncated_somewhere_near_the_end_version_one", filename_suffix: "" },
                   second_step_id => { uploaded_file_key: "key2", original_filename: "a different filename", filename_suffix: "" },
@@ -290,10 +292,10 @@ RSpec.describe Flow::Journey do
 
   describe "#all_steps" do
     context "when answers are loaded from the session" do
-      let(:answer_store) { Store::SessionAnswerStore.new(store, form.id) }
+      let(:answer_store) { Store::SessionAnswerStore.new(store, form_id) }
 
       context "when some questions have not been answered" do
-        let(:store) { { answers: { form.id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" } } } } }
+        let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => { text: "Example text" } } } } }
 
         it "creates steps for the unanswered questions" do
           expect(journey.all_steps.length).to eq(4)
@@ -323,7 +325,7 @@ RSpec.describe Flow::Journey do
   end
 
   describe "#step_by_id" do
-    let(:answer_store) { Store::SessionAnswerStore.new(store, form.id) }
+    let(:answer_store) { Store::SessionAnswerStore.new(store, form_id) }
 
     it "returns the step with the matching ID" do
       step = journey.step_by_id(second_step_id)
@@ -342,11 +344,11 @@ RSpec.describe Flow::Journey do
     let(:fourth_step) { build(:v2_question_step, :with_text_settings, id: fourth_step_id) }
     let(:form_document_steps) { [first_step, second_step, third_step, fourth_step] }
 
-    let(:answer_store) { Store::SessionAnswerStore.new(store, form.id) }
+    let(:answer_store) { Store::SessionAnswerStore.new(store, form_id) }
     let(:store) do
       {
         answers: {
-          form.id.to_s =>
+          form_id.to_s =>
             {
               first_step_id => { uploaded_file_key: "key1", original_filename: "file1" },
               second_step_id => { original_filename: "" },
@@ -366,7 +368,7 @@ RSpec.describe Flow::Journey do
   end
 
   describe "journey navigation methods" do
-    let(:answer_store) { Store::SessionAnswerStore.new(store, form.id) }
+    let(:answer_store) { Store::SessionAnswerStore.new(store, form_id) }
 
     context "when no questions have been answered" do
       it "can visit the first step" do
@@ -394,7 +396,7 @@ RSpec.describe Flow::Journey do
       let(:store) do
         {
           answers: {
-            form.id.to_s => { first_step_id => { selection: "Option 2" },
+            form_id.to_s => { first_step_id => { selection: "Option 2" },
                               second_step_id => { text: "Example text" } },
           },
         }
@@ -432,7 +434,7 @@ RSpec.describe Flow::Journey do
       let(:store) do
         {
           answers: {
-            form.id.to_s => { first_step_id => { selection: "Option 2" },
+            form_id.to_s => { first_step_id => { selection: "Option 2" },
                               second_step_id => { text: "Example text" },
                               third_step_id => { text: "More example text" },
                               fourth_step_id => { text: "Even more example text" } },

--- a/spec/lib/flow/step_factory_spec.rb
+++ b/spec/lib/flow/step_factory_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Flow::StepFactory do
-  let(:form) { build :form, form_slug: "test-form", start_page: "page-1", steps: [] }
-  let(:factory) { described_class.new(form:) }
+  let(:form_document) { build :v2_form_document, form_slug: "test-form", start_page: "page-1", steps: [] }
+  let(:factory) { described_class.new(form_document:) }
 
   describe "#create_step" do
     context "when creating a CheckYourAnswersStep" do
@@ -17,7 +17,7 @@ RSpec.describe Flow::StepFactory do
       let(:question) { instance_double(Question) }
 
       before do
-        allow(form.form_document_steps).to receive(:find).and_return(form_document_step)
+        allow(form_document.steps).to receive(:find).and_return(form_document_step)
         allow(Flow::QuestionRegister).to receive(:from_form_document_step).with(form_document_step).and_return(question)
       end
 
@@ -44,7 +44,7 @@ RSpec.describe Flow::StepFactory do
       let(:question) { instance_double(Question) }
 
       before do
-        allow(form.form_document_steps).to receive(:find).and_return(form_document_step)
+        allow(form_document.steps).to receive(:find).and_return(form_document_step)
         allow(Flow::QuestionRegister).to receive(:from_form_document_step).with(form_document_step).and_return(question)
       end
 
@@ -64,7 +64,7 @@ RSpec.describe Flow::StepFactory do
       let(:start_page) { build :v2_question_step, id: "page-1", next_step_id: "page-2" }
 
       before do
-        allow(form.form_document_steps).to receive(:find).and_return(start_page)
+        allow(form_document.steps).to receive(:find).and_return(start_page)
         allow(Flow::QuestionRegister).to receive(:from_form_document_step).with(start_page).and_return(instance_double(Question))
       end
 

--- a/spec/lib/tasks/submissions.rake_spec.rb
+++ b/spec/lib/tasks/submissions.rake_spec.rb
@@ -15,8 +15,11 @@ RSpec.describe "submissions.rake" do
         .tap(&:reenable)
     end
 
+    let(:form_document) { build :v2_form_document, :with_steps }
+    let(:answers) { { form_document.steps.first.id => { selection: "Option 1" } } }
+
     before do
-      create :submission, :sent, reference: "test_ref"
+      create :submission, :sent, reference: "test_ref", form_document:, answers:
     end
 
     describe "given a submission reference" do
@@ -35,9 +38,9 @@ RSpec.describe "submissions.rake" do
         expect { task.invoke("test_ref") }.not_to output(a_string_including("Option 1")).to_stdout
       end
 
-      describe "given a step slug" do
+      describe "given a step id" do
         it "displays the answers submitted by the user" do
-          expect { task.invoke("test_ref", "1") }.to output(a_string_including("Option 1")).to_stdout
+          expect { task.invoke("test_ref", form_document.steps.first.id) }.to output(a_string_including("Option 1")).to_stdout
         end
       end
     end
@@ -744,6 +747,7 @@ RSpec.describe "submissions.rake" do
     let(:form_document) do
       build(
         :v2_form_document,
+        start_page: "aB123z",
         steps: [
           build(
             :v2_question_step,
@@ -851,6 +855,7 @@ RSpec.describe "submissions.rake" do
       let(:form_document) do
         build(
           :v2_form_document,
+          start_page: "i",
           steps: [
             build(
               :v2_question_step,

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -200,4 +200,12 @@ RSpec.describe Form, type: :model do
       end
     end
   end
+
+  describe "#document_json" do
+    let(:form_document) { build :v2_form_document, :live, :s3_submissions_enabled }
+
+    it "returns the form document as JSON" do
+      expect(form.document_json).to eq(form_document.as_json)
+    end
+  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -12,28 +12,6 @@ RSpec.describe Form, type: :model do
     expect(form).to have_attributes form_id: form_document.form_id
   end
 
-  describe "#form_document_steps" do
-    let(:form_document) { build :v2_form_document, steps: }
-    let(:steps) do
-      [
-        build(:v2_question_step, id: 9, next_step_id: 10, answer_type: "date", question_text: "Question one"),
-        build(:v2_question_step, id: 10, answer_type: "address", question_text: "Question two"),
-      ]
-    end
-
-    it "returns the form_document_steps for the form" do
-      form_document_steps = form.form_document_steps
-      expect(form_document_steps.length).to eq(2)
-      expect(form_document_steps[0].id).to eq(9)
-      expect(form_document_steps[0].next_step_id).to eq(10)
-      expect(form_document_steps[0].answer_type).to eq("date")
-      expect(form_document_steps[0].question_text).to eq("Question one")
-      expect(form_document_steps[1].id).to eq(10)
-      expect(form_document_steps[1].answer_type).to eq("address")
-      expect(form_document_steps[1].question_text).to eq("Question two")
-    end
-  end
-
   describe "#payment_url_with_reference" do
     let(:form_document) { build :v2_form_document, payment_url: }
     let(:reference) { SecureRandom.base58(8).upcase }

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Forms::CheckYourAnswersController, :capture_logging, type: :reque
     end
 
     allow(Flow::Context).to receive(:new).and_wrap_original do |original_method, *args|
-      context_spy = original_method.call(form: args[0][:form], store:)
+      context_spy = original_method.call(form: args[0][:form], form_document: args[0][:form_document], store:)
       allow(context_spy).to receive(:form_submitted?).and_return(repeat_form_submission)
       context_spy
     end

--- a/spec/requests/forms/copy_of_answers_controller_spec.rb
+++ b/spec/requests/forms/copy_of_answers_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Forms::CopyOfAnswersController, type: :request do
     end
 
     allow(Flow::Context).to receive(:new).and_wrap_original do |original_method, *args|
-      original_method.call(form: args[0][:form], store:)
+      original_method.call(form: args[0][:form], form_document: args[0][:form_document], store:)
     end
 
     allow(FeatureService).to receive(:enabled?).with("filler_answer_email_enabled").and_return(true)

--- a/spec/requests/forms/remove_file_controller_spec.rb
+++ b/spec/requests/forms/remove_file_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Forms::RemoveFileController, type: :request do
-  let(:form_data) do
+  let(:form_document) do
     build(:v2_form_document, :with_support, :live,
           form_id: 1,
           start_page: 1,
@@ -36,7 +36,7 @@ RSpec.describe Forms::RemoveFileController, type: :request do
   let(:store) do
     {
       answers: {
-        form_data.form_id.to_s => {
+        form_document.form_id.to_s => {
           file_upload_step.id.to_s => {
             "original_filename" => uploaded_filename,
             "uploaded_file_key" => uploaded_file_key,
@@ -48,18 +48,18 @@ RSpec.describe Forms::RemoveFileController, type: :request do
 
   before do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get "/api/v2/forms/1#{api_url_suffix}", req_headers, form_data.to_json, 200
+      mock.get "/api/v2/forms/1#{api_url_suffix}", req_headers, form_document.to_json, 200
     end
 
     allow(Flow::Context).to receive(:new).and_wrap_original do |original_method, *args|
-      context_spy = original_method.call(form: args[0][:form], store:)
+      context_spy = original_method.call(form: args[0][:form], form_document: args[0][:form_document], store:)
       context_spy
     end
   end
 
   describe "#show" do
     before do
-      get remove_file_confirmation_path(mode:, form_id: form_data.form_id, form_slug: form_data.form_slug, step_slug:, changing_existing_answer:)
+      get remove_file_confirmation_path(mode:, form_id: form_document.form_id, form_slug: form_document.form_slug, step_slug:, changing_existing_answer:)
     end
 
     context "when the question is a file upload question" do
@@ -75,7 +75,7 @@ RSpec.describe Forms::RemoveFileController, type: :request do
         end
 
         it "displays a back link to the review file page" do
-          expect(response.body).to include(review_file_path(form_data.form_id, form_data.form_slug, step_slug, changing_existing_answer:))
+          expect(response.body).to include(review_file_path(form_document.form_id, form_document.form_slug, step_slug, changing_existing_answer:))
         end
       end
 
@@ -83,7 +83,7 @@ RSpec.describe Forms::RemoveFileController, type: :request do
         let(:store) { {} }
 
         it "redirects to the show page route" do
-          expect(response).to redirect_to form_step_path(form_data.form_id, form_data.form_slug, step_slug)
+          expect(response).to redirect_to form_step_path(form_document.form_id, form_document.form_slug, step_slug)
         end
       end
 
@@ -92,7 +92,7 @@ RSpec.describe Forms::RemoveFileController, type: :request do
 
         it "includes the changing_existing_answer query parameter for the confirmation URL" do
           rendered = Capybara.string(response.body)
-          expected_url = remove_file_confirmation_path(mode:, form_id: form_data.form_id, form_slug: form_data.form_slug, step_slug:, changing_existing_answer:)
+          expected_url = remove_file_confirmation_path(mode:, form_id: form_document.form_id, form_slug: form_document.form_slug, step_slug:, changing_existing_answer:)
           expect(rendered).to have_css("form[action='#{expected_url}'][method='post']")
         end
       end
@@ -102,7 +102,7 @@ RSpec.describe Forms::RemoveFileController, type: :request do
       let(:step_slug) { text_question_step.id }
 
       it "redirects to the show page route" do
-        expect(response).to redirect_to form_step_path(form_data.form_id, form_data.form_slug, step_slug)
+        expect(response).to redirect_to form_step_path(form_document.form_id, form_document.form_slug, step_slug)
       end
     end
   end
@@ -114,7 +114,7 @@ RSpec.describe Forms::RemoveFileController, type: :request do
     before do
       allow(Aws::S3::Client).to receive(:new).and_return(mock_s3_client)
       allow(mock_s3_client).to receive(:delete_object)
-      delete remove_file_path(mode:, form_id: form_data.form_id, form_slug: form_data.form_slug, step_slug:, changing_existing_answer:, remove_input: { remove: })
+      delete remove_file_path(mode:, form_id: form_document.form_id, form_slug: form_document.form_slug, step_slug:, changing_existing_answer:, remove_input: { remove: })
     end
 
     context "when the question is a file upload question" do
@@ -134,7 +134,7 @@ RSpec.describe Forms::RemoveFileController, type: :request do
         end
 
         it "displays a back link to the review file page" do
-          expect(response.body).to include(review_file_path(form_data.form_id, form_data.form_slug, step_slug, changing_existing_answer:))
+          expect(response.body).to include(review_file_path(form_document.form_id, form_document.form_slug, step_slug, changing_existing_answer:))
         end
       end
 
@@ -145,11 +145,11 @@ RSpec.describe Forms::RemoveFileController, type: :request do
           end
 
           it "removes the answer from the session" do
-            expect(store[:answers][form_data.form_id.to_s]).not_to have_key step_slug
+            expect(store[:answers][form_document.form_id.to_s]).not_to have_key step_slug
           end
 
           it "redirects to the show page route" do
-            expect(response).to redirect_to form_step_path(form_data.form_id, form_data.form_slug, step_slug)
+            expect(response).to redirect_to form_step_path(form_document.form_id, form_document.form_slug, step_slug)
           end
 
           it "displays a success banner" do
@@ -160,7 +160,7 @@ RSpec.describe Forms::RemoveFileController, type: :request do
             let(:changing_existing_answer) { true }
 
             it "redirects to the change answer route" do
-              expect(response).to redirect_to form_change_answer_path(form_data.form_id, form_data.form_slug, step_slug)
+              expect(response).to redirect_to form_change_answer_path(form_document.form_id, form_document.form_slug, step_slug)
             end
           end
         end
@@ -169,11 +169,11 @@ RSpec.describe Forms::RemoveFileController, type: :request do
           let(:uploaded_file_key) { nil }
 
           it "does not remove the answer from the session" do
-            expect(store[:answers][form_data.form_id.to_s]).to have_key step_slug
+            expect(store[:answers][form_document.form_id.to_s]).to have_key step_slug
           end
 
           it "redirects to the show page route" do
-            expect(response).to redirect_to form_step_path(form_data.form_id, form_data.form_slug, step_slug)
+            expect(response).to redirect_to form_step_path(form_document.form_id, form_document.form_slug, step_slug)
           end
         end
       end
@@ -186,11 +186,11 @@ RSpec.describe Forms::RemoveFileController, type: :request do
         end
 
         it "does not remove the answer from the session" do
-          expect(store[:answers][form_data.form_id.to_s]).to have_key step_slug
+          expect(store[:answers][form_document.form_id.to_s]).to have_key step_slug
         end
 
         it "redirects to the review file page route" do
-          expect(response).to redirect_to review_file_path(form_data.form_id, form_data.form_slug, step_slug, changing_existing_answer:)
+          expect(response).to redirect_to review_file_path(form_document.form_id, form_document.form_slug, step_slug, changing_existing_answer:)
         end
       end
     end
@@ -200,7 +200,7 @@ RSpec.describe Forms::RemoveFileController, type: :request do
       let(:store) do
         {
           answers: {
-            form_data.form_id.to_s => {
+            form_document.form_id.to_s => {
               text_question_step.id.to_s => {
                 "text" => "foo",
               },
@@ -210,11 +210,11 @@ RSpec.describe Forms::RemoveFileController, type: :request do
       end
 
       it "does not remove the answer from the session" do
-        expect(store[:answers][form_data.form_id.to_s]).to have_key step_slug
+        expect(store[:answers][form_document.form_id.to_s]).to have_key step_slug
       end
 
       it "redirects to the show page route" do
-        expect(response).to redirect_to form_step_path(form_data.form_id, form_data.form_slug, step_slug)
+        expect(response).to redirect_to form_step_path(form_document.form_id, form_document.form_slug, step_slug)
       end
     end
   end

--- a/spec/requests/forms/review_file_controller_spec.rb
+++ b/spec/requests/forms/review_file_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Forms::ReviewFileController, type: :request do
     end
 
     allow(Flow::Context).to receive(:new).and_wrap_original do |original_method, *args|
-      context_spy = original_method.call(form: args[0][:form], store:)
+      context_spy = original_method.call(form: args[0][:form], form_document: args[0][:form_document], store:)
       context_spy
     end
   end

--- a/spec/requests/forms/selection_none_of_the_above_controller_spec.rb
+++ b/spec/requests/forms/selection_none_of_the_above_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Forms::SelectionNoneOfTheAboveController, type: :request do
     end
 
     allow(Flow::Context).to receive(:new).and_wrap_original do |original_method, *args|
-      context_spy = original_method.call(form: args[0][:form], store:)
+      context_spy = original_method.call(form: args[0][:form], form_document: args[0][:form_document], store:)
       context_spy
     end
   end

--- a/spec/requests/forms/step_controller_spec.rb
+++ b/spec/requests/forms/step_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
           is_optional:
   end
 
-  let(:page_with_routing) do
+  let(:step_with_routing) do
     build :v2_selection_question_step,
           id: first_step_id,
           next_step_id: 2,
@@ -284,7 +284,7 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
 
     context "when page has routing conditions" do
       let(:first_step_in_form) do
-        page_with_routing
+        step_with_routing
       end
 
       let(:validation_errors) { [] }
@@ -404,7 +404,7 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
 
       before do
         allow(Flow::Context).to receive(:new).and_wrap_original do |original_method, *args|
-          context_spy = original_method.call(form: args[0][:form], store:)
+          context_spy = original_method.call(form: args[0][:form], form_document: args[0][:form_document], store:)
           context_spy
         end
         get form_step_path(mode:, form_id: 2, form_slug: form_data.form_slug, step_slug: first_step_id)
@@ -519,7 +519,7 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
 
     context "when page has routing conditions" do
       let(:first_step_in_form) do
-        page_with_routing
+        step_with_routing
       end
 
       let(:validation_errors) { [] }
@@ -639,7 +639,7 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
 
       before do
         allow(Flow::Context).to receive(:new).and_wrap_original do |original_method, *args|
-          context_spy = original_method.call(form: args[0][:form], store:)
+          context_spy = original_method.call(form: args[0][:form], form_document: args[0][:form_document], store:)
           context_spy
         end
         get form_step_path(mode:, form_id: 2, form_slug: form_data.form_slug, step_slug: first_step_id)
@@ -819,7 +819,7 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
 
     context "when page has routing conditions" do
       let(:first_step_in_form) do
-        page_with_routing
+        step_with_routing
       end
 
       let(:validation_errors) { [] }

--- a/spec/requests/forms/step_controller_spec.rb
+++ b/spec/requests/forms/step_controller_spec.rb
@@ -302,13 +302,10 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
               is_optional:
       end
 
-      let(:pages_data) { [third_step_in_form, first_step_in_form, second_step_in_form] }
-
       let(:api_url_suffix) { "/draft" }
       let(:mode) { "preview-draft" }
 
       context "when the routing has a cannot_have_goto_page_before_routing_page error" do
-        let(:pages_data) { [first_step_in_form, second_step_in_form, third_step_in_form] }
         let(:validation_errors) { [{ name: "cannot_have_goto_page_before_routing_page" }] }
 
         it "returns a 422 response" do
@@ -355,7 +352,6 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
       end
 
       context "when the routing has a goto_page which does not exist" do
-        let(:pages_data) { [first_step_in_form, second_step_in_form, third_step_in_form] }
         let(:validation_errors) { [{ name: "goto_page_doesnt_exist" }] }
 
         it "returns a 422 response" do
@@ -537,13 +533,10 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
               is_optional:
       end
 
-      let(:pages_data) { [third_step_in_form, first_step_in_form, second_step_in_form] }
-
       let(:api_url_suffix) { "/draft" }
       let(:mode) { "preview-draft" }
 
       context "when the routing has a cannot_have_goto_page_before_routing_page error" do
-        let(:pages_data) { [first_step_in_form, second_step_in_form, third_step_in_form] }
         let(:validation_errors) { [{ name: "cannot_have_goto_page_before_routing_page" }] }
 
         it "returns a 422 response" do
@@ -590,7 +583,6 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
       end
 
       context "when the routing has a goto_page which does not exist" do
-        let(:pages_data) { [first_step_in_form, second_step_in_form, third_step_in_form] }
         let(:validation_errors) { [{ name: "goto_page_doesnt_exist" }] }
 
         it "returns a 422 response" do
@@ -837,8 +829,6 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
               is_optional:
       end
 
-      let(:pages_data) { [first_step_in_form, second_step_in_form, third_step_in_form] }
-
       let(:api_url_suffix) { "/draft" }
       let(:mode) { "preview-draft" }
 
@@ -855,7 +845,6 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
       end
 
       context "when the routing has a cannot_have_goto_page_before_routing_page error" do
-        let(:pages_data) { [first_step_in_form, second_step_in_form, third_step_in_form] }
         let(:validation_errors) { [{ name: "cannot_have_goto_page_before_routing_page" }] }
 
         it "returns a 422 response" do

--- a/spec/resources/api/v2/form_document_resource_spec.rb
+++ b/spec/resources/api/v2/form_document_resource_spec.rb
@@ -196,4 +196,11 @@ RSpec.describe Api::V2::FormDocumentResource do
       end
     end
   end
+
+  describe "#as_json" do
+    it "returns a hash of the form document's attributes as read from the API" do
+      form_document = described_class.find(1, :live)
+      expect(form_document.as_json).to eq JSON.parse(response_data)
+    end
+  end
 end

--- a/spec/services/api/v2/form_document_repository_spec.rb
+++ b/spec/services/api/v2/form_document_repository_spec.rb
@@ -22,23 +22,17 @@ RSpec.describe Api::V2::FormDocumentRepository do
       end
     end
 
-    it "returns a form" do
+    it "returns form document" do
       form = described_class.find(tag:, form_id:)
 
       expect(form).to have_attributes(form_id:, name: "All question types form")
     end
 
-    it "attaches the form document JSON to the form" do
-      form = described_class.find(tag:, form_id:)
-
-      expect(form.document_json).to eq api_v2_response_data
-    end
-
     context "with the archived tag" do
       let(:tag) { :archived }
 
-      context "when a form has been archived" do
-        it "returns an archived form" do
+      context "when form has been archived" do
+        it "returns an archived form document" do
           form = described_class.find(tag: :archived, form_id: form_id)
 
           expect(form).to have_attributes(form_id: form_id, name: "All question types form")
@@ -116,14 +110,14 @@ RSpec.describe Api::V2::FormDocumentRepository do
       end
     end
 
-    it "finds a form snapshot given a form id and document tag" do
+    it "finds a form document given a form id and document tag" do
       expect(described_class.find_with_mode(form_id: 1, mode: Mode.new("preview-draft"))).to be_truthy
     end
 
-    it "returns a form model" do
+    it "returns a FormDocumentResource model" do
       form_snapshot = described_class.find_with_mode(form_id: 1, mode: Mode.new("preview-draft"))
-      expect(form_snapshot).to be_a Form
-      expect(form_snapshot.form_document_steps).to all be_a Api::V2::StepResource
+      expect(form_snapshot).to be_a Api::V2::FormDocumentResource
+      expect(form_snapshot.steps).to all be_a Api::V2::StepResource
     end
 
     it "returns nil if the form does not exist" do
@@ -185,9 +179,9 @@ RSpec.describe Api::V2::FormDocumentRepository do
         end
       end
 
-      it "returns Welsh form model" do
+      it "returns Welsh form document" do
         form = described_class.find_with_mode(form_id: "1", mode: Mode.new("live"), language: :cy)
-        expect(form).to have_attributes(form_id: "1", name: "Welsh form", language: :cy)
+        expect(form).to have_attributes(form_id: "1", name: "Welsh form", language: "cy")
       end
     end
   end

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe FormSubmissionService, :capture_logging do
   let(:mode) { Mode.new }
   let(:confirmation_email_address) { "testing@gov.uk" }
   let(:email_confirmation_input) { build :email_confirmation_input_opted_in, confirmation_email_address: }
-  let(:form) { Form.new(form_document, document_json) }
-  let(:welsh_form) { Form.new(welsh_form_document, welsh_document_json) }
+  let(:form) { Form.new(form_document) }
+  let(:welsh_form) { Form.new(welsh_form_document) }
 
   let(:form_document) do
     build(


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/02H0xEqG

The intention behind this PR is to only consume `Api::V2::StepResources` when we need them to construct `Step` models. In all other places in the code, we should use the `Step` or `QuestionBase` models to get information about steps, in order to decouple from the API and make it easier to make changes to the API in future.

To achieve this, construct the `Journey` using a `Api::V2::FormDocumentResource` so that we don't need to expose the `Api::V2::StepResources` via the `Form` model. Whenever we need to access steps in other areas of the code, get them from the `Journey`.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
