### PR TITLE
Fix tests being skipped by Rake tasks aborting (and hopefully prevent same in future)

### DIFF
--- a/app/lib/application_logger.rb
+++ b/app/lib/application_logger.rb
@@ -36,6 +36,7 @@ private
         .merge(attribs || {})
         .merge(CurrentRequestLoggingAttributes.as_hash)
         .merge(CurrentJobLoggingAttributes.as_hash)
+        .merge(CurrentTaskLoggingAttributes.as_hash)
         .compact
     rescue NameError
       # if we log during startup for tests, CurrentLoggingAttributes will be uninitialized

--- a/app/models/current_task_logging_attributes.rb
+++ b/app/models/current_task_logging_attributes.rb
@@ -1,0 +1,9 @@
+class CurrentTaskLoggingAttributes < ActiveSupport::CurrentAttributes
+  attribute :task_name
+
+  def as_hash
+    {
+      task_name:,
+    }.compact_blank
+  end
+end

--- a/lib/tasks/logging.rake
+++ b/lib/tasks/logging.rake
@@ -1,0 +1,43 @@
+require "English"
+
+Rake::Task.define_task(:environment).enhance do
+  task_finished_normally = false
+
+  at_exit do
+    unless task_finished_normally
+      exit_cause = $ERROR_INFO ? $ERROR_INFO.class.name : "Signal or exit"
+
+      Rails.logger.error "Task terminated early", {
+        task: Rake.application.top_level_tasks.first,
+        exit_cause:,
+      }
+    end
+  end
+
+  Rake.application.top_level_tasks.each do |task_name|
+    task_name_clean = task_name.gsub(/\[.*\]$/, "")
+    next unless Rake::Task.task_defined?(task_name_clean)
+
+    task = Rake::Task[task_name_clean]
+    original_actions = task.actions.dup
+    task.actions.clear
+
+    task.enhance do |t, args|
+      CurrentTaskLoggingAttributes.task_name = task_name_clean
+      Rails.logger.info "Task started", { args: args.to_a }
+
+      begin
+        original_actions.each { |action| action.call(t, args) }
+        Rails.logger.info "Task finished"
+      rescue SystemExit => e
+        Rails.logger.error "Task aborted", { exit_message: e.message }
+        raise e
+      rescue StandardError => e
+        Rails.logger.error "Task failed", { exception: [e.class.name, e.message] }
+        raise e
+      ensure
+        task_finished_normally = true
+      end
+    end
+  end
+end

--- a/spec/lib/application_logger_spec.rb
+++ b/spec/lib/application_logger_spec.rb
@@ -20,6 +20,25 @@ RSpec.describe ApplicationLogger, :capture_logging do
     end
   end
 
+  context "when CurrentTaskLoggingAttributes has attributes set" do
+    before do
+      CurrentTaskLoggingAttributes.task_name = "task:example"
+      logger.info("A message")
+    end
+
+    it "includes the message as a field" do
+      expect(log_line["message"]).to eq "A message"
+    end
+
+    it "includes attributes with values on the log line" do
+      expect(log_line["task_name"]).to eq "task:example"
+    end
+
+    it "does not include attributes without values on the log line" do
+      expect(log_line.keys).not_to include "user_id"
+    end
+  end
+
   context "when a hash is passed as an argument" do
     before do
       CurrentRequestLoggingAttributes.request_id = "a-request-id"

--- a/spec/lib/tasks/jobs.rake_spec.rb
+++ b/spec/lib/tasks/jobs.rake_spec.rb
@@ -1,18 +1,11 @@
-require "rake"
 require "rails_helper"
 
-RSpec.describe "jobs.rake" do
+RSpec.describe "jobs.rake", type: :task do
   include ActiveJob::TestHelper
-
-  before do
-    Rake.application.rake_require "tasks/jobs"
-    Rake::Task.define_task(:environment)
-  end
 
   describe "jobs:retry_failed" do
     subject(:task) do
       Rake::Task["jobs:retry_failed"]
-        .tap(&:reenable)
     end
 
     # If a job is retried, there are multiple jobs with the same active_job_id but the failed execution is only
@@ -75,7 +68,6 @@ RSpec.describe "jobs.rake" do
   describe "jobs:delete_failed" do
     subject(:task) do
       Rake::Task["jobs:delete_failed"]
-        .tap(&:reenable)
     end
 
     # If a job is retried, there are multiple jobs with the same active_job_id but the failed execution is only
@@ -149,7 +141,6 @@ RSpec.describe "jobs.rake" do
   describe "jobs:retry_all_failed" do
     subject(:task) do
       Rake::Task["jobs:retry_all_failed"]
