### PR TITLE
Remove MailerOptions Data object used by confirmation email mailer

### DIFF
--- a/app/jobs/send_confirmation_email_job.rb
+++ b/app/jobs/send_confirmation_email_job.rb
@@ -1,6 +1,5 @@
 class SendConfirmationEmailJob < ApplicationJob
   queue_as :confirmation_emails
-  MailerOptions = Data.define(:title, :is_preview, :timestamp, :submission_reference, :payment_url)
 
   def perform(submission:, notify_response_id:, confirmation_email_address:)
     set_submission_logging_attributes(submission:)
@@ -8,14 +7,11 @@ class SendConfirmationEmailJob < ApplicationJob
     form = submission.form
     welsh_form = fetch_welsh_form(submission:, form:)
     mail = FormSubmissionConfirmationMailer.send_confirmation_email(
-      what_happens_next_markdown: form.what_happens_next_markdown,
-      what_happens_next_markdown_cy: welsh_form&.what_happens_next_markdown,
-      support_contact_details: form.support_details,
-      support_contact_details_cy: welsh_form&.support_details,
+      form:,
+      welsh_form:,
+      submission:,
       notify_response_id:,
       confirmation_email_address:,
-      mailer_options: mailer_options_for(submission:, form:),
-      submission_locale: submission.submission_locale,
     )
 
     mail.deliver_now
@@ -26,16 +22,6 @@ class SendConfirmationEmailJob < ApplicationJob
   end
 
 private
-
-  def mailer_options_for(submission:, form:)
-    MailerOptions.new(
-      title: form.name,
-      is_preview: submission.preview?,
-      timestamp: submission.submission_time,
-      submission_reference: submission.reference,
-      payment_url: submission.payment_url,
-    )
-  end
 
   def fetch_welsh_form(submission:, form:)
     return nil unless submission.submission_locale.to_sym == :cy

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -1,26 +1,24 @@
 class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
   include NotifyUtils
 
-  def send_confirmation_email(what_happens_next_markdown:, support_contact_details:, notify_response_id:, confirmation_email_address:, mailer_options:, submission_locale: :en, what_happens_next_markdown_cy: nil, support_contact_details_cy: nil)
-    @submission_locale = submission_locale.to_sym
+  def send_confirmation_email(form:, welsh_form:, submission:, notify_response_id:, confirmation_email_address:)
+    @submission_locale = submission.submission_locale.to_sym
     set_template(template_id)
 
+    what_happens_next_text = form.what_happens_next_markdown.presence || default_what_happens_next_text
     set_personalisation(
-      title: mailer_options.title,
-      what_happens_next_text: what_happens_next_markdown.presence || default_what_happens_next_text,
-      what_happens_next_text_cy: what_happens_next_markdown_cy.presence || what_happens_next_markdown.presence || default_what_happens_next_text,
-      support_contact_details: format_support_details(support_contact_details).presence || default_support_contact_details_text,
-      support_contact_details_cy: format_support_details(support_contact_details_cy || support_contact_details, locale: :cy).presence || default_support_contact_details_text,
-      submission_time: mailer_options.timestamp.strftime("%l:%M%P").strip,
-      submission_date: I18n.l(mailer_options.timestamp, format: "%-d %B %Y", locale: :en),
-      submission_date_cy: I18n.l(mailer_options.timestamp, format: "%-d %B %Y", locale: :cy),
-      # GOV.UK Notify's templates have conditionals, but only positive
-      # conditionals, so to simulate negative conditionals we add two boolean
-      # flags; but they must always have opposite values!
-      test: make_notify_boolean(mailer_options.is_preview),
-      submission_reference: mailer_options.submission_reference,
-      include_payment_link: make_notify_boolean(mailer_options.payment_url.present?),
-      payment_link: mailer_options.payment_url || "",
+      title: form.name,
+      what_happens_next_text:,
+      what_happens_next_text_cy: welsh_form&.what_happens_next_markdown.presence || what_happens_next_text,
+      support_contact_details: format_support_details(form.support_details).presence || default_support_contact_details_text,
+      support_contact_details_cy: welsh_support_details(form, welsh_form),
+      submission_time: submission.submission_time.strftime("%l:%M%P").strip,
+      submission_date: I18n.l(submission.submission_time, format: "%-d %B %Y", locale: :en),
+      submission_date_cy: I18n.l(submission.submission_time, format: "%-d %B %Y", locale: :cy),
+      test: make_notify_boolean(submission.preview?),
+      submission_reference: submission.reference,
+      include_payment_link: make_notify_boolean(submission.payment_url.present?),
+      payment_link: submission.payment_url || "",
     )
 
     set_reference(notify_response_id)
