### PR TITLE
Allow routing to work with multiple conditions

### DIFF
--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -86,8 +86,8 @@ class Step
       return goto_condition_step_slug(routing_conditions.first)
     end
 
-    if first_condition_matches?
-      return goto_condition_step_slug(routing_conditions.first)
+    if (matching_condition = find_matching_condition)
+      return goto_condition_step_slug(matching_condition)
     end
 
     next_step_slug
@@ -141,19 +141,25 @@ private
     end
   end
 
+  def find_matching_condition
+    return unless question.respond_to?(:selection)
+
+    routing_conditions.find { condition_matches? it }
+  end
+
+  def condition_matches?(condition)
+    return question.selection == I18n.t("page.none_of_the_above") if condition.answer_value == :none_of_the_above.to_s
+
+    condition.answer_value == question.selection
+  end
+
   def first_condition_matches?
     return unless question.respond_to?(:selection)
 
-    return question.selection == I18n.t("page.none_of_the_above") if routing_condition_none_of_the_above
-
-    routing_conditions.any? && (routing_conditions.first.answer_value == question.selection)
+    routing_conditions.any? && condition_matches?(routing_conditions.first)
   end
 
   def first_condition_default?
     routing_conditions.any? && routing_conditions.first.answer_value.blank?
-  end
-
-  def routing_condition_none_of_the_above
-    routing_conditions.any? && routing_conditions.first.answer_value == :none_of_the_above.to_s
   end
 end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -127,11 +127,11 @@ RSpec.describe Step do
   end
 
   describe "#next_step_slug_after_routing" do
-    let(:default_next_step_id) { second_step_id }
+    let(:default_next_step_id) { "11111111" } # dummy value to make the default next step ID obvious when it appears
     let(:selection) { "Yes" }
     let(:question) { instance_double(Question::Selection, selection:) }
     let(:routing_conditions) { [] }
-    let(:form_document_step) { build(:v2_question_step, id: first_step_id, position: 1, next_step_id: default_next_step_id, routing_conditions:) }
+    let(:form_document_step) { build(:v2_question_step, id: "00000000", position: 1, next_step_id: default_next_step_id, routing_conditions:) }
 
     describe "basic routing" do
       context "without any routing conditions" do

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -224,46 +224,58 @@ RSpec.describe Step do
       end
     end
 
-    describe "with invalid states" do
-      context "with multiple conditions and second matches" do
-        let(:routing_conditions) do
-          [
-            OpenStruct.new(answer_value: "No", goto_page_id: first_step_id),
-            OpenStruct.new(answer_value: "Yes", goto_page_id: second_step_id),
-            OpenStruct.new(answer_value: "Maybe", goto_page_id: third_step_id),
-          ]
+    context "with multiple conditions" do
+      let(:routing_conditions) do
+        [
+          OpenStruct.new(answer_value: "No", goto_page_id: first_step_id),
+          OpenStruct.new(answer_value: "Yes", goto_page_id: second_step_id),
+          OpenStruct.new(answer_value: "Maybe", goto_page_id: third_step_id),
+        ]
+      end
+
+      context "and first matches" do
+        let(:selection) { "No" }
+
+        it "returns the next_step_slug" do
+          expect(step.next_step_slug_after_routing).to eq(first_step_id)
         end
+      end
+
+      context "and second matches" do
         let(:selection) { "Yes" }
 
         it "returns the next_step_slug" do
-          expect(step.next_step_slug_after_routing).to eq(default_next_step_id)
+          expect(step.next_step_slug_after_routing).to eq(second_step_id)
         end
       end
 
-      context "with multiple conditions and second is default" do
-        let(:routing_conditions) do
-          [
-            OpenStruct.new(answer_value: "No", goto_page_id: first_step_id),
-            OpenStruct.new(answer_value: "Yes", goto_page_id: second_step_id),
-            OpenStruct.new(answer_value: "", goto_page_id: third_step_id),
-          ]
+      context "and third matches" do
+        let(:selection) { "Maybe" }
+
+        it "returns the next_step_slug" do
+          expect(step.next_step_slug_after_routing).to eq(third_step_id)
         end
-        let(:selection) { "Something else" }
+      end
+
+      context "but none match" do
+        let(:selection) { "Something Else" }
 
         it "returns the next_step_slug" do
           expect(step.next_step_slug_after_routing).to eq(default_next_step_id)
         end
       end
+    end
 
-      context "with multiple conditions but no matches" do
+    describe "with invalid states" do
+      context "with multiple conditions and default matches" do
         let(:routing_conditions) do
           [
-            OpenStruct.new(answer_value: "Yes", goto_page_id: first_step_id),
-            OpenStruct.new(answer_value: "No", goto_page_id: second_step_id),
-            OpenStruct.new(answer_value: "Maybe", goto_page_id: third_step_id),
+            OpenStruct.new(answer_value: "No", goto_page_id: first_step_id),
+            OpenStruct.new(answer_value: "Yes", goto_page_id: second_step_id),
+            OpenStruct.new(answer_value: nil, goto_page_id: third_step_id),
           ]
         end
-        let(:selection) { "Something Else" }
+        let(:selection) { "Something else" }
 
         it "returns the next_step_slug" do
           expect(step.next_step_slug_after_routing).to eq(default_next_step_id)


### PR DESCRIPTION

### What problem does this pull request solve?

Trello card: https://trello.com/c/Ndp9ZPrn/3062-update-forms-runner-to-work-with-more-than-one-routing-condition-per-question <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Update the logic in Step#next_step_slug_after_routing so that it will match a routing condition even if it isn't the first condition. This should allow forms-runner to support forms with multiple branches.

Note that this still won't match a "default" condition (answer_value of `nil`) that isn't the first in the list of routing conditions; our plans for routing don't currently have a use case for a default condition on a selection question, so there shouldn't be a situation where there are multiple conditions and one of them is a default condition.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
