### PR TITLE
Send bounce notifications to org admins after a week

### DIFF
--- a/app/jobs/schedule_bounce_notifications_job.rb
+++ b/app/jobs/schedule_bounce_notifications_job.rb
@@ -6,6 +6,6 @@ class ScheduleBounceNotificationsJob < ApplicationJob
     CurrentJobLoggingAttributes.job_class = self.class.name
     CurrentJobLoggingAttributes.job_id = job_id
 
-    SendBounceNotificationsJob.perform_later(bounced_on_date: Time.zone.yesterday.to_date)
+    SendBounceNotificationsJob.perform_later(bounced_on_date: Time.zone.yesterday.to_date, user_role: :group_admin)
   end
 end

--- a/app/jobs/schedule_bounce_notifications_job.rb
+++ b/app/jobs/schedule_bounce_notifications_job.rb
@@ -6,6 +6,7 @@ class ScheduleBounceNotificationsJob < ApplicationJob
     CurrentJobLoggingAttributes.job_class = self.class.name
     CurrentJobLoggingAttributes.job_id = job_id
 
-    SendBounceNotificationsJob.perform_later(bounced_on_date: Time.zone.yesterday.to_date, user_role: :group_admin)
+    SendBounceNotificationsJob.perform_later(bounced_on_date: 1.day.ago.to_date, user_role: :group_admin)
+    SendBounceNotificationsJob.perform_later(bounced_on_date: 8.days.ago.to_date, user_role: :organisation_admin)
   end
 end

--- a/app/jobs/send_bounce_notifications_job.rb
+++ b/app/jobs/send_bounce_notifications_job.rb
@@ -12,7 +12,7 @@ class SendBounceNotificationsJob < ApplicationJob
       group = Api::V2::GroupResource.find(form_id)
 
       group.group_admin_users.each do |user|
-        BounceNotificationMailer.bounce_notification_to_group_admins_email(form:, user:, deliveries:).deliver_now
+        BounceNotificationMailer.bounce_notification_email(form:, user:, deliveries:, user_role: :group_admin).deliver_now
       end
 
       Rails.logger.info "Sent bounce notifications to group admins for bounced deliveries on #{bounced_on_date.strftime('%-d %B %Y')} for form #{form_id}"

--- a/app/jobs/send_bounce_notifications_job.rb
+++ b/app/jobs/send_bounce_notifications_job.rb
@@ -1,7 +1,7 @@
 class SendBounceNotificationsJob < ApplicationJob
   queue_as :bounce_notifications
 
-  def perform(bounced_on_date:)
+  def perform(bounced_on_date:, user_role:)
     CloudWatchService.record_job_started_metric(self.class.name)
     CurrentJobLoggingAttributes.job_class = self.class.name
     CurrentJobLoggingAttributes.job_id = job_id
@@ -11,13 +11,15 @@ class SendBounceNotificationsJob < ApplicationJob
       form = deliveries.first.form
       group = Api::V2::GroupResource.find(form_id)
 
-      group.group_admin_users.each do |user|
+      users = user_role == :organisation_admin ? group.organisation.organisation_admin_users : group.group_admin_users
+
+      users.each do |user|
         BounceNotificationMailer.bounce_notification_email(
-          form:, group_name: group.name, user:, user_role: :group_admin, deliveries:, bounced_on_date:,
+          form:, group_name: group.name, user:, user_role:, deliveries:, bounced_on_date:,
         ).deliver_now
       end
 
-      Rails.logger.info "Sent bounce notifications to group admins for bounced deliveries on #{bounced_on_date.strftime('%-d %B %Y')} for form #{form_id}"
+      Rails.logger.info "Sent bounce notifications to #{user_role.to_s.gsub('_', ' ')} users for bounced deliveries on #{bounced_on_date.strftime('%-d %B %Y')} for form #{form_id}"
     end
   end
 end

--- a/app/jobs/send_bounce_notifications_job.rb
+++ b/app/jobs/send_bounce_notifications_job.rb
@@ -12,7 +12,9 @@ class SendBounceNotificationsJob < ApplicationJob
       group = Api::V2::GroupResource.find(form_id)
 
       group.group_admin_users.each do |user|
