### PR TITLE
Make confirmation email for Welsh bi-lingual

### DIFF
--- a/app/jobs/send_confirmation_email_job.rb
+++ b/app/jobs/send_confirmation_email_job.rb
@@ -5,19 +5,21 @@ class SendConfirmationEmailJob < ApplicationJob
   def perform(submission:, notify_response_id:, confirmation_email_address:)
     set_submission_logging_attributes(submission:)
 
-    I18n.with_locale(submission.submission_locale || I18n.default_locale) do
-      form = submission.form
-      mail = FormSubmissionConfirmationMailer.send_confirmation_email(
-        what_happens_next_markdown: form.what_happens_next_markdown,
-        support_contact_details: form.support_details,
-        notify_response_id:,
-        confirmation_email_address:,
-        mailer_options: mailer_options_for(submission:, form:),
-      )
+    form = submission.form
+    welsh_form = fetch_welsh_form(submission:, form:)
+    mail = FormSubmissionConfirmationMailer.send_confirmation_email(
+      what_happens_next_markdown: form.what_happens_next_markdown,
+      what_happens_next_markdown_cy: welsh_form&.what_happens_next_markdown,
+      support_contact_details: form.support_details,
+      support_contact_details_cy: welsh_form&.support_details,
+      notify_response_id:,
+      confirmation_email_address:,
+      mailer_options: mailer_options_for(submission:, form:),
+      submission_locale: submission.submission_locale,
+    )
 
-      mail.deliver_now
-      CurrentJobLoggingAttributes.confirmation_email_id = mail.govuk_notify_response.id
-    end
+    mail.deliver_now
+    CurrentJobLoggingAttributes.confirmation_email_id = mail.govuk_notify_response.id
   rescue StandardError
     CloudWatchService.record_job_failure_metric(self.class.name)
     raise
@@ -33,5 +35,16 @@ private
       submission_reference: submission.reference,
       payment_url: submission.payment_url,
     )
+  end
+
+  def fetch_welsh_form(submission:, form:)
+    return nil unless submission.submission_locale.to_sym == :cy
+
+    form_document = Api::V2::FormDocumentRepository.find_with_mode(
+      form_id: form.id,
+      mode: submission.mode_object,
+      language: :cy,
+    )
+    Form.new(form_document) if form_document
   end
 end

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -1,13 +1,17 @@
 class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
