### PR TITLE
Add start-stop logs to rake tasks

### DIFF
--- a/app/lib/application_logger.rb
+++ b/app/lib/application_logger.rb
@@ -36,6 +36,7 @@ private
         .merge(attribs || {})
         .merge(CurrentRequestLoggingAttributes.as_hash)
         .merge(CurrentJobLoggingAttributes.as_hash)
+        .merge(CurrentTaskLoggingAttributes.as_hash)
         .compact
     rescue NameError
       # if we log during startup for tests, CurrentLoggingAttributes will be uninitialized

--- a/app/models/current_task_logging_attributes.rb
+++ b/app/models/current_task_logging_attributes.rb
@@ -1,0 +1,9 @@
+class CurrentTaskLoggingAttributes < ActiveSupport::CurrentAttributes
+  attribute :task_name
+
+  def as_hash
+    {
+      task_name:,
+    }.compact_blank
+  end
+end

--- a/lib/tasks/logging.rake
+++ b/lib/tasks/logging.rake
@@ -1,0 +1,43 @@
+require "English"
+
+Rake::Task.define_task(:environment).enhance do
+  task_finished_normally = false
+
+  at_exit do
+    unless task_finished_normally
+      exit_cause = $ERROR_INFO ? $ERROR_INFO.class.name : "Signal or exit"
+
+      Rails.logger.error "Task terminated early", {
+        task: Rake.application.top_level_tasks.first,
+        exit_cause:,
+      }
+    end
+  end
+
+  Rake.application.top_level_tasks.each do |task_name|
+    task_name_clean = task_name.gsub(/\[.*\]$/, "")
+    next unless Rake::Task.task_defined?(task_name_clean)
+
+    task = Rake::Task[task_name_clean]
+    original_actions = task.actions.dup
+    task.actions.clear
+
+    task.enhance do |t, args|
+      CurrentTaskLoggingAttributes.task_name = task_name_clean
+      Rails.logger.info "Task started", { args: args.to_a }
+
+      begin
+        original_actions.each { |action| action.call(t, args) }
+        Rails.logger.info "Task finished"
+      rescue SystemExit => e
+        Rails.logger.error "Task aborted", { exit_message: e.message }
+        raise e
+      rescue StandardError => e
+        Rails.logger.error "Task failed", { exception: [e.class.name, e.message] }
+        raise e
+      ensure
+        task_finished_normally = true
+      end
+    end
+  end
+end

--- a/spec/lib/application_logger_spec.rb
+++ b/spec/lib/application_logger_spec.rb
@@ -20,6 +20,25 @@ RSpec.describe ApplicationLogger, :capture_logging do
     end
   end
 
+  context "when CurrentTaskLoggingAttributes has attributes set" do
+    before do
+      CurrentTaskLoggingAttributes.task_name = "task:example"
+      logger.info("A message")
+    end
+
+    it "includes the message as a field" do
+      expect(log_line["message"]).to eq "A message"
+    end
+
+    it "includes attributes with values on the log line" do
+      expect(log_line["task_name"]).to eq "task:example"
+    end
+
+    it "does not include attributes without values on the log line" do
+      expect(log_line.keys).not_to include "user_id"
+    end
+  end
+
   context "when a hash is passed as an argument" do
     before do
       CurrentRequestLoggingAttributes.request_id = "a-request-id"

--- a/spec/lib/tasks/logging.rake_spec.rb
+++ b/spec/lib/tasks/logging.rake_spec.rb
@@ -1,0 +1,72 @@
+require "rake"
+require "rails_helper"
+
+RSpec.describe "Logging Rake Tasks" do
+  let(:rake) { Rake::Application.new }
+
+  before do
+    Rake.application = rake
+
+    Rake::Task.define_task(:environment)
+    my_task
+
+    allow(rake).to receive(:top_level_tasks).and_return(%w[my_task])
+
+    load Rails.root.join("lib/tasks/logging.rake")
+
+    rake["environment"].invoke
+  end
+
+  context "when the task runs successfully" do
+    let(:my_task) { Rake::Task.define_task(my_task: :environment) }
+
+    it "logs when the task starts and finishes" do
+      expect(Rails.logger).to receive(:info).with("Task started", hash_including(:args))
+
+      expect(Rails.logger).to receive(:info).with("Task finished")
+
+      rake["my_task"].invoke
+    end
+
+    it "logs the arguments passed in to the task" do
+      expect(Rails.logger).to receive(:info).with("Task started", hash_including(args: %w[arg1 arg2]))
+
+      allow(Rails.logger).to receive(:info).with("Task finished")
+
+      rake["my_task"].invoke("arg1", "arg2")
+    end
+  end
+
+  context "when the task raises an error" do
+    let(:my_task) do
+      Rake::Task.define_task(my_task: :environment) do
+        raise StandardError, "Something went wrong"
+      end
+    end
+
+    it "logs an error with the exception" do
+      allow(Rails.logger).to receive(:info).with("Task started", hash_including(:args))
+      expect(Rails.logger).to receive(:error).with(
+        "Task failed",
+        { exception: ["StandardError", "Something went wrong"] },
+      )
+
+      expect { rake["my_task"].invoke }.to raise_error(StandardError, "Something went wrong")
+    end
+  end
+
+  context "when the task is aborted with SystemExit" do
+    let(:my_task) do
+      Rake::Task.define_task(my_task: :environment) do
+        raise SystemExit.new(0, "exit")
+      end
+    end
+
+    it "logs an error with the exit message" do
+      allow(Rails.logger).to receive(:info).with("Task started", hash_including(:args))
+      expect(Rails.logger).to receive(:error).with("Task aborted", { exit_message: "exit" })
+
+      expect { rake["my_task"].invoke }.to output(/exit/).to_stderr
+    end
+  end
+end


### PR DESCRIPTION
This adds a task that wraps around all existing rake tasks. It will log details about the task before it executes, and then again logs information when the task resolves.

Depending on how the task resolves, different logs are sent. If the task exits early or raises an error, the error message will be sent to the logs.

### What problem does this pull request solve?

https://trello.com/c/cyOMbfi4/2924-finishing-the-rake-task-logging-from-firebreak

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