@@ -31,11 +29,11 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
   end
 
   def format_support_details(support_details, locale: :en)
-    phone = support_details.phone
-    call_charges_url = support_details.call_charges_url
-    email = support_details.email
-    url = support_details.url
-    url_text = support_details.url_text
+    phone = support_details&.phone
+    call_charges_url = support_details&.call_charges_url
+    email = support_details&.email
+    url = support_details&.url
+    url_text = support_details&.url_text
 
     support_details = []
     support_details << normalize_whitespace(phone) if phone.present?
@@ -47,6 +45,12 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
   end
 
 private
+
+  def welsh_support_details(form, welsh_form)
+    format_support_details(welsh_form&.support_details, locale: :cy).presence ||
+      format_support_details(form.support_details, locale: :cy).presence ||
+      default_support_contact_details_text
+  end
 
   def default_what_happens_next_text
     I18n.t("mailer.submission_confirmation.default_what_happens_next")

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -9,8 +9,6 @@ class FormSubmissionService
     end
   end
 
-  MailerOptions = Data.define(:title, :is_preview, :timestamp, :submission_reference, :payment_url)
-
   def initialize(current_context:, email_confirmation_input:, mode:)
     @current_context = current_context
     @form = current_context.form

--- a/spec/jobs/send_confirmation_email_job_spec.rb
+++ b/spec/jobs/send_confirmation_email_job_spec.rb
@@ -54,30 +54,16 @@ RSpec.describe SendConfirmationEmailJob, type: :job do
     )
 
     expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
-      what_happens_next_markdown: "Please wait for a response",
-      what_happens_next_markdown_cy: nil,
-      support_contact_details: have_attributes(
-        phone: "0203 222 2222",
-        call_charges_url: "https://www.gov.uk/call-charges",
-        email: "help@example.gov.uk",
-        url: "https://example.gov.uk/help",
-        url_text: "Get help",
-      ),
-      support_contact_details_cy: nil,
+      form: submission.form,
+      welsh_form: nil,
+      submission:,
       notify_response_id: "confirmation-ref",
       confirmation_email_address: "testing@gov.uk",
-      mailer_options: an_instance_of(SendConfirmationEmailJob::MailerOptions),
-      submission_locale: "en",
     )
   end
 
   context "when submission locale is Welsh" do
-    let(:welsh_form_document) do
-      build(:v2_form_document,
-            what_happens_next_markdown: "Arhoswch am ymateb",
-            support_phone: "0291 111 1111",
-            support_email: "cymraeg@example.gov.uk")
-    end
+    let(:welsh_form_document) { build(:v2_form_document, name: "Welsh Form") }
 
     before do
       submission.update!(submission_locale: "cy")
@@ -100,7 +86,7 @@ RSpec.describe SendConfirmationEmailJob, type: :job do
       expect(mail.govuk_notify_template).to eq("7891011")
     end
 
-    it "passes the Welsh what happens next to the mailer" do
+    it "passes the Welsh form to the mailer" do
       allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email).and_call_original
 
       described_class.perform_now(
@@ -110,24 +96,7 @@ RSpec.describe SendConfirmationEmailJob, type: :job do
       )
 
       expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
-        hash_including(what_happens_next_markdown_cy: "Arhoswch am ymateb"),
-      )
-    end
-
-    it "passes the Welsh support details" do
-      allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email).and_call_original
-
-      described_class.perform_now(
-        submission:,
-        notify_response_id:,
-        confirmation_email_address:,
-      )
-
-      expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
-        hash_including(support_contact_details_cy: have_attributes(
-          phone: "0291 111 1111",
-          email: "cymraeg@example.gov.uk",
-        )),
+        hash_including(welsh_form: have_attributes(name: welsh_form_document.name)),
       )
     end
   end

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -3,28 +3,41 @@ require "rails_helper"
 describe FormSubmissionConfirmationMailer, type: :mailer do
   let(:submission_locale) { :en }
   let(:mail) do
-    described_class.send_confirmation_email(what_happens_next_markdown:,
-                                            support_contact_details:,
+    described_class.send_confirmation_email(form:,
+                                            welsh_form:,
+                                            submission:,
                                             notify_response_id: "for-my-ref",
-                                            confirmation_email_address:,
-                                            mailer_options:,
-                                            submission_locale:)
+                                            confirmation_email_address:)
   end
