### PR TITLE
Add missing Welsh personalisations for confirmation email

### DIFF
--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -8,6 +8,7 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
     what_happens_next_text = form.what_happens_next_markdown.presence || default_what_happens_next_text
     set_personalisation(
       title: form.name,
+      title_cy: welsh_form&.name || form.name,
       what_happens_next_text:,
       what_happens_next_text_cy: welsh_form&.what_happens_next_markdown.presence || what_happens_next_text,
       support_contact_details: format_support_details(form.support_details).presence || default_support_contact_details_text,
@@ -18,7 +19,8 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
       test: make_notify_boolean(submission.preview?),
       submission_reference: submission.reference,
       include_payment_link: make_notify_boolean(submission.payment_url.present?),
-      payment_link: submission.payment_url || "",
+      payment_link: form.payment_url_with_reference(submission.reference) || "",
+      payment_link_cy: welsh_form&.payment_url_with_reference(submission.reference) || "",
     )
 
     set_reference(notify_response_id)

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -53,6 +53,20 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
       expect(mail.govuk_notify_personalisation[:title]).to eq(form.name)
     end
 
+    context "when no Welsh form is provided" do
+      it "falls back to the English title for title_cy" do
+        expect(mail.govuk_notify_personalisation[:title_cy]).to eq(form.name)
+      end
+    end
+
+    context "when a Welsh form is provided" do
+      let(:welsh_form) { Form.new(build(:v2_form_document, name: "Ffurflen 1")) }
+
+      it "uses the Welsh form name as title_cy" do
+        expect(mail.govuk_notify_personalisation[:title_cy]).to eq("Ffurflen 1")
+      end
+    end
+
     it "includes the forms what happens next" do
       expect(mail.govuk_notify_personalisation[:what_happens_next_text]).to eq("Please wait for a response")
     end
@@ -104,6 +118,19 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
       it "sets the payment_link" do
         expect(mail.govuk_notify_personalisation[:payment_link]).to eq("#{payment_url}?reference=#{submission_reference}")
       end
+
+      it "sets payment_link_cy to an empty string when no Welsh form is provided" do
+        expect(mail.govuk_notify_personalisation[:payment_link_cy]).to eq("")
+      end
+
+      context "when the Welsh form has a payment url" do
+        let(:welsh_payment_url) { "https://www.gov.uk/payments/welsh-service/pay-for-licence" }
+        let(:welsh_form) { Form.new(build(:v2_form_document, payment_url: welsh_payment_url)) }
+
+        it "sets payment_link_cy to the Welsh payment url with reference" do
+          expect(mail.govuk_notify_personalisation[:payment_link_cy]).to eq("#{welsh_payment_url}?reference=#{submission_reference}")
+        end
+      end
     end
 
     context "when a payment url is not set" do
@@ -115,6 +142,10 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
 
       it "sets the payment link personalisation to an empty string" do
         expect(mail.govuk_notify_personalisation[:payment_link]).to eq("")
+      end
+
+      it "sets the Welsh payment link personalisation to an empty string" do
+        expect(mail.govuk_notify_personalisation[:payment_link_cy]).to eq("")
       end
     end
 

--- a/spec/requests/forms/check_your_answers_controller_spec.rb
+++ b/spec/requests/forms/check_your_answers_controller_spec.rb
@@ -496,6 +496,7 @@ RSpec.describe Forms::CheckYourAnswersController, :capture_logging, type: :reque
 
         expected_personalisation = {
           title: form_data.name,
+          title_cy: form_data.name,
           what_happens_next_text: form_data.what_happens_next_markdown,
           what_happens_next_text_cy: form_data.what_happens_next_markdown,
           support_contact_details: contact_support_details_format,
@@ -507,6 +508,7 @@ RSpec.describe Forms::CheckYourAnswersController, :capture_logging, type: :reque
           submission_reference: reference,
           include_payment_link: "no",
           payment_link: "",
+          payment_link_cy: "",
         }
 
         expect(mail.body.raw_source).to include(expected_personalisation.to_s)


### PR DESCRIPTION
### What problem does this pull request solve?

A couple were missed from https://github.com/govuk-forms/forms-runner/pull/2083

The Notify template will also need updating

Trello card: https://trello.com/c/NLqWmwvf/2894-update-confirmation-emails-to-cater-for-new-welsh-form-submissions

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
