### PR TITLE
Add error pages for one login journey

### DIFF
--- a/app/controllers/unknown_form_submitted_controller.rb
+++ b/app/controllers/unknown_form_submitted_controller.rb
@@ -1,0 +1,4 @@
+class UnknownFormSubmittedController < ApplicationController
+  # This action is only visited when we've lost the user's session after they've been logged out from One Login
+  def show; end
+end

--- a/app/controllers/users/omniauth_controller.rb
+++ b/app/controllers/users/omniauth_controller.rb
@@ -1,14 +1,20 @@
 module Users
   class OmniauthController < ApplicationController
-    class OmniAuthFailure < StandardError; end
+    class FailureError < StandardError; end
+
+    rescue_from AuthService::DataMissingError, FailureError do |exception|
+      CurrentRequestLoggingAttributes.rescued_exception = [exception.class.name, exception.message]
+      Sentry.capture_exception(exception)
+
+      link_url = copy_of_answers_path(**auth_service.form_path_params)
+      render "errors/auth_error", locals: { link_url: }, status: :bad_request
+    end
 
     def callback
       auth_hash = request.env["omniauth.auth"]
       auth_service.store_auth_details(auth_hash)
 
-      path_params = auth_service.form_path_params
-
-      redirect_to check_your_answers_path(**path_params)
+      redirect_to check_your_answers_path(**auth_service.form_path_params)
     rescue Store::ReturnFromOneLoginStore::MissingReturnParamsError
       Rails.logger.warn("Missing return params in session for One Login callback")
       redirect_to error_404_path
@@ -16,7 +22,7 @@ module Users
 
     def failure
       error = request.env["omniauth.error"]
-      raise OmniAuthFailure, error
+      raise FailureError, error
     end
 
     def logged_out

--- a/app/controllers/users/omniauth_controller.rb
+++ b/app/controllers/users/omniauth_controller.rb
@@ -8,6 +8,8 @@ module Users
 
       link_url = copy_of_answers_path(**auth_service.form_path_params)
       render "errors/auth_error", locals: { link_url: }, status: :bad_request
+    rescue Store::ReturnFromOneLoginStore::MissingReturnParamsError
+      render "errors/return_from_one_login_session_missing", status: :bad_request
     end
 
     def callback
@@ -15,9 +17,9 @@ module Users
       auth_service.store_auth_details(auth_hash)
 
       redirect_to check_your_answers_path(**auth_service.form_path_params)
-    rescue Store::ReturnFromOneLoginStore::MissingReturnParamsError
-      Rails.logger.warn("Missing return params in session for One Login callback")
-      redirect_to error_404_path
+    rescue Store::ReturnFromOneLoginStore::MissingReturnParamsError => e
+      CurrentRequestLoggingAttributes.rescued_exception = [e.class.name, e.message]
+      render "errors/return_from_one_login_session_missing", status: :bad_request
     end
 
     def failure

--- a/app/controllers/users/omniauth_controller.rb
+++ b/app/controllers/users/omniauth_controller.rb
@@ -32,6 +32,9 @@ module Users
 
       path_params = auth_service.form_path_params
       redirect_to form_submitted_path(**path_params)
+    rescue Store::ReturnFromOneLoginStore::MissingReturnParamsError => e
+      CurrentRequestLoggingAttributes.rescued_exception = [e.class.name, e.message]
+      redirect_to :unknown_form_submitted
     end
   end
 end

--- a/app/lib/store/return_from_one_login_store.rb
+++ b/app/lib/store/return_from_one_login_store.rb
@@ -1,6 +1,10 @@
 module Store
   class ReturnFromOneLoginStore
-    class MissingReturnParamsError < StandardError; end
+    class MissingReturnParamsError < StandardError
+      def initialize(message = "Return from One Login parameters are missing from the session")
+        super(message)
+      end
+    end
 
     RETURN_FROM_ONE_LOGIN_KEY = "return_from_one_login".freeze
     LAST_FORM_ID_KEY = "last_form_id".freeze