-        .tap(&:reenable)
     end
 
     let(:failed_job) { create :solid_queue_job, class_name: SendSubmissionJob.name }
@@ -191,7 +182,6 @@ RSpec.describe "jobs.rake" do
   describe "jobs:list_failed" do
     subject(:task) do
       Rake::Task["jobs:list_failed"]
-        .tap(&:reenable)
     end
 
     let(:queue_name) { "queue-1" }

--- a/spec/lib/tasks/logging.rake_spec.rb
+++ b/spec/lib/tasks/logging.rake_spec.rb
@@ -1,0 +1,72 @@
+require "rake"
+require "rails_helper"
+
+RSpec.describe "Logging Rake Tasks" do
+  let(:rake) { Rake::Application.new }
+
+  before do
+    Rake.application = rake
+
+    Rake::Task.define_task(:environment)
+    my_task
+
+    allow(rake).to receive(:top_level_tasks).and_return(%w[my_task])
+
+    load Rails.root.join("lib/tasks/logging.rake")
+
+    rake["environment"].invoke
+  end
+
+  context "when the task runs successfully" do
+    let(:my_task) { Rake::Task.define_task(my_task: :environment) }
+
+    it "logs when the task starts and finishes" do
+      expect(Rails.logger).to receive(:info).with("Task started", hash_including(:args))
+
+      expect(Rails.logger).to receive(:info).with("Task finished")
+
+      rake["my_task"].invoke
+    end
+
+    it "logs the arguments passed in to the task" do
+      expect(Rails.logger).to receive(:info).with("Task started", hash_including(args: %w[arg1 arg2]))
+
+      allow(Rails.logger).to receive(:info).with("Task finished")
+
+      rake["my_task"].invoke("arg1", "arg2")
+    end
+  end
+
+  context "when the task raises an error" do
+    let(:my_task) do
+      Rake::Task.define_task(my_task: :environment) do
+        raise StandardError, "Something went wrong"
+      end
+    end
+
+    it "logs an error with the exception" do
+      allow(Rails.logger).to receive(:info).with("Task started", hash_including(:args))
+      expect(Rails.logger).to receive(:error).with(
+        "Task failed",
+        { exception: ["StandardError", "Something went wrong"] },
+      )
+
+      expect { rake["my_task"].invoke }.to raise_error(StandardError, "Something went wrong")
+    end
+  end
+
+  context "when the task is aborted with SystemExit" do
+    let(:my_task) do
+      Rake::Task.define_task(my_task: :environment) do
+        raise SystemExit.new(0, "exit")
+      end
+    end
+
+    it "logs an error with the exit message" do
+      allow(Rails.logger).to receive(:info).with("Task started", hash_including(:args))
+      expect(Rails.logger).to receive(:error).with("Task aborted", { exit_message: "exit" })
+
+      expect { rake["my_task"].invoke }.to output(/exit/).to_stderr
+    end
+  end
+end

--- a/spec/lib/tasks/logging.rake_spec.rb
+++ b/spec/lib/tasks/logging.rake_spec.rb
@@ -1,13 +1,9 @@
-require "rake"
 require "rails_helper"
 
-RSpec.describe "Logging Rake Tasks" do
-  let(:rake) { Rake::Application.new }
+RSpec.describe "Logging Rake Tasks", rakefile: false, type: :task do
+  let(:rake) { Rake.application }
 
   before do
-    Rake.application = rake
-
-    Rake::Task.define_task(:environment)
     my_task
 
     allow(rake).to receive(:top_level_tasks).and_return(%w[my_task])

--- a/spec/lib/tasks/logging.rake_spec.rb
+++ b/spec/lib/tasks/logging.rake_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Logging Rake Tasks", rakefile: false, type: :task do
   context "when the task is aborted with SystemExit" do
     let(:my_task) do
       Rake::Task.define_task(my_task: :environment) do
-        raise SystemExit.new(0, "exit")
+        abort "exit" # rubocop:disable Rails/Exit
       end
     end
 
@@ -62,7 +62,9 @@ RSpec.describe "Logging Rake Tasks", rakefile: false, type: :task do
       allow(Rails.logger).to receive(:info).with("Task started", hash_including(:args))
       expect(Rails.logger).to receive(:error).with("Task aborted", { exit_message: "exit" })
 
-      expect { rake["my_task"].invoke }.to output(/exit/).to_stderr
+      expect { rake["my_task"].invoke }
+        .to raise_error(SystemExit)
+        .and output(/exit/).to_stderr
     end
   end
 end

--- a/spec/lib/tasks/submissions.rake_spec.rb
+++ b/spec/lib/tasks/submissions.rake_spec.rb
@@ -1,18 +1,11 @@
-require "rake"
 require "rails_helper"
 