-        BounceNotificationMailer.bounce_notification_email(form:, user:, deliveries:, user_role: :group_admin).deliver_now
+        BounceNotificationMailer.bounce_notification_email(
+          form:, group_name: group.name, user:, user_role: :group_admin, deliveries:, bounced_on_date:,
+        ).deliver_now
       end
 
       Rails.logger.info "Sent bounce notifications to group admins for bounced deliveries on #{bounced_on_date.strftime('%-d %B %Y')} for form #{form_id}"

--- a/app/mailers/bounce_notification_mailer.rb
+++ b/app/mailers/bounce_notification_mailer.rb
@@ -1,7 +1,7 @@
 class BounceNotificationMailer < GovukNotifyRails::Mailer
   include NotifyUtils
 
-  def bounce_notification_email(form:, user:, deliveries:, user_role:)
+  def bounce_notification_email(form:, group_name:, user:, user_role:, deliveries:, bounced_on_date:)
     set_template(Settings.govuk_notify.bounce_notification_to_group_admins_template_id)
 
     # We're assuming that all bounces are for the same reason
@@ -23,6 +23,7 @@ class BounceNotificationMailer < GovukNotifyRails::Mailer
       deadline_date: deadline_date(deliveries),
       is_organisation_admin: make_notify_boolean(user_role == :organisation_admin),
       is_group_admin: make_notify_boolean(user_role == :group_admin),
+      contacted_group_admins_paragraph: contacted_group_admins_paragraph(user_role:, group_name:, bounced_on_date:),
     )
 
     mail(to: user.email)
@@ -65,5 +66,12 @@ private
     earliest_submission_date_time = earliest_submission_created_at.in_time_zone(TimeZoneUtils.submission_time_zone)
     deadline_date_time = earliest_submission_date_time + Settings.submissions.maximum_retention_seconds.seconds
     deadline_date_time.strftime("%-d %B %Y")
+  end
+
+  def contacted_group_admins_paragraph(user_role:, group_name:, bounced_on_date:)
+    return "" if user_role == :group_admin
+
+    contacted_date = (bounced_on_date + 1.day).strftime("%-d %B %Y")
+    I18n.t("mailer.bounce_notification.contacted_group_admins_paragraph", group_name:, contacted_date:)
   end
 end

--- a/app/mailers/bounce_notification_mailer.rb
+++ b/app/mailers/bounce_notification_mailer.rb
@@ -1,7 +1,7 @@
 class BounceNotificationMailer < GovukNotifyRails::Mailer
   include NotifyUtils
 
-  def bounce_notification_to_group_admins_email(form:, user:, deliveries:)
+  def bounce_notification_email(form:, user:, deliveries:, user_role:)
     set_template(Settings.govuk_notify.bounce_notification_to_group_admins_template_id)
 
     # We're assuming that all bounces are for the same reason
@@ -21,6 +21,8 @@ class BounceNotificationMailer < GovukNotifyRails::Mailer
       hard_bounce: make_notify_boolean(hard_bounce),
       soft_bounce: make_notify_boolean(!hard_bounce),
       deadline_date: deadline_date(deliveries),
+      is_organisation_admin: make_notify_boolean(user_role == :organisation_admin),
+      is_group_admin: make_notify_boolean(user_role == :group_admin),
     )
 
     mail(to: user.email)

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -472,6 +472,7 @@ cy:
       bounced_daily_batch: Daily batch sent at %{sent_at_time} on %{sent_at_date}
       bounced_submission: "%{submission_reference} at %{sent_at_time} on %{sent_at_date}"
       bounced_weekly_batch: Weekly batch sent at %{sent_at_time} on %{sent_at_date}
+      contacted_group_admins_paragraph: We emailed the group admins of the group the form is in, “%{group_name}”, on %{contacted_date}. We have not received a response.
     cannot_reply:
       contact_form_filler_html: "<p>If you need to contact the person who completed this form, you’ll need to contact them directly.</p>"
       contact_form_filler_plain: If you need to contact the person who completed this form, you’ll need to contact them directly.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -472,6 +472,7 @@ en:
       bounced_daily_batch: Daily batch sent at %{sent_at_time} on %{sent_at_date}
       bounced_submission: "%{submission_reference} at %{sent_at_time} on %{sent_at_date}"
       bounced_weekly_batch: Weekly batch sent at %{sent_at_time} on %{sent_at_date}