--- a/app/views/errors/auth_error.html.erb
+++ b/app/views/errors/auth_error.html.erb
@@ -1,0 +1,9 @@
+<% set_page_title(t('errors.auth_error.title'), t("gov_uk_forms")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('errors.auth_error.title') %></h1>
+
+    <%= t("errors.auth_error.body_html", link_url:) %>
+  </div>
+</div>

--- a/app/views/errors/return_from_one_login_session_missing.html.erb
+++ b/app/views/errors/return_from_one_login_session_missing.html.erb
@@ -1,0 +1,9 @@
+<% set_page_title(t('errors.return_from_one_login_session_missing.title'), t("gov_uk_forms")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('errors.return_from_one_login_session_missing.title') %></h1>
+
+    <%= t("errors.return_from_one_login_session_missing.body_html") %>
+  </div>
+</div>

--- a/app/views/unknown_form_submitted/show.html.erb
+++ b/app/views/unknown_form_submitted/show.html.erb
@@ -1,0 +1,9 @@
+<% set_page_title(t('.title'), t("gov_uk_forms")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel(title_text: t('.title'), classes: "govuk-!-margin-bottom-7") %>
+
+    <p><%= t('.email_sent') %></p>
+  </div>
+</div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -670,3 +670,7 @@ cy:
     link_text: "%{link} (agor mewn tab newydd)"
     online: Ar-lein
     phone: Ffôn
+  unknown_form_submitted:
+    show:
+      email_sent: We’ve sent you a confirmation email with a copy of your answers.
+      title: Your form has been submitted

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -296,6 +296,12 @@ cy:
     user-research: User research
   error_summary_title: Mae problem
   errors:
+    auth_error:
+      body_html: |
+        <p>We could not confirm your email address using GOV.UK One Login.</p>
+        <p>You’ll need to go back to the form and submit your answers.</p>
+        <p><a href="%{link_url}">Back to form</a></p>
+      title: Sorry, something has gone wrong
     goto_page_routing_error:
       cannot_have_goto_page_before_routing_page:
         body_html: |

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -335,6 +335,11 @@ cy:
       body_2: Os hoffech chi gyflwyno’r ffurflen eto, mae angen ichi
       link_text: fynd yn ôl i’r dechrau
       title: Er lles eich diogelwch, rydyn ni wedi dileu’ch atebion
+    return_from_one_login_session_missing:
+      body_html: |
+        <p>We could not confirm your email address using GOV.UK One Login.</p>
+        <p>You’ll need to go back to the form and submit your answers - try clicking the ‘Back’ button in your browser.</p>
+      title: Sorry, something has gone wrong
     submission_error:
       body: |
         Roedd yna broblem gyda’r gwasanaeth ac rydyn ni wedi methu cyflwyno’ch atebion.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -670,3 +670,7 @@ en:
     link_text: "%{link} (opens in new tab)"
     online: Online
     phone: Phone
+  unknown_form_submitted:
+    show:
+      email_sent: We’ve sent you a confirmation email with a copy of your answers.
+      title: Your form has been submitted

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -335,6 +335,11 @@ en:
       body_2: If you want to submit the form again, you need to
       link_text: go back to the start
       title: For your security, we deleted your answers
+    return_from_one_login_session_missing:
+      body_html: |
+        <p>We could not confirm your email address using GOV.UK One Login.</p>
+        <p>You’ll need to go back to the form and submit your answers - try clicking the ‘Back’ button in your browser.</p>
+      title: Sorry, something has gone wrong
     submission_error:
       body: |
         There was a problem with the service and we have been unable to submit your answers.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -296,6 +296,12 @@ en:
     user-research: User research
   error_summary_title: There is a problem
   errors:
+    auth_error:
+      body_html: |
+        <p>We could not confirm your email address using GOV.UK One Login.</p>
+        <p>You’ll need to go back to the form and submit your answers.</p>
+        <p><a href="%{link_url}">Back to form</a></p>
+      title: Sorry, something has gone wrong
     goto_page_routing_error:
       cannot_have_goto_page_before_routing_page:
         body_html: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get "/submitted" => "unknown_form_submitted#show", as: :unknown_form_submitted
+
   get "/maintenance" => "errors#maintenance", as: :maintenance_page
   get "/404", to: "errors#not_found", as: :error_404, via: :all
   get "/500", to: "errors#internal_server_error", as: :error_500, via: :all

--- a/spec/requests/unknown_form_submitted_controller_spec.rb
+++ b/spec/requests/unknown_form_submitted_controller_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe UnknownFormSubmittedController, type: :request do
+  describe "GET #show" do
+    it "renders the show template" do
+      get unknown_form_submitted_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:show)
+    end
+  end
+end

--- a/spec/requests/users/omniauth_controller_spec.rb
+++ b/spec/requests/users/omniauth_controller_spec.rb
@@ -149,13 +149,14 @@ RSpec.describe Users::OmniauthController, type: :request do
     end
   end
 
-  describe "GET #logged_out" do
+  describe "GET #logged_out", :capture_logging do
     let(:token) { Faker::Alphanumeric.alphanumeric }
 
     before do
       allow(AuthService).to receive(:new).and_wrap_original do |original_method, *_args|
         original_method.call(store)
       end
+      get omniauth_logged_out_path
     end
 
     context "when the return from one login params are set on the session" do
@@ -164,10 +165,6 @@ RSpec.describe Users::OmniauthController, type: :request do
           "return_from_one_login" => return_from_one_login_session,
           "auth": { "token": token },
         }.with_indifferent_access
-      end
-
-      before do
-        get omniauth_logged_out_path
       end
 
       it "clears the auth details on the session" do
@@ -182,8 +179,12 @@ RSpec.describe Users::OmniauthController, type: :request do
     context "when the return from one login params are not set on the session" do
       let(:store) { {} }
 
-      it "raises a Store::ReturnFromOneLoginStore::MissingReturnParamsError error" do
-        expect { get omniauth_logged_out_path }.to raise_error Store::ReturnFromOneLoginStore::MissingReturnParamsError
+      it "redirects to the unknown form submitted page" do
+        expect(response).to redirect_to(:unknown_form_submitted)
+      end
+
+      it "logs the error" do
+        expect(log_lines.last["rescued_exception"]).to eq(["Store::ReturnFromOneLoginStore::MissingReturnParamsError", "Return from One Login parameters are missing from the session"])
       end
     end
   end

--- a/spec/requests/users/omniauth_controller_spec.rb
+++ b/spec/requests/users/omniauth_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Users::OmniauthController, type: :request do
       "last_locale" => locale,
     }
   end