-  def send_confirmation_email(what_happens_next_markdown:, support_contact_details:, notify_response_id:, confirmation_email_address:, mailer_options:)
+  def send_confirmation_email(what_happens_next_markdown:, support_contact_details:, notify_response_id:, confirmation_email_address:, mailer_options:, submission_locale: :en, what_happens_next_markdown_cy: nil, support_contact_details_cy: nil)
+    @submission_locale = submission_locale.to_sym
     set_template(template_id)
 
     set_personalisation(
       title: mailer_options.title,
       what_happens_next_text: what_happens_next_markdown.presence || default_what_happens_next_text,
+      what_happens_next_text_cy: what_happens_next_markdown_cy.presence || what_happens_next_markdown.presence || default_what_happens_next_text,
       support_contact_details: format_support_details(support_contact_details).presence || default_support_contact_details_text,
+      support_contact_details_cy: format_support_details(support_contact_details_cy || support_contact_details, locale: :cy).presence || default_support_contact_details_text,
       submission_time: mailer_options.timestamp.strftime("%l:%M%P").strip,
-      submission_date: I18n.l(mailer_options.timestamp, format: "%-d %B %Y"),
+      submission_date: I18n.l(mailer_options.timestamp, format: "%-d %B %Y", locale: :en),
+      submission_date_cy: I18n.l(mailer_options.timestamp, format: "%-d %B %Y", locale: :cy),
       # GOV.UK Notify's templates have conditionals, but only positive
       # conditionals, so to simulate negative conditionals we add two boolean
       # flags; but they must always have opposite values!
@@ -24,7 +28,7 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
     mail(to: confirmation_email_address)
   end
 
-  def format_support_details(support_details)
+  def format_support_details(support_details, locale: :en)
     phone = support_details.phone
     call_charges_url = support_details.call_charges_url
     email = support_details.email
@@ -33,7 +37,7 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
 
     support_details = []
     support_details << normalize_whitespace(phone) if phone.present?
-    support_details << "[#{I18n.t('support_details.call_charges')}](#{call_charges_url})" if phone.present?
+    support_details << "[#{I18n.t('support_details.call_charges', locale: locale)}](#{call_charges_url})" if phone.present?
     support_details << "[#{email}](mailto:#{email})" if email.present?
     support_details << "[#{url_text}](#{url})" if url.present? && url_text.present?
 
@@ -55,7 +59,7 @@ private
   end
 
   def template_id
-    return Settings.govuk_notify.form_filler_confirmation_email_welsh_template_id if I18n.locale == :cy
+    return Settings.govuk_notify.form_filler_confirmation_email_welsh_template_id if @submission_locale == :cy
 
     Settings.govuk_notify.form_filler_confirmation_email_template_id
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,7 +26,7 @@ govuk_notify:
   form_submission_email_reply_to_id: fab9373b-fb7c-483f-ae25-5a9852bfcc04
   form_submission_email_template_id: 427eb8bc-ce0d-40a3-bf54-d76e8c3ec916
   form_filler_confirmation_email_template_id: 2d1f36dc-9799-43dd-8673-b631f9e0b4a5
-  form_filler_confirmation_email_welsh_template_id: 4c5c75df-3a48-48ec-80d9-df9cabcdc9fc
+  form_filler_confirmation_email_welsh_template_id: b297c8f1-419e-4af4-b067-b8cad6364daf
 
 # Configuration for Sentry
 # Sentry will only initialise if dsn is set to some other value

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -45,7 +45,7 @@ describe "Settings" do
     include_examples expected_value_test, :form_submission_email_reply_to_id, govuk_notify, "fab9373b-fb7c-483f-ae25-5a9852bfcc04"
     include_examples expected_value_test, :form_submission_email_template_id, govuk_notify, "427eb8bc-ce0d-40a3-bf54-d76e8c3ec916"
     include_examples expected_value_test, :form_filler_confirmation_email_template_id, govuk_notify, "2d1f36dc-9799-43dd-8673-b631f9e0b4a5"
-    include_examples expected_value_test, :form_filler_confirmation_email_welsh_template_id, govuk_notify, "4c5c75df-3a48-48ec-80d9-df9cabcdc9fc"
+    include_examples expected_value_test, :form_filler_confirmation_email_welsh_template_id, govuk_notify, "b297c8f1-419e-4af4-b067-b8cad6364daf"
   end
 
   describe "sentry" do

--- a/spec/jobs/send_confirmation_email_job_spec.rb
+++ b/spec/jobs/send_confirmation_email_job_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe SendConfirmationEmailJob, type: :job do
 
     expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
       what_happens_next_markdown: "Please wait for a response",
+      what_happens_next_markdown_cy: nil,
       support_contact_details: have_attributes(
         phone: "0203 222 2222",
         call_charges_url: "https://www.gov.uk/call-charges",
@@ -62,15 +63,33 @@ RSpec.describe SendConfirmationEmailJob, type: :job do
         url: "https://example.gov.uk/help",
         url_text: "Get help",
       ),
+      support_contact_details_cy: nil,
       notify_response_id: "confirmation-ref",
       confirmation_email_address: "testing@gov.uk",
       mailer_options: an_instance_of(SendConfirmationEmailJob::MailerOptions),
+      submission_locale: "en",
     )
   end
 
-  context "when locale is Welsh" do
-    it "uses the Welsh template" do
+  context "when submission locale is Welsh" do
+    let(:welsh_form_document) do
+      build(:v2_form_document,
+            what_happens_next_markdown: "Arhoswch am ymateb",
+            support_phone: "0291 111 1111",
+            support_email: "cymraeg@example.gov.uk")
+    end
+
+    before do
       submission.update!(submission_locale: "cy")