+      contacted_group_admins_paragraph: We emailed the group admins of the group the form is in, “%{group_name}”, on %{contacted_date}. We have not received a response.
     cannot_reply:
       contact_form_filler_html: "<p>If you need to contact the person who completed this form, you’ll need to contact them directly.</p>"
       contact_form_filler_plain: If you need to contact the person who completed this form, you’ll need to contact them directly.

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -17,6 +17,9 @@ production:
   schedule_weekly_batch_deliveries_job:
     class: ScheduleWeeklyBatchDeliveriesJob
     schedule: every Monday at 2:15am Europe/London
+  schedule_bounce_notifications_job:
+    class: ScheduleBounceNotificationsJob
+    schedule: every day at 2:30am Europe/London
 development:
   delete_submissions_job:
     class: DeleteSubmissionsJob

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,7 +27,7 @@ govuk_notify:
   form_submission_email_template_id: 427eb8bc-ce0d-40a3-bf54-d76e8c3ec916
   form_filler_confirmation_email_template_id: 2d1f36dc-9799-43dd-8673-b631f9e0b4a5
   form_filler_confirmation_email_welsh_template_id: b297c8f1-419e-4af4-b067-b8cad6364daf
-  bounce_notification_to_group_admins_template_id: 9a93a110-c97d-4b51-87f3-a7ec5b9daddc
+  bounce_notification_to_group_admins_template_id: 8062ca3f-3a21-4e1b-847f-cfa45c48ed87
 
 # Configuration for Sentry
 # Sentry will only initialise if dsn is set to some other value

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -13,10 +13,10 @@ FactoryBot.define do
     end
 
     organisation do
-      {
+      DataStruct.new({
         name: organisation_name,
-        admin_users: build_list(:admin_user, organisation_admin_users_count),
-      }
+        organisation_admin_users: build_list(:admin_user, organisation_admin_users_count),
+      })
     end
   end
 end

--- a/spec/jobs/schedule_bounce_notifications_job_spec.rb
+++ b/spec/jobs/schedule_bounce_notifications_job_spec.rb
@@ -1,10 +1,23 @@
 require "rails_helper"
 
 RSpec.describe ScheduleBounceNotificationsJob do
-  it "schedules a SendBounceNotifications job with yesterday's date" do
-    expect(SendBounceNotificationsJob).to receive(:perform_later)
-                                            .with(bounced_on_date: Time.zone.yesterday.to_date, user_role: :group_admin)
+  before do
+    allow(SendBounceNotificationsJob).to receive(:perform_later)
 
-    described_class.perform_now
+    travel_to Time.zone.local(2026, 5, 12, 15, 0, 0) do
+      described_class.perform_now
+    end
+  end
+
+  it "schedules a SendBounceNotifications job to send to group admins with yesterday's date" do
+    expect(SendBounceNotificationsJob).to have_received(:perform_later)
+                                            .with({ bounced_on_date: Date.new(2026, 5, 11), user_role: :group_admin })
+                                            .once
+  end
+
+  it "schedules a SendBounceNotifications job to send to organisation admins with a date of 8 days ago" do
+    expect(SendBounceNotificationsJob).to have_received(:perform_later)
+                                            .with({ bounced_on_date: Date.new(2026, 5, 4), user_role: :organisation_admin })
+                                            .once
   end
 end

--- a/spec/jobs/schedule_bounce_notifications_job_spec.rb
+++ b/spec/jobs/schedule_bounce_notifications_job_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe ScheduleBounceNotificationsJob do
   it "schedules a SendBounceNotifications job with yesterday's date" do
-    expect(SendBounceNotificationsJob).to receive(:perform_later).with(bounced_on_date: Time.zone.yesterday.to_date)
+    expect(SendBounceNotificationsJob).to receive(:perform_later)
+                                            .with(bounced_on_date: Time.zone.yesterday.to_date, user_role: :group_admin)
 
     described_class.perform_now
   end

--- a/spec/jobs/send_bounce_notifications_job_spec.rb
+++ b/spec/jobs/send_bounce_notifications_job_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
-RSpec.describe SendBounceNotificationsJob do
+RSpec.describe SendBounceNotificationsJob, :capture_logging do
   include ActiveSupport::Testing::TimeHelpers
   include ActiveJob::TestHelper
 
   let(:bounced_on_date) { Date.new(2026, 5, 6) }
+  let(:user_role) { :group_admin }
 
   let(:form_with_bounces) { build :form }
   let(:other_form_with_bounces) { build :form }