+  let(:store) { {}.with_indifferent_access }
 
   before do
     allow(AuthService).to receive(:new).and_wrap_original do |original_method, *_args|
@@ -87,19 +88,19 @@ RSpec.describe Users::OmniauthController, type: :request do
     context "when the return from one login params are not present on the session" do
       let(:store) { {} }
 
-      it "redirects to the 404 error page" do
-        expect(response).to redirect_to(error_404_path)
+      it "renders the return from one login session missing page" do
+        expect(response).to have_http_status(400)
+        expect(response).to render_template("errors/return_from_one_login_session_missing")
+      end
+
+      it "logs the error" do
+        expect(log_lines.last["rescued_exception"]).to eq(["Store::ReturnFromOneLoginStore::MissingReturnParamsError", "Return from One Login parameters are missing from the session"])
       end
     end
   end
 
   describe "GET #failure", :capture_logging do
     let(:error_message) { "an error message" }
-    let(:store) do
-      {
-        "return_from_one_login" => return_from_one_login_session,
-      }.with_indifferent_access
-    end
 
     before do
       allow(Sentry).to receive(:capture_exception)
@@ -107,10 +108,33 @@ RSpec.describe Users::OmniauthController, type: :request do
     end
 
     context "when the return from one login params are present on the session" do
+      let(:store) do
+        {
+          "return_from_one_login" => return_from_one_login_session,
+        }.with_indifferent_access
+      end
+
       it "renders the auth error page" do
         expect(response).to have_http_status(400)
         expect(response).to render_template("errors/auth_error")
         expect(response.body).to include("href=\"#{copy_of_answers_path(mode:, form_id:, form_slug:, locale:)}\"")
+      end
+
+      it "logs the error" do
+        expect(log_lines.last["rescued_exception"]).to eq(["Users::OmniauthController::FailureError", error_message])
+      end
+
+      it "sends the error to Sentry" do
+        expect(Sentry).to have_received(:capture_exception).with(
+          an_instance_of(Users::OmniauthController::FailureError),
+        )
+      end
+    end
+
+    context "when the return from one login params are not present on the session" do
+      it "renders the return from one login session missing page" do
+        expect(response).to have_http_status(400)
+        expect(response).to render_template("errors/return_from_one_login_session_missing")
       end
 
       it "logs the error" do

--- a/spec/requests/users/omniauth_controller_spec.rb
+++ b/spec/requests/users/omniauth_controller_spec.rb
@@ -14,7 +14,13 @@ RSpec.describe Users::OmniauthController, type: :request do
     }
   end
 