-  let(:mailer_options) do
-    FormSubmissionService::MailerOptions.new(title:,
-                                             is_preview:,
-                                             timestamp: submission_timestamp,
-                                             submission_reference:,
-                                             payment_url:)
-  end
-  let(:title) { "Form 1" }
   let(:what_happens_next_markdown) { "Please wait for a response" }
-  let(:support_contact_details) { OpenStruct.new(phone: "0203 222 2222", email: nil, support_url: nil, support_url_text: nil, call_charges_url: "https://www.gov.uk/call-charges") }
+  let(:support_email) { nil }
+  let(:support_phone) { "0203 222 2222" }
+  let(:support_url) { nil }
+  let(:support_url_text) { nil }
   let(:is_preview) { false }
   let(:confirmation_email_address) { "testing@gov.uk" }
   let(:submission_timestamp) { Time.zone.now }
   let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
   let(:payment_url) { nil }
+  let(:submission) do
+    build :submission,
+          form_document:,
+          created_at: submission_timestamp,
+          reference: submission_reference,
+          submission_locale:,
+          is_preview:
+  end
+  let(:form_document) do
+    build :v2_form_document,
+          what_happens_next_markdown:,
+          support_email:,
+          support_phone:,
+          support_url:,
+          support_url_text:,
+          payment_url:
+  end
+  let(:form) { Form.new(form_document) }
+  let(:welsh_form) { nil }
 
   context "when form filler wants an form submission confirmation email" do
     before do
@@ -32,81 +45,20 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
       Settings.govuk_notify.form_filler_confirmation_email_welsh_template_id = "7891011"
     end
 
-    context "when submission_locale is :en" do
-      let(:submission_locale) { :en }
-
-      it "uses the English language template" do
-        expect(mail.govuk_notify_template).to eq("123456")
-      end
-    end
-
-    context "when submission_locale is :cy" do
-      let(:submission_locale) { :cy }
-
-      it "uses the bilingual template" do
-        expect(mail.govuk_notify_template).to eq("7891011")
-      end
-    end
-
     it "sends an email to the form filler's email address" do
       expect(mail.to).to eq(["testing@gov.uk"])
     end
 
     it "includes the form title" do
-      expect(mail.govuk_notify_personalisation[:title]).to eq("Form 1")
+      expect(mail.govuk_notify_personalisation[:title]).to eq(form.name)
     end
 
     it "includes the forms what happens next" do
       expect(mail.govuk_notify_personalisation[:what_happens_next_text]).to eq("Please wait for a response")
     end
 
-    context "when what_happens_next_markdown_cy is provided" do
-      let(:mail) do
-        described_class.send_confirmation_email(what_happens_next_markdown:,
-                                                support_contact_details:,
-                                                notify_response_id: "for-my-ref",
-                                                confirmation_email_address:,
-                                                mailer_options:,
-                                                submission_locale:,
-                                                what_happens_next_markdown_cy: "Arhoswch am ymateb")
-      end
-
-      it "includes the Welsh what happens next" do
-        expect(mail.govuk_notify_personalisation[:what_happens_next_text_cy]).to eq("Arhoswch am ymateb")
-      end
-    end
-
-    context "when what_happens_next_markdown_cy is not provided" do
-      it "falls back to the English what happens next" do
-        expect(mail.govuk_notify_personalisation[:what_happens_next_text_cy]).to eq("Please wait for a response")
-      end
-    end
-
     it "includes the forms support contact details" do
       expect(mail.govuk_notify_personalisation[:support_contact_details]).to eq("0203 222 2222\n\n[Find out about call charges](https://www.gov.uk/call-charges)")
-    end
-
-    context "when support_contact_details_cy is not provided" do
-      it "falls back to support_contact_details formatted with Welsh locale" do
-        expect(mail.govuk_notify_personalisation[:support_contact_details_cy]).to eq("0203 222 2222\n\n[Darganfyddwch am gostau galwadau](https://www.gov.uk/call-charges)")
-      end
-    end
-
-    context "when support_contact_details_cy is provided" do
-      let(:welsh_support) { OpenStruct.new(phone: "0291 111 1111", email: nil, url: nil, url_text: nil, call_charges_url: "https://www.gov.uk/call-charges") }
-      let(:mail) do
-        described_class.send_confirmation_email(what_happens_next_markdown:,
-                                                support_contact_details:,
-                                                support_contact_details_cy: welsh_support,
-                                                notify_response_id: "for-my-ref",
-                                                confirmation_email_address:,
-                                                mailer_options:,
-                                                submission_locale:)
-      end
-
-      it "uses the Welsh support details formatted with Welsh locale" do
-        expect(mail.govuk_notify_personalisation[:support_contact_details_cy]).to eq("0291 111 1111\n\n[Darganfyddwch am gostau galwadau](https://www.gov.uk/call-charges)")
-      end
     end
 
     context "when what happens next is missing" do