@@ -24,10 +25,10 @@ RSpec.describe SendBounceNotificationsJob do
     end
   end
 
-  context "when there are multiple forms with bounces on the date", :capture_logging do
+  context "when there are multiple forms with bounces on the date" do
     before do
       create_list :delivery, 2, :bounced, :daily_scheduled_delivery, form_id: other_form_with_bounces.id, failed_at: Time.zone.local(2026, 5, 6, 22, 59, 0)
-      described_class.perform_now(bounced_on_date:)
+      described_class.perform_now(bounced_on_date:, user_role:)
     end
 
     it "sends an email per form with bounced submissions" do
@@ -42,21 +43,22 @@ RSpec.describe SendBounceNotificationsJob do
       expect(log_lines).to include(
         hash_including(
           "level" => "INFO",
-          "message" => "Sent bounce notifications to group admins for bounced deliveries on 6 May 2026 for form #{form_with_bounces.form_id}",
+          "message" => "Sent bounce notifications to group admin users for bounced deliveries on 6 May 2026 for form #{form_with_bounces.form_id}",
         ),
         hash_including(
           "level" => "INFO",
-          "message" => "Sent bounce notifications to group admins for bounced deliveries on 6 May 2026 for form #{other_form_with_bounces.form_id}",
+          "message" => "Sent bounce notifications to group admin users for bounced deliveries on 6 May 2026 for form #{other_form_with_bounces.form_id}",
         ),
       )
     end
   end
 
-  context "when the group has multiple group admins" do
+  context "when notifying the group admins" do
+    let(:user_role) { :group_admin }
     let(:group) { build :group, group_admin_users_count: 2 }
 
     before do
-      described_class.perform_now(bounced_on_date:)
+      described_class.perform_now(bounced_on_date:, user_role:)
     end
 
     it "sends an email to each group admin" do
@@ -64,6 +66,41 @@ RSpec.describe SendBounceNotificationsJob do
       expect(ActionMailer::Base.deliveries.map(&:to).flatten).to contain_exactly(
         group.group_admin_users.first.email,
         group.group_admin_users.second.email,
+      )
+    end
+
+    it "logs that it sent the notifications to the group admins" do
+      expect(log_lines).to include(
+        hash_including(
+          "level" => "INFO",
+          "message" => "Sent bounce notifications to group admin users for bounced deliveries on 6 May 2026 for form #{form_with_bounces.form_id}",
+        ),
+      )
+    end
+  end
+
+  context "when notifying the organisation admins" do
+    let(:user_role) { :organisation_admin }
+    let(:group) { build :group, group_admin_users_count: 1, organisation_admin_users_count: 2 }
+
+    before do
+      described_class.perform_now(bounced_on_date:, user_role:)
+    end
+
+    it "sends an email to each organisation admin" do
+      expect(ActionMailer::Base.deliveries.size).to eq 2
+      expect(ActionMailer::Base.deliveries.map(&:to).flatten).to contain_exactly(
+        group.organisation.organisation_admin_users.first.email,
+        group.organisation.organisation_admin_users.second.email,
+      )
+    end
+
+    it "logs that it sent the notifications to the organisation admins" do
+      expect(log_lines).to include(
+        hash_including(
+          "level" => "INFO",
+          "message" => "Sent bounce notifications to organisation admin users for bounced deliveries on 6 May 2026 for form #{form_with_bounces.form_id}",
+        ),
       )
     end
   end

--- a/spec/mailers/bounce_notification_mailer_spec.rb
+++ b/spec/mailers/bounce_notification_mailer_spec.rb
@@ -3,19 +3,19 @@ require "rails_helper"
 RSpec.describe BounceNotificationMailer do
   describe "#bounce_notification_to_group_admins_email" do
     subject(:mail) do
-      described_class.bounce_notification_to_group_admins_email(form:, user:, deliveries: deliveries)
+      described_class.bounce_notification_email(form:, user:, deliveries:, user_role:)
     end
 
+    let(:deliveries) { create_list :delivery, 3, :bounced, :immediate }
     let(:user) { build :admin_user }
     let(:form) { build :form }
+    let(:user_role) { :group_admin }
 
     before do
       Settings.govuk_notify.bounce_notification_to_group_admins_template_id = "some-template-id"
     end
 
     describe "basic personalisation" do