-  describe "GET #callback" do
+  before do
+    allow(AuthService).to receive(:new).and_wrap_original do |original_method, *_args|
+      original_method.call(store)
+    end
+  end
+
+  describe "GET #callback", :capture_logging do
     let(:store) do
       {
         "return_from_one_login" => return_from_one_login_session,
@@ -39,17 +45,12 @@ RSpec.describe Users::OmniauthController, type: :request do
     before do
       OmniAuth.config.test_mode = true
       OmniAuth.config.mock_auth[:default] = auth_hash
+      allow(Sentry).to receive(:capture_exception)
 
-      allow(AuthService).to receive(:new).and_wrap_original do |original_method, *_args|
-        original_method.call(store)
-      end
+      get omniauth_callback_path
     end
 
     context "when the auth details are present on the request and the user has a valid session" do
-      before do
-        get omniauth_callback_path
-      end
-
       it "redirects to the check your answers page" do
         expect(response).to redirect_to(check_your_answers_path(form_id:, form_slug:, mode:, locale:))
       end
@@ -66,8 +67,20 @@ RSpec.describe Users::OmniauthController, type: :request do
     context "when data is missing on the auth details on the request" do
       let(:auth_hash) { {} }
 
-      it "raises an OmniAuthLoggedInDataMissingError" do
-        expect { get omniauth_callback_path }.to raise_error(AuthService::DataMissingError)
+      it "renders the auth error page" do
+        expect(response).to have_http_status(400)
+        expect(response).to render_template("errors/auth_error")
+        expect(response.body).to include("href=\"#{copy_of_answers_path(mode:, form_id:, form_slug:, locale:)}\"")
+      end
+
+      it "logs the error" do
+        expect(log_lines.last["rescued_exception"]).to eq(["AuthService::DataMissingError", "Auth hash is missing on request"])
+      end
+
+      it "sends the error to Sentry" do
+        expect(Sentry).to have_received(:capture_exception).with(
+          an_instance_of(AuthService::DataMissingError),
+        )
       end
     end
 
@@ -75,17 +88,40 @@ RSpec.describe Users::OmniauthController, type: :request do
       let(:store) { {} }
 
       it "redirects to the 404 error page" do
-        get omniauth_callback_path
         expect(response).to redirect_to(error_404_path)
       end
     end
   end
 
-  describe "GET #failure" do
+  describe "GET #failure", :capture_logging do
     let(:error_message) { "an error message" }
+    let(:store) do
+      {
+        "return_from_one_login" => return_from_one_login_session,
+      }.with_indifferent_access
+    end
 
-    it "raises a OmniAuthFailure error" do
-      expect { get omniauth_failure_path, env: { "omniauth.error" => error_message } }.to raise_error(Users::OmniauthController::OmniAuthFailure, error_message)
+    before do
+      allow(Sentry).to receive(:capture_exception)
+      get omniauth_failure_path, env: { "omniauth.error" => error_message }
+    end
+
+    context "when the return from one login params are present on the session" do
+      it "renders the auth error page" do
+        expect(response).to have_http_status(400)
+        expect(response).to render_template("errors/auth_error")
+        expect(response.body).to include("href=\"#{copy_of_answers_path(mode:, form_id:, form_slug:, locale:)}\"")
+      end
+
+      it "logs the error" do
+        expect(log_lines.last["rescued_exception"]).to eq(["Users::OmniauthController::FailureError", error_message])
+      end
+
+      it "sends the error to Sentry" do
+        expect(Sentry).to have_received(:capture_exception).with(
+          an_instance_of(Users::OmniauthController::FailureError),
+        )
+      end
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/tKtA1VPQ/2858-create-integration-with-one-login

Add error pages for the following scenarios:

**The auth details are missing or there is an unexpected error authorising with One Login**

<img width="1052" height="575" alt="Screenshot 2026-04-29 at 16 57 51" src="https://github.com/user-attachments/assets/9b6e0053-73df-41f7-a893-518fd2c8dd53" />

**The user's session has been lost when they're returned to us from One Login**

<img width="1052" height="575" alt="Screenshot 2026-04-29 at 17 01 45" src="https://github.com/user-attachments/assets/daa69906-f887-42c5-a0ba-c83bf2742a9b" />

**The user's session has been lost after they've been logged out when they submit their form**

In this case, rather than showing an error, show a generic success page without the form details as the user's form will still have been submitted and we should have sent them an email with their answers.

<img width="1052" height="575" alt="Screenshot 2026-04-29 at 17 03 46" src="https://github.com/user-attachments/assets/2d08f987-290e-44c0-9238-7496c9d75fc4" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