+      allow(Api::V2::FormDocumentRepository).to receive(:find_with_mode).and_call_original
+      allow(Api::V2::FormDocumentRepository).to receive(:find_with_mode).with(
+        form_id: anything,
+        mode: anything,
+        language: :cy,
+      ).and_return(welsh_form_document)
+    end
+
+    it "uses the bilingual template" do
       described_class.perform_now(
         submission:,
         notify_response_id:,
@@ -79,6 +98,37 @@ RSpec.describe SendConfirmationEmailJob, type: :job do
 
       mail = ActionMailer::Base.deliveries.last
       expect(mail.govuk_notify_template).to eq("7891011")
+    end
+
+    it "passes the Welsh what happens next to the mailer" do
+      allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email).and_call_original
+
+      described_class.perform_now(
+        submission:,
+        notify_response_id:,
+        confirmation_email_address:,
+      )
+
+      expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
+        hash_including(what_happens_next_markdown_cy: "Arhoswch am ymateb"),
+      )
+    end
+
+    it "passes the Welsh support details" do
+      allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email).and_call_original
+
+      described_class.perform_now(
+        submission:,
+        notify_response_id:,
+        confirmation_email_address:,
+      )
+
+      expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
+        hash_including(support_contact_details_cy: have_attributes(
+          phone: "0291 111 1111",
+          email: "cymraeg@example.gov.uk",
+        )),
+      )
     end
   end
 

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -1,12 +1,14 @@
 require "rails_helper"
 
 describe FormSubmissionConfirmationMailer, type: :mailer do