-RSpec.describe "submissions.rake" do
+RSpec.describe "submissions.rake", type: :task do
   include ActiveJob::TestHelper
-
-  before do
-    Rake.application.rake_require "tasks/submissions"
-    Rake::Task.define_task(:environment)
-  end
 
   describe "submissions:inspect_submission_data" do
     subject(:task) do
       Rake::Task["submissions:inspect_submission_data"]
-        .tap(&:reenable)
     end
 
     let(:form_document) { build :v2_form_document, :with_steps }
@@ -49,7 +42,6 @@ RSpec.describe "submissions.rake" do
   describe "submissions:check_delivery_statuses" do
     subject(:task) do
       Rake::Task["submissions:check_delivery_statuses"]
-        .tap(&:reenable)
     end
 
     before do
@@ -71,7 +63,6 @@ RSpec.describe "submissions.rake" do
   describe "submissions:list_bounced_submissions_for_form" do
     subject(:task) do
       Rake::Task["submissions:list_bounced_submissions_for_form"]
-        .tap(&:reenable)
     end
 
     let(:form_id) { 42 }
@@ -100,7 +91,6 @@ RSpec.describe "submissions.rake" do
   describe "submissions:retry_bounced_deliveries" do
     subject(:task) do
       Rake::Task["submissions:retry_bounced_deliveries"]
-        .tap(&:reenable)
     end
 
     let(:form_id) { 1 }
@@ -179,7 +169,6 @@ RSpec.describe "submissions.rake" do
   describe "submissions:disregard_bounced_delivery" do
     subject(:task) do
       Rake::Task["submissions:disregard_bounced_delivery"]
-        .tap(&:reenable)
     end
 
     let(:delivery_reference) { "delivery-reference" }
@@ -263,7 +252,6 @@ RSpec.describe "submissions.rake" do
   describe "submissions:disregard_bounced_deliveries_for_form" do
     subject(:task) do
       Rake::Task["submissions:disregard_bounced_deliveries_for_form"]
-        .tap(&:reenable)
     end
 
     let(:form_id) { 1 }
@@ -412,7 +400,6 @@ RSpec.describe "submissions.rake" do
   describe "submissions:redeliver_submissions_by_date" do
     subject(:task) do
       Rake::Task["submissions:redeliver_submissions_by_date"]
-        .tap(&:reenable)
     end
 
     let(:form_id) { 1 }
@@ -556,7 +543,6 @@ RSpec.describe "submissions.rake" do
   describe "submissions:redeliver_batches_by_date" do
     subject(:task) do
       Rake::Task["submissions:redeliver_batches_by_date"]
-        .tap(&:reenable)
     end
 
     let(:form_id) { 1 }
@@ -737,7 +723,6 @@ RSpec.describe "submissions.rake" do
   describe "submissions:file_answers:fix_missing_original_filenames" do
     subject(:task) do
       Rake::Task["submissions:file_answers:fix_missing_original_filenames"]
-        .tap(&:reenable)
     end
 
     let(:submission) do

--- a/spec/support/rake_task_helpers.rb
+++ b/spec/support/rake_task_helpers.rb
@@ -1,0 +1,37 @@
+require "rake"
+
+module RakeTaskHelpers
+  class UnexpectedSystemExit < StandardError; end
+
+  def self.included(base)
+    base.class_eval do
+      before do
+        metadata = self.class.metadata
+        rakefile = metadata.include?(:rakefile) ? metadata[:rakefile] : self.class.top_level_description
+
+        Rake.application = Rake::Application.new
+        Rake.load_rakefile("lib/tasks/#{rakefile}") if rakefile
+
+        Rake::Task.define_task(:environment)
+      end
+
+      around do |example|
+        example.run
+      rescue SystemExit => e
+        message = <<~MSG
+          SystemExit raised but not expected in this example
+
+          This may be because a task was invoked that calls `abort`.
+          If the task was supposed to abort in this example, make
+          sure to expect the SystemExit exception with
+          `expect { }.to raise_error(SystemExit)`.
+        MSG
+        raise UnexpectedSystemExit, message, e.backtrace, cause: e
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include RakeTaskHelpers, type: :task
+end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We had an issue recently where tests were being silently skipped in CI because a test added in PR #2045 was raising SystemExit and not catching it, and we had to revert that PR.

This PR restores the changes in that PR, adds a guard to try and catch similar issues in future (where Rake tasks call `abort` in specs and it's not `expect`ed), and fixes the (now) failing tests that caused the problems before.

We also refactor the way we write Rake task specs a bit to reduce boilerplate, and hopefully make it easier to write them (as well as safer).

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
