### PR TITLE
Stop supporting unencrypted submission answers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -87,11 +87,6 @@ module FormsRunner
     # Prevent ActiveRecord::PreparedStatementCacheExpired errors when adding columns
     config.active_record.enumerate_columns_in_select_statements = true
 
-    # TODO: remove this when all sensitive data is encrypted
-    # https://trello.com/c/MXv9NJuX/3459-stop-supporting-unencrypted-data-in-forms-runner
-    # See https://guides.rubyonrails.org/active_record_encryption.html#support-for-unencrypted-data
-    config.active_record.encryption.support_unencrypted_data = true
-
     I18n.available_locales = %i[en cy]
     I18n.default_locale = :en
   end


### PR DESCRIPTION
### What problem does this pull request solve?

All retained submission data should now be encrypted, so remove the temporary Active Record setting that allowed plaintext answers to coexist during the rollout.

Trello card: https://trello.com/c/MXv9NJuX/3459-stop-supporting-unencrypted-data-in-forms-runner
