### PR TITLE
Store Welsh from document on submission

### DIFF
--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -53,7 +53,15 @@ private
 
     raise ActiveResource::ResourceNotFound.new(404, "Not Found") if english_form_document.nil?
 
+    @welsh_form = form if form.welsh?
     @form = Form.new(english_form_document)
+  end
+
+  def welsh_form_document
+    return unless submission_locale == :cy
+    return @welsh_form.document_json if @welsh_form.present?
+
+    Api::V2::FormDocumentRepository.find_with_mode(form_id: form.id, mode:, language: :cy)
   end
 
   def validate_submission
@@ -89,6 +97,7 @@ private
       answers: current_context.answers,
       mode: mode,
       form_document: form.document_json,
+      welsh_form_document: welsh_form_document,
       submission_locale:,
       created_at: timestamp,
     )

--- a/db/migrate/20260520093250_add_welsh_form_document_to_submissions.rb
+++ b/db/migrate/20260520093250_add_welsh_form_document_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddWelshFormDocumentToSubmissions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :submissions, :welsh_form_document, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_142828) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_20_093250) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -46,6 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_142828) do
     t.string "reference"
     t.string "submission_locale", default: "en", null: false, comment: "The language the form was submitted in ISO 2 letter format. Normally either 'en' or 'cy'"
     t.datetime "updated_at", null: false
+    t.jsonb "welsh_form_document"
     t.index ["created_at", "form_id", "mode"], name: "index_submissions_on_created_at_and_form_id_and_mode"
   end
 

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -190,8 +190,12 @@ RSpec.describe FormSubmissionService, :capture_logging do
           }.to change(Submission, :count).by(1)
                                          .and change(Delivery, :count).by(1)
 
-          expect(Submission.last).to have_attributes(reference:, form_id: form.id, answers: answers.deep_stringify_keys,
-                                                     mode: "form", form_document: document_json,
+          expect(Submission.last).to have_attributes(reference:,
+                                                     form_id: form.id,
+                                                     answers: answers.deep_stringify_keys,
+                                                     mode: "form",
+                                                     form_document: document_json,
+                                                     welsh_form_document: nil,
                                                      submission_locale: "en")
         end
 
@@ -283,6 +287,32 @@ RSpec.describe FormSubmissionService, :capture_logging do
         end
       end
 
+      context "when Welsh has been used to complete the form" do
+        let(:locales_used) { %i[en cy] }
+
+        before do
+          ActiveResource::HttpMock.respond_to do |mock|
+            mock.get "/api/v2/forms/1/live?language=cy", {}, welsh_form_document.to_json, 200
+          end
+        end
+
+        it "fetches the Welsh form" do
+          service.submit
+          expect(ActiveResource::HttpMock.requests).to include ActiveResource::Request.new(:get, "/api/v2/forms/1/live?language=cy")
+        end
+
+        it "saves the submission data including the Welsh version of the form" do
+          expect {
+            service.submit
+          }.to change(Submission, :count).by(1)
+
+          expect(Submission.last.form_document["language"]).to eq("en")
+          expect(Submission.last.form_document["name"]).to eq("Form 1")
+          expect(Submission.last.welsh_form_document["language"]).to eq("cy")
+          expect(Submission.last.welsh_form_document["name"]).to eq("Welsh Form 1")
+        end
+      end
+
       context "when form is not in english" do
         let(:submission_type) { "email" }
         let(:submission_format) { [] }
@@ -305,9 +335,21 @@ RSpec.describe FormSubmissionService, :capture_logging do
             service.submit
           }.to change(Submission, :count).by(1)
 
-          # expect(Submission.last).to have_attributes(form_id: form.id, answers: answers.deep_stringify_keys, form_document: document_json)
           expect(Submission.last.form_document["language"]).to eq("en")
           expect(Submission.last.form_document["name"]).to eq("Form 1")
+        end
+
+        context "when Welsh has been used to complete the form" do
+          let(:locales_used) { %i[en cy] }
+
+          it "saves the original Welsh version of the form on the submission" do
+            expect {
+              service.submit
+            }.to change(Submission, :count).by(1)
+
+            expect(Submission.last.welsh_form_document["language"]).to eq("cy")
+            expect(Submission.last.welsh_form_document["name"]).to eq("Welsh Form 1")
+          end
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/hCWhyMOm

In order to send confirmation emails with a copy of the user's answers in Welsh, we need to store the Welsh version of the form document at the time of submission in order to get the Welsh translations for the questions that exist in the form at that moment in time. 

This is necessary as we send confirmation emails asynchronously using ActiveJob, so cannot retrieve the document from forms-admin at the time of sending as it may have changed since the submission.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