-      let(:deliveries) { create_list :delivery, 3, :bounced, :immediate }
-
       it "includes personalisation for the user and form" do
         expect(mail.govuk_notify_personalisation).to include(
           user_name: user.name,
@@ -30,6 +30,32 @@ RSpec.describe BounceNotificationMailer do
 
       it "sets the template" do
         expect(mail.govuk_notify_template).to eq "some-template-id"
+      end
+    end
+
+    describe "personalisation for the user role" do
+      context "when sending to an organisation admin" do
+        let(:user_role) { :organisation_admin }
+
+        it "sets is_organisation_admin to yes" do
+          expect(mail.govuk_notify_personalisation[:is_organisation_admin]).to eq "yes"
+        end
+
+        it "sets is_group_admin to no" do
+          expect(mail.govuk_notify_personalisation[:is_group_admin]).to eq "no"
+        end
+      end
+
+      context "when sending to a group admin" do
+        let(:user_role) { :group_admin }
+
+        it "sets is_organisation_admin to no" do
+          expect(mail.govuk_notify_personalisation[:is_organisation_admin]).to eq "no"
+        end
+
+        it "sets is_group_admin to yes" do
+          expect(mail.govuk_notify_personalisation[:is_group_admin]).to eq "yes"
+        end
       end
     end
 

--- a/spec/mailers/bounce_notification_mailer_spec.rb
+++ b/spec/mailers/bounce_notification_mailer_spec.rb
@@ -3,13 +3,15 @@ require "rails_helper"
 RSpec.describe BounceNotificationMailer do
   describe "#bounce_notification_to_group_admins_email" do
     subject(:mail) do
-      described_class.bounce_notification_email(form:, user:, deliveries:, user_role:)
+      described_class.bounce_notification_email(form:, group_name:, user:, user_role:, deliveries:, bounced_on_date:)
     end
 
     let(:deliveries) { create_list :delivery, 3, :bounced, :immediate }
     let(:user) { build :admin_user }
     let(:form) { build :form }
     let(:user_role) { :group_admin }
+    let(:group_name) { "A group" }
+    let(:bounced_on_date) { Date.new(2026, 5, 7) }
 
     before do
       Settings.govuk_notify.bounce_notification_to_group_admins_template_id = "some-template-id"
@@ -44,6 +46,13 @@ RSpec.describe BounceNotificationMailer do
         it "sets is_group_admin to no" do
           expect(mail.govuk_notify_personalisation[:is_group_admin]).to eq "no"
         end
+
+        it "sets the personalisation for the contacted_group_admins_paragraph" do
+          expected_paragraph = I18n.t("mailer.bounce_notification.contacted_group_admins_paragraph",
+                                      group_name:,
+                                      contacted_date: "8 May 2026")
+          expect(mail.govuk_notify_personalisation[:contacted_group_admins_paragraph]).to eq expected_paragraph
+        end
       end
 
       context "when sending to a group admin" do
@@ -55,6 +64,10 @@ RSpec.describe BounceNotificationMailer do
 
         it "sets is_group_admin to yes" do
           expect(mail.govuk_notify_personalisation[:is_group_admin]).to eq "yes"
+        end
+
+        it "sets contacted_group_admins_paragraph to blank" do
+          expect(mail.govuk_notify_personalisation[:contacted_group_admins_paragraph]).to eq ""
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/WmCipXbC

A week after we've contacted group admins about bounced email deliveries, contact the organisation admins.

We contact group admins the day after the bounce, so contact organisation admins 8 days after the bounce.

Re-use the same Notify template and Jobs for sending to organisation admins. Update the ScheduleBounceNotificationsJob to schedule another SendBounceNotificationsJob pass in different parameters for the `bounced_on_date` and `user_role` (`:group_admin` or (`:organisation_admin`)

### Testing

I've tested this on dev. See screenshots below.

Note that to test I temporarily changed it to email org admins after 2 days rather than 8 so it would send the email for some bounces I had already triggered, which is reflected in the dates in the screenshotted email.

Email to org admins:

<img width="628" height="975" alt="Screenshot 2026-05-13 at 16 45 35" src="https://github.com/user-attachments/assets/219103a0-62d5-4eb9-85fb-13e579d84cce" />

Email to group admins (should be unchanged by this PR):

<img width="672" height="834" alt="Screenshot 2026-05-13 at 16 16 11" src="https://github.com/user-attachments/assets/5b776eeb-8906-485b-99c9-59e879886043" />


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