+  let(:submission_locale) { :en }
   let(:mail) do
     described_class.send_confirmation_email(what_happens_next_markdown:,
                                             support_contact_details:,
                                             notify_response_id: "for-my-ref",
                                             confirmation_email_address:,
-                                            mailer_options:)
+                                            mailer_options:,
+                                            submission_locale:)
   end
   let(:mailer_options) do
     FormSubmissionService::MailerOptions.new(title:,
@@ -30,24 +32,18 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
       Settings.govuk_notify.form_filler_confirmation_email_welsh_template_id = "7891011"
     end
 
-    context "when the request locale is not set" do
-      it "uses the English language template" do
-        expect(mail.govuk_notify_template).to eq("123456")
-      end
-    end
-
-    context "when the request locale is set to :en" do
-      include_context "with locale set to :en"
+    context "when submission_locale is :en" do
+      let(:submission_locale) { :en }
 
       it "uses the English language template" do
         expect(mail.govuk_notify_template).to eq("123456")
       end
     end
 
-    context "when the request locale is set to :cy" do
-      include_context "with locale set to :cy"
+    context "when submission_locale is :cy" do
+      let(:submission_locale) { :cy }
 
-      it "uses the Welsh language template" do
+      it "uses the bilingual template" do
         expect(mail.govuk_notify_template).to eq("7891011")
       end
     end
@@ -64,8 +60,53 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
       expect(mail.govuk_notify_personalisation[:what_happens_next_text]).to eq("Please wait for a response")
     end
 
+    context "when what_happens_next_markdown_cy is provided" do
+      let(:mail) do
+        described_class.send_confirmation_email(what_happens_next_markdown:,
+                                                support_contact_details:,
+                                                notify_response_id: "for-my-ref",
+                                                confirmation_email_address:,
+                                                mailer_options:,
+                                                submission_locale:,
+                                                what_happens_next_markdown_cy: "Arhoswch am ymateb")
+      end
+
+      it "includes the Welsh what happens next" do
+        expect(mail.govuk_notify_personalisation[:what_happens_next_text_cy]).to eq("Arhoswch am ymateb")
+      end
+    end
+
+    context "when what_happens_next_markdown_cy is not provided" do
+      it "falls back to the English what happens next" do
+        expect(mail.govuk_notify_personalisation[:what_happens_next_text_cy]).to eq("Please wait for a response")
+      end
+    end
+
     it "includes the forms support contact details" do
       expect(mail.govuk_notify_personalisation[:support_contact_details]).to eq("0203 222 2222\n\n[Find out about call charges](https://www.gov.uk/call-charges)")
+    end
+
+    context "when support_contact_details_cy is not provided" do
+      it "falls back to support_contact_details formatted with Welsh locale" do
+        expect(mail.govuk_notify_personalisation[:support_contact_details_cy]).to eq("0203 222 2222\n\n[Darganfyddwch am gostau galwadau](https://www.gov.uk/call-charges)")
+      end
+    end
+
+    context "when support_contact_details_cy is provided" do
+      let(:welsh_support) { OpenStruct.new(phone: "0291 111 1111", email: nil, url: nil, url_text: nil, call_charges_url: "https://www.gov.uk/call-charges") }
+      let(:mail) do
+        described_class.send_confirmation_email(what_happens_next_markdown:,
+                                                support_contact_details:,
+                                                support_contact_details_cy: welsh_support,
+                                                notify_response_id: "for-my-ref",
+                                                confirmation_email_address:,
+                                                mailer_options:,
+                                                submission_locale:)
+      end
+
+      it "uses the Welsh support details formatted with Welsh locale" do
+        expect(mail.govuk_notify_personalisation[:support_contact_details_cy]).to eq("0291 111 1111\n\n[Darganfyddwch am gostau galwadau](https://www.gov.uk/call-charges)")
+      end
     end
 
     context "when what happens next is missing" do
@@ -143,30 +184,15 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
           end
         end
 
-        context "when the request locale is not set" do
-          it "includes the date user submitted the form in English" do
-            travel_to timestamp do
-              expect(mail.govuk_notify_personalisation[:submission_date]).to eq("14 September 2022")
-            end
+        it "includes the date user submitted the form in English" do
+          travel_to timestamp do
+            expect(mail.govuk_notify_personalisation[:submission_date]).to eq("14 September 2022")
           end
         end
 
-        context "when the request locale is set to :en" do
-          include_context "with locale set to :en"
-          it "includes the date user submitted the form in English" do
-            travel_to timestamp do
-              expect(mail.govuk_notify_personalisation[:submission_date]).to eq("14 September 2022")
-            end
-          end
-        end
-
-        context "when the request locale is set to :cy" do
-          include_context "with locale set to :cy"
-
-          it "includes the date user submitted the form in Welsh" do
-            travel_to timestamp do
-              expect(mail.govuk_notify_personalisation[:submission_date]).to eq("14 Medi 2022")
-            end
+        it "includes the date user submitted the form in Welsh" do
+          travel_to timestamp do
+            expect(mail.govuk_notify_personalisation[:submission_date_cy]).to eq("14 Medi 2022")
           end
         end
       end

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -497,9 +497,12 @@ RSpec.describe Forms::CheckYourAnswersController, :capture_logging, type: :reque
         expected_personalisation = {
           title: form_data.name,
           what_happens_next_text: form_data.what_happens_next_markdown,
+          what_happens_next_text_cy: form_data.what_happens_next_markdown,
           support_contact_details: contact_support_details_format,
+          support_contact_details_cy: I18n.with_locale(:cy) { contact_support_details_format },
           submission_time: "10:00am",
           submission_date: "14 December 2022",
+          submission_date_cy: "14 Rhagfyr 2022",
           test: "no",
           submission_reference: reference,
           include_payment_link: "no",


### PR DESCRIPTION
### What problem does this pull request solve?

When a user answers Welsh questions, the confirmation email now uses a bilingual Notify template. The mailer passes both English and Welsh personalisation variables (_cy variants for submission_date, what_happens_next_text, and support_contact_details) so each language section of the template receives the correct content. Template selection is driven by the explicit submission_locale parameter rather than the ambient I18n locale.

Trello card:  https://trello.com/c/NLqWmwvf/2894-update-confirmation-emails-to-cater-for-new-welsh-form-submissions 

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