@@ -126,15 +78,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
     end
 
     context "when support contact details are missing" do
-      let(:support_contact_details) { OpenStruct.new(phone: nil, email: nil, url: nil, url_text: nil, call_charges_url: "https://www.gov.uk/call-charges") }
-
-      it "uses placeholder text" do
-        expect(mail.govuk_notify_personalisation[:support_contact_details]).to eq(I18n.t("mailer.submission_confirmation.default_support_contact_details"))
-      end
-    end
-
-    context "when support contact details are blank" do
-      let(:support_contact_details) { OpenStruct.new(phone: "", email: "", url: "", url_text: "", call_charges_url: "https://www.gov.uk/call-charges") }
+      let(:support_phone) { nil }
 
       it "uses placeholder text" do
         expect(mail.govuk_notify_personalisation[:support_contact_details]).to eq(I18n.t("mailer.submission_confirmation.default_support_contact_details"))
@@ -150,19 +94,19 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
       expect(mail.govuk_notify_email_reply_to).to eq("send-this-to-me@gov.uk")
     end
 
-    context "when a payment url is in" do
-      let(:payment_url) { "https://www.gov.uk/payments/test-service/pay-for-licence?reference=#{submission_reference}" }
+    context "when a payment url is set" do
+      let(:payment_url) { "https://www.gov.uk/payments/test-service/pay-for-licence" }
 
       it "sets the boolean for the payment content to 'yes'" do
         expect(mail.govuk_notify_personalisation[:include_payment_link]).to eq("yes")
       end
 
       it "sets the payment_link" do
-        expect(mail.govuk_notify_personalisation[:payment_link]).to eq(payment_url)
+        expect(mail.govuk_notify_personalisation[:payment_link]).to eq("#{payment_url}?reference=#{submission_reference}")
       end
     end
 
-    context "when a payment link is not set" do
+    context "when a payment url is not set" do
       let(:payment_url) { nil }
 
       it "sets the boolean for the payment content to 'no'" do
@@ -171,6 +115,56 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
 
       it "sets the payment link personalisation to an empty string" do
         expect(mail.govuk_notify_personalisation[:payment_link]).to eq("")
+      end
+    end
+
+    context "when submission_locale is :en" do
+      let(:submission_locale) { :en }
+
+      it "uses the English language template" do
+        expect(mail.govuk_notify_template).to eq("123456")
+      end
+    end
+
+    context "when submission_locale is :cy" do
+      let(:submission_locale) { :cy }
+
+      it "uses the bilingual template" do
+        expect(mail.govuk_notify_template).to eq("7891011")
+      end
+
+      context "when a Welsh version of the form is present" do
+        let(:welsh_what_happens_next_markdown) { "Arhoswch am ymateb" }
+        let(:welsh_support_phone) { "0291 111 1111" }
+        let(:welsh_form) do
+          build :form,
+                what_happens_next_markdown: welsh_what_happens_next_markdown,
+                support_phone: welsh_support_phone
+        end
+
+        it "includes the Welsh what happens next" do
+          expect(mail.govuk_notify_personalisation[:what_happens_next_text_cy]).to eq(welsh_what_happens_next_markdown)
+        end
+
+        it "uses the Welsh support details formatted with Welsh locale" do
+          expect(mail.govuk_notify_personalisation[:support_contact_details_cy]).to eq("0291 111 1111\n\n[Darganfyddwch am gostau galwadau](https://www.gov.uk/call-charges)")
+        end
+
+        context "when the what happens next is not set on the Welsh form" do
+          let(:welsh_what_happens_next_markdown) { nil }
+
+          it "falls back to the English what happens next" do
+            expect(mail.govuk_notify_personalisation[:what_happens_next_text_cy]).to eq(what_happens_next_markdown)
+          end
+        end
+
+        context "when the contact details are not set on the Welsh form" do
+          let(:welsh_support_phone) { nil }
+
+          it "falls back to support_contact_details formatted with Welsh locale" do
+            expect(mail.govuk_notify_personalisation[:support_contact_details_cy]).to eq("0203 222 2222\n\n[Darganfyddwch am gostau galwadau](https://www.gov.uk/call-charges)")
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/NLqWmwvf

This Data object existed before the Submission model existed and was used to pass common data used by the submission and confirmation emails.

It is no longer needed, and we can instead pass the Submission and Form objects to the mailer to get the data we need.

This means we don't need to pass attributes for all the form attributes that have Welsh translations.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
