### PR TITLE
Bump vite_ruby and dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,10 @@ updates:
       sentry:
         patterns:
           - "sentry-*"
+      vite_ruby:
+        patterns:
+          - "vite_rails"
+          - "vite_ruby"
 
   # Maintain dependencies for npm
   - package-ecosystem: npm

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -711,7 +711,7 @@ GEM
     vite_rails (3.0.20)
       railties (>= 5.1, < 9)
       vite_ruby (~> 3.0, >= 3.2.2)
-    vite_ruby (3.9.3)
+    vite_ruby (3.10.2)
       dry-cli (>= 0.7, < 2)
       logger (~> 1.6)
       mutex_m
@@ -1037,7 +1037,7 @@ CHECKSUMS
   view_component (4.2.0) sha256=f250a3397a794336354f73c229b3b7549af0b24906551b99a03492b54cb5233d
   virtus (2.0.0) sha256=8841dae4eb7fcc097320ba5ea516bf1839e5d056c61ee27138aa4bddd6e3d1c2
   vite_rails (3.0.20) sha256=582bf9aa3bc3b4d9b0a48c17862b4fa9bd17384ac597a57b7a38d2f95d96e682
-  vite_ruby (3.9.3) sha256=560afb7dc01eb1fb2349c21b02e206f016ef7d59075daf00510caaf459b04a13
+  vite_ruby (3.10.2) sha256=db465451eb180abbdc81f596ba63671d2b2552e2bb7bf3c1f7b79f9d58ca9a86
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -708,7 +708,7 @@ GEM
       axiom-types (~> 0.1)
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
-    vite_rails (3.0.20)
+    vite_rails (3.10.0)
       railties (>= 5.1, < 9)
       vite_ruby (~> 3.0, >= 3.2.2)
     vite_ruby (3.10.2)
@@ -1036,7 +1036,7 @@ CHECKSUMS
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   view_component (4.2.0) sha256=f250a3397a794336354f73c229b3b7549af0b24906551b99a03492b54cb5233d
   virtus (2.0.0) sha256=8841dae4eb7fcc097320ba5ea516bf1839e5d056c61ee27138aa4bddd6e3d1c2
-  vite_rails (3.0.20) sha256=582bf9aa3bc3b4d9b0a48c17862b4fa9bd17384ac597a57b7a38d2f95d96e682
+  vite_rails (3.10.0) sha256=8c4471554870c043e8d9ff7d379302a01d147ade2cd61476ddf020fed32a107a
   vite_ruby (3.10.2) sha256=db465451eb180abbdc81f596ba63671d2b2552e2bb7bf3c1f7b79f9d58ca9a86
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "stylelint": "^16.26.1",
         "stylelint-config-gds": "^2.0.0",
         "vite": "^7.3.1",
-        "vite-plugin-ruby": "^5.1.3",
+        "vite-plugin-ruby": "^5.2.1",
         "vitest": "^4.1.2"
       }
     },
@@ -7131,14 +7131,14 @@
       }
     },
     "node_modules/vite-plugin-ruby": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-ruby/-/vite-plugin-ruby-5.1.3.tgz",
-      "integrity": "sha512-vpTOKbR6AmnupmXvQccRcr/jIY+oobNuCbNJHUzkT8oQ2BBQSlp22Xec3zszBBc7GjwDGn2+E+IQoNRXdEY7Ig==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-ruby/-/vite-plugin-ruby-5.2.1.tgz",
+      "integrity": "sha512-wI3F/Yr4e4mEwiMff/cvNwGu8nZok5wrwUjHxO8we+h3y9+qCluO3Y5dzvz6vHJDBya9fKXkltoMwoJhaB2SRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2"
+        "obug": "^2.0",
+        "tinyglobby": "^0.2.12"
       },
       "peerDependencies": {
         "vite": ">=5.0.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "stylelint": "^16.26.1",
     "stylelint-config-gds": "^2.0.0",
     "vite": "^7.3.1",
-    "vite-plugin-ruby": "^5.1.3",
+    "vite-plugin-ruby": "^5.2.1",
     "vitest": "^4.1.2"
   },
   "dependencies": {


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This PR rolls a bunch of Dependabot PRs bumping packages for Vite Ruby into one, as they need to be bumped together.

- **Bump vite_ruby from 3.9.3 to 3.10.2**
- **Bump vite_rails from 3.0.20 to 3.10.0**
- **Bump vite-plugin-ruby from 5.1.3 to 5.2.1**

This PR also adds a Dependabot group to try and make it work better in future... I'm not hopeful though as Dependabot doesn't seem to have groups across package ecosystems (see https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#grouping-related-dependencies-together), so it's only possible to have a group for `vite_ruby` and `vite_rails`, which are both Ruby gems, but they can't also be in a group with `vite-plugin-ruby`, which is an NPM package.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
