### PR TITLE
Send confirmation emails with a copy of answers using SES

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem "govuk-components", "~> 6"
 gem "govuk_design_system_formbuilder", "~> 6"
 
 # Our own custom markdown renderer
-gem "govuk-forms-markdown", github: "govuk-forms/govuk-forms-markdown", tag: "0.8.0"
+gem "govuk-forms-markdown", github: "govuk-forms/govuk-forms-markdown", tag: "0.9.0"
 
 # For compiling our frontend assets
 gem "vite_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,10 +22,10 @@ GIT
 
 GIT
   remote: https://github.com/govuk-forms/govuk-forms-markdown.git
-  revision: 62bcbf4390aa4998390c1390debcbf250aa90ec0
-  tag: 0.8.0
+  revision: 84c6b2296accca578e7b77e7d1730472d9c9e7af
+  tag: 0.9.0
   specs:
-    govuk-forms-markdown (0.8.0)
+    govuk-forms-markdown (0.9.0)
       redcarpet (~> 3.6)
 
 GEM
@@ -860,7 +860,6 @@ CHECKSUMS
   bootsnap (1.24.4) sha256=a4d939fc2cc5242a83d3a7cb4fb97743ac58475afe91e0600479a3df6f117541
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   coercible (1.0.0) sha256=5081ad24352cc8435ce5472bc2faa30260c7ea7f2102cc6a9f167c4d9bffaadc
@@ -898,7 +897,7 @@ CHECKSUMS
   google-protobuf (4.35.0-x86_64-linux-musl) sha256=be0218520d77b2aee898b363514b03819f6f63f9c041ae0d0d79b4ce5247bffd
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   govuk-components (6.2.0) sha256=85ec75f93b425e62cbedf83e04a749d7cdd35eeed6208071974dd24775013207
-  govuk-forms-markdown (0.8.0)
+  govuk-forms-markdown (0.9.0)
   govuk_design_system_formbuilder (6.1.0) sha256=b0fdb3714e59665f1a522291840bcc89801cb4325f243e8717e0f9be87d1192c
   govuk_notify_rails (3.0.0) sha256=e0e1b8b0a7c47f90963034f290fb2982652aa8051a733c25c178680d44f2d7aa
   hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d

--- a/app/helpers/email_format_helper.rb
+++ b/app/helpers/email_format_helper.rb
@@ -1,3 +1,5 @@
+require "govuk_forms_markdown"
+
 module EmailFormatHelper
   def normalize_whitespace(text)
     text.strip.gsub(/\r\n?/, "\n").split(/\n\n+/).map(&:strip).join("\n\n")
@@ -10,6 +12,14 @@ module EmailFormatHelper
   def normalize_whitespace_and_convert_to_html(text)
     output = normalize_whitespace(text)
     convert_newlines_to_html(output)
+  end
+
+  def markdown_to_html(markdown)
+    HtmlMarkdownSanitizer.new.render_scrubbed_markdown(markdown, allow_headings: false, for_email: true)
+  end
+
+  def markdown_to_plain_text(markdown)
+    GovukFormsMarkdown.render_plain_text(markdown)
   end
 
   def format_date(datetime)

--- a/app/jobs/send_confirmation_email_job.rb
+++ b/app/jobs/send_confirmation_email_job.rb
@@ -4,11 +4,7 @@ class SendConfirmationEmailJob < ApplicationJob
   def perform(submission:, notify_response_id:, confirmation_email_address:)
     set_submission_logging_attributes(submission:)
 
-    form = submission.form
-    welsh_form = fetch_welsh_form(submission:, form:)
     mail = FormSubmissionConfirmationMailer.send_confirmation_email(
-      form:,
-      welsh_form:,
       submission:,
       notify_response_id:,
       confirmation_email_address:,
@@ -19,18 +15,5 @@ class SendConfirmationEmailJob < ApplicationJob
   rescue StandardError
     CloudWatchService.record_job_failure_metric(self.class.name)
     raise
-  end
-
-private
-
-  def fetch_welsh_form(submission:, form:)
-    return nil unless submission.submission_locale.to_sym == :cy
-
-    form_document = Api::V2::FormDocumentRepository.find_with_mode(
-      form_id: form.id,
-      mode: submission.mode_object,
-      language: :cy,
-    )
-    Form.new(form_document) if form_document
   end
 end

--- a/app/jobs/send_confirmation_email_job.rb
+++ b/app/jobs/send_confirmation_email_job.rb
@@ -1,17 +1,21 @@
 class SendConfirmationEmailJob < ApplicationJob
   queue_as :confirmation_emails
 
-  def perform(submission:, notify_response_id:, confirmation_email_address:)
+  def perform(submission:, notify_response_id:, confirmation_email_address:, include_copy_of_answers: false)
     set_submission_logging_attributes(submission:)
 
-    mail = FormSubmissionConfirmationMailer.send_confirmation_email(
-      submission:,
-      notify_response_id:,
-      confirmation_email_address:,
-    )
+    mail = if include_copy_of_answers
+             AwsSesSubmissionConfirmationMailer.submission_confirmation_email(
+               submission:, confirmation_email_address:, include_copy_of_answers:,
+             )
+           else
+             FormSubmissionConfirmationMailer.send_confirmation_email(
+               submission:, notify_response_id:, confirmation_email_address:,
+             )
+           end
 
     mail.deliver_now
-    CurrentJobLoggingAttributes.confirmation_email_id = mail.govuk_notify_response.id
+    CurrentJobLoggingAttributes.confirmation_email_id = mail.govuk_notify_response&.id.presence || mail.message_id
   rescue StandardError
     CloudWatchService.record_job_failure_metric(self.class.name)
     raise

--- a/app/jobs/send_confirmation_email_job.rb
+++ b/app/jobs/send_confirmation_email_job.rb
@@ -4,18 +4,22 @@ class SendConfirmationEmailJob < ApplicationJob
   def perform(submission:, notify_response_id:, confirmation_email_address:, include_copy_of_answers: false)
     set_submission_logging_attributes(submission:)
 
-    mail = if include_copy_of_answers
-             AwsSesSubmissionConfirmationMailer.submission_confirmation_email(
-               submission:, confirmation_email_address:, include_copy_of_answers:,
-             )
-           else
-             FormSubmissionConfirmationMailer.send_confirmation_email(
-               submission:, notify_response_id:, confirmation_email_address:,
-             )
-           end
+    # The job will use the locale at the time it was created. Force it to be "en" as we send multilingual emails for
+    # forms submitted in Welsh.
+    I18n.with_locale("en") do
+      mail = if include_copy_of_answers
+               AwsSesSubmissionConfirmationMailer.submission_confirmation_email(
+                 submission:, confirmation_email_address:, include_copy_of_answers:,
+               )
+             else
+               FormSubmissionConfirmationMailer.send_confirmation_email(
+                 submission:, notify_response_id:, confirmation_email_address:,
+               )
+             end
 
-    mail.deliver_now
-    CurrentJobLoggingAttributes.confirmation_email_id = mail.govuk_notify_response&.id.presence || mail.message_id
+      mail.deliver_now
+      CurrentJobLoggingAttributes.confirmation_email_id = mail.govuk_notify_response&.id.presence || mail.message_id
+    end
   rescue StandardError
     CloudWatchService.record_job_failure_metric(self.class.name)
     raise

--- a/app/lib/html_markdown_sanitizer.rb
+++ b/app/lib/html_markdown_sanitizer.rb
@@ -17,8 +17,14 @@ class HtmlMarkdownSanitizer
 
   # renders Markdown to HTML and strips out all tags not explicitly allowed in LimitedHtmlScrubber.
   # Use this instead of rendering Markdown directly in views.
-  def render_scrubbed_markdown(markdown)
-    sanitize_html(GovukFormsMarkdown.render(markdown, locale: I18n.locale.to_s), LimitedHtmlScrubber.new(allow_headings: true))
+  def render_scrubbed_markdown(markdown, allow_headings: true, for_email: false)
+    html = if for_email
+             GovukFormsMarkdown.render_for_email(markdown)
+           else
+             GovukFormsMarkdown.render(markdown, locale: I18n.locale.to_s)
+           end
+
+    sanitize_html(html, LimitedHtmlScrubber.new(allow_headings:, for_email:))
   end
 
   # renders the limited subset of HTML allowed by LimitedHtmlScrubber and strips all other tags.

--- a/app/lib/limited_html_scrubber.rb
+++ b/app/lib/limited_html_scrubber.rb
@@ -1,9 +1,9 @@
 class LimitedHtmlScrubber < Rails::Html::PermitScrubber
-  def initialize(allow_headings: false)
+  def initialize(allow_headings: false, for_email: false)
     super()
 
-    self.tags = ["a", "ol", "ul", "li", "p", "br", *(%w[h2 h3] if allow_headings)]
+    self.tags = ["a", "ol", "ul", "li", "p", "br", *(%w[h2 h3] if allow_headings), *(%w[table tr td] if for_email)]
 
-    self.attributes = %w[href class rel target title]
+    self.attributes = ["href", "class", "rel", "target", "title", *(%w[style] if for_email)]
   end
 end

--- a/app/lib/ses_email_formatter.rb
+++ b/app/lib/ses_email_formatter.rb
@@ -6,9 +6,10 @@ class SesEmailFormatter
 
   class FormattingError < StandardError; end
 
-  def initialize(submission_reference:, steps:)
+  def initialize(submission_reference:, steps:, confirmation_email:)
     @submission_reference = submission_reference
     @steps = steps
+    @confirmation_email = confirmation_email
   end
 
   def build_question_answers_section_html(heading_tag: "h3")
@@ -58,7 +59,7 @@ private
   end
 
   def prep_answer_text(step)
-    answer = step.show_answer_in_email(submission_reference: @submission_reference)
+    answer = step.show_answer_in_email(submission_reference: @submission_reference, confirmation_email: @confirmation_email)
 
     return "[#{I18n.t('mailer.submission.question_skipped')}]" if answer.blank?
 

--- a/app/lib/ses_email_formatter.rb
+++ b/app/lib/ses_email_formatter.rb
@@ -11,9 +11,9 @@ class SesEmailFormatter
     @steps = steps
   end
 
-  def build_question_answers_section_html
+  def build_question_answers_section_html(heading_tag: "h3")
     @steps.map { |step|
-      [prep_question_title_html(step),
+      [prep_question_title_html(step, heading_tag),
        prep_answer_text_html(step)].join
     }.join(H_RULE)
   end
@@ -27,8 +27,8 @@ class SesEmailFormatter
 
 private
 
-  def prep_question_title_html(step)
-    "<h3>#{prep_question_title_plain_text(step)}</h3>"
+  def prep_question_title_html(step, heading_tag)
+    "<#{heading_tag}>#{prep_question_title_plain_text(step)}</#{heading_tag}>"
   end
 
   def prep_answer_text_html(step)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  helper :email_format
+  helper EmailFormatHelper
 
   layout "mailer"
 

--- a/app/mailers/aws_ses_submission_confirmation_mailer.rb
+++ b/app/mailers/aws_ses_submission_confirmation_mailer.rb
@@ -1,0 +1,29 @@
+class AwsSesSubmissionConfirmationMailer < ApplicationMailer
+  def submission_confirmation_email(
+    submission:,
+    confirmation_email_address:,
+    include_copy_of_answers:
+  )
+    @submission_locale = submission.submission_locale.to_sym
+    @form = submission.form
+    @welsh_form = submission.welsh_form
+    @submission = submission
+    @include_copy_of_answers = include_copy_of_answers
+
+    mail(to: confirmation_email_address, subject: subject)
+  end
+
+  def subject
+    subject = if @submission.preview?
+                I18n.t("mailer.submission_confirmation.subject_preview", reference: @submission.reference)
+              else
+                I18n.t("mailer.submission_confirmation.subject", reference: @submission.reference)
+              end
+
+    if @submission_locale == :cy
+      subject = "#{subject} | #{I18n.t('mailer.submission_confirmation.subject', reference: @submission.reference, locale: :cy)}"
+    end
+
+    subject
+  end
+end

--- a/app/mailers/form_submission_confirmation_mailer.rb
+++ b/app/mailers/form_submission_confirmation_mailer.rb
@@ -2,10 +2,12 @@ class FormSubmissionConfirmationMailer < GovukNotifyRails::Mailer
   include NotifyUtils
   include EmailFormatHelper
 
-  def send_confirmation_email(form:, welsh_form:, submission:, notify_response_id:, confirmation_email_address:)
+  def send_confirmation_email(submission:, notify_response_id:, confirmation_email_address:)
     @submission_locale = submission.submission_locale.to_sym
     set_template(template_id)
 
+    form = submission.form
+    welsh_form = submission.welsh_form
     what_happens_next_text = form.what_happens_next_markdown.presence || default_what_happens_next_text
     set_personalisation(
       title: form.name,

--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -44,10 +44,14 @@ module Question
       original_filename
     end
 
-    def show_answer_in_email(submission_reference:)
+    def show_answer_in_email(submission_reference:, confirmation_email: false)
       return nil if original_filename.blank?
 
-      I18n.t("mailer.submission.file_attached", filename: email_filename(submission_reference:))
+      if confirmation_email
+        I18n.t("mailer.submission_confirmation.file_answer", filename: original_filename)
+      else
+        I18n.t("mailer.submission.file_attached", filename: email_filename(submission_reference:))
+      end
     end
 
     def show_answer_in_csv(submission_reference:, is_s3_submission:)

--- a/app/models/repeatable_step.rb
+++ b/app/models/repeatable_step.rb
@@ -77,9 +77,9 @@ class RepeatableStep < Step
     end
   end
 
-  def show_answer_in_email(submission_reference:)
+  def show_answer_in_email(submission_reference:, confirmation_email: false)
     questions.map.with_index(1) { |question, index|
-      "#{index}. #{question.show_answer_in_email(submission_reference:)}"
+      "#{index}. #{question.show_answer_in_email(submission_reference:, confirmation_email:)}"
     }.join("\n\n")
   end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -59,12 +59,12 @@ class Submission < ApplicationRecord
     Mode.new(mode)
   end
 
-  def answer_content_for_email_html(heading_tag:, locale: :en)
-    ses_email_formatter(locale).build_question_answers_section_html(heading_tag:)
+  def answer_content_for_email_html(heading_tag:, locale: :en, confirmation_email: false)
+    ses_email_formatter(locale, confirmation_email).build_question_answers_section_html(heading_tag:)
   end
 
-  def answer_content_for_email_plain_text(locale: :en)
-    ses_email_formatter(locale).build_question_answers_section_plain_text
+  def answer_content_for_email_plain_text(locale: :en, confirmation_email: false)
+    ses_email_formatter(locale, confirmation_email).build_question_answers_section_plain_text
   end
 
 private
@@ -81,8 +81,9 @@ private
     @form_document_resource ||= Api::V2::FormDocumentResource.new(form_document, true)
   end
 
-  def ses_email_formatter(locale)
-    SesEmailFormatter.new(submission_reference: reference, steps: journey(locale:).completed_steps)
+  def ses_email_formatter(locale, confirmation_email)
+    SesEmailFormatter.new(submission_reference: reference, steps: journey(locale:).completed_steps,
+                          confirmation_email:)
   end
 
   def english_journey

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -24,8 +24,10 @@ class Submission < ApplicationRecord
 
   encrypts :answers
 
-  def journey
-    @journey ||= Flow::Journey.new(answer_store:, form_document: form_document_resource)
+  def journey(locale: :en)
+    return welsh_journey if locale.to_sym == :cy
+
+    english_journey
   end
 
   def form
@@ -57,12 +59,12 @@ class Submission < ApplicationRecord
     Mode.new(mode)
   end
 
-  def answer_content_for_email_html(heading_tag:)
-    ses_email_formatter.build_question_answers_section_html(heading_tag:)
+  def answer_content_for_email_html(heading_tag:, locale: :en)
+    ses_email_formatter(locale).build_question_answers_section_html(heading_tag:)
   end
 
-  def answer_content_for_email_plain_text
-    ses_email_formatter.build_question_answers_section_plain_text
+  def answer_content_for_email_plain_text(locale: :en)
+    ses_email_formatter(locale).build_question_answers_section_plain_text
   end
 
 private
@@ -79,8 +81,16 @@ private
     @form_document_resource ||= Api::V2::FormDocumentResource.new(form_document, true)
   end
 
-  def ses_email_formatter
-    SesEmailFormatter.new(submission_reference: reference, steps: journey.completed_steps)
+  def ses_email_formatter(locale)
+    SesEmailFormatter.new(submission_reference: reference, steps: journey(locale:).completed_steps)
+  end
+
+  def english_journey
+    @english_journey ||= Flow::Journey.new(answer_store:, form_document: form_document_resource)
+  end
+
+  def welsh_journey
+    @welsh_journey ||= Flow::Journey.new(answer_store:, form_document: welsh_form_document_resource)
   end
 
   def welsh_form_document_resource

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -32,6 +32,10 @@ class Submission < ApplicationRecord
     @form ||= form_from_document
   end
 
+  def welsh_form
+    @welsh_form ||= Form.new(welsh_form_document_resource) if welsh_form_document
+  end
+
   def submission_time
     created_at.in_time_zone(TimeZoneUtils.submission_time_zone)
   end
@@ -77,5 +81,9 @@ private
 
   def ses_email_formatter
     SesEmailFormatter.new(submission_reference: reference, steps: journey.completed_steps)
+  end
+
+  def welsh_form_document_resource
+    @welsh_form_document_resource ||= Api::V2::FormDocumentResource.new(welsh_form_document, true)
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -57,8 +57,8 @@ class Submission < ApplicationRecord
     Mode.new(mode)
   end
 
-  def answer_content_for_email_html
-    ses_email_formatter.build_question_answers_section_html
+  def answer_content_for_email_html(heading_tag:)
+    ses_email_formatter.build_question_answers_section_html(heading_tag:)
   end
 
   def answer_content_for_email_plain_text

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -27,7 +27,7 @@ class FormSubmissionService
     validate_confirmation_email_address if requested_confirmation?
 
     submission = deliver_submission
-    enqueue_send_confirmation_email_job(submission:) if requested_confirmation?
+    enqueue_send_confirmation_email_job(submission:) if requested_confirmation? || send_copy_of_answers?
 
     submission_reference
   end
@@ -142,7 +142,8 @@ private
     SendConfirmationEmailJob.perform_later(
       submission:,
       notify_response_id: email_confirmation_input.confirmation_email_reference,
-      confirmation_email_address: email_confirmation_input.confirmation_email_address,
+      confirmation_email_address: confirmation_email_address,
+      include_copy_of_answers: send_copy_of_answers?,
     ) do |job|
       next if job.successfully_enqueued?
 
@@ -153,5 +154,17 @@ private
 
   def requested_confirmation?
     email_confirmation_input.send_confirmation == "send_email"
+  end
+
+  def send_copy_of_answers?
+    @current_context.wants_copy_of_answers? && @current_context.get_copy_of_answers_email_address.present?
+  end
+
+  def confirmation_email_address
+    if send_copy_of_answers?
+      @current_context.get_copy_of_answers_email_address
+    else
+      email_confirmation_input.confirmation_email_address
+    end
   end
 end

--- a/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
@@ -40,7 +40,7 @@
   <p><%= I18n.t("mailer.submission.json_file", filename: @json_filename) %></p>
 <% end %>
 
-<%= @submission.answer_content_for_email_html.html_safe %>
+<%= @submission.answer_content_for_email_html(heading_tag: "h3").html_safe %>
 
 <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
 

--- a/app/views/aws_ses_submission_confirmation_mailer/_content.html.erb
+++ b/app/views/aws_ses_submission_confirmation_mailer/_content.html.erb
@@ -33,7 +33,7 @@
 
 <% if @include_copy_of_answers %>
   <h3><%= I18n.t("mailer.submission_confirmation.answers_submitted_heading") %></h3>
-  <%= @submission.answer_content_for_email_html(heading_tag: "h4").html_safe %>
+  <%= @submission.answer_content_for_email_html(heading_tag: "h4", locale: locale).html_safe %>
   <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
 <% end %>
 

--- a/app/views/aws_ses_submission_confirmation_mailer/_content.html.erb
+++ b/app/views/aws_ses_submission_confirmation_mailer/_content.html.erb
@@ -33,7 +33,7 @@
 
 <% if @include_copy_of_answers %>
   <h3><%= I18n.t("mailer.submission_confirmation.answers_submitted_heading") %></h3>
-  <%= @submission.answer_content_for_email_html(heading_tag: "h4", locale: locale).html_safe %>
+  <%= @submission.answer_content_for_email_html(heading_tag: "h4", locale: locale, confirmation_email: true).html_safe %>
   <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
 <% end %>
 

--- a/app/views/aws_ses_submission_confirmation_mailer/_content.html.erb
+++ b/app/views/aws_ses_submission_confirmation_mailer/_content.html.erb
@@ -1,0 +1,57 @@
+<% if @submission.preview? %>
+  <h2><%= I18n.t("mailer.submission_confirmation.title_preview") %></h2>
+  <p><%= I18n.t("mailer.submission_confirmation.this_is_a_test") %></p>
+<% else %>
+  <h2><%= I18n.t("mailer.submission_confirmation.title") %></h2>
+<% end %>
+
+<p><%= I18n.t("mailer.submission_confirmation.submitted_at", form_name: form.name,
+              time: format_time(@submission.submission_time),
+              date: format_date(@submission.submission_time)) %></p>
+
+<p><%= I18n.t("mailer.submission_confirmation.reference_number", reference: @submission.reference) %></p>
+
+<div
+  style="margin: 0 0 20px 0; border-left: 10px solid #B1B4B6;
+    padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;"
+>
+  <p style="margin: 0 0 20px 0"><%= I18n.t("mailer.submission_confirmation.you_cannot_reply") %></p>
+</div>
+
+
+<% if form.payment_url.present? %>
+  <h3><%= I18n.t("mailer.submission_confirmation.payment_link_heading") %></h3>
+  <p><%= I18n.t("mailer.submission_confirmation.payment_link_html", payment_link: form.payment_url_with_reference(@submission.reference)).html_safe %></p>
+<% end %>
+
+<h3><%= I18n.t("mailer.submission_confirmation.what_happens_next_heading") %></h3>
+<% if form.what_happens_next_markdown.present? %>
+  <%= markdown_to_html(form.what_happens_next_markdown) %>
+<% else %>
+  <p><%= I18n.t("mailer.submission_confirmation.default_what_happens_next") %></p>
+<% end %>
+
+<% if @include_copy_of_answers %>
+  <h3><%= I18n.t("mailer.submission_confirmation.answers_submitted_heading") %></h3>
+  <%= @submission.answer_content_for_email_html.html_safe %>
+  <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
+<% end %>
+
+<h3><%= I18n.t("mailer.submission_confirmation.contact_details_heading") %></h3>
+
+<% if form.support_details.phone || form.support_details.email || form.support_details.url %>
+  <% if form.support_details.phone.present? %>
+    <p><%= normalize_whitespace_and_convert_to_html(form.support_details.phone).html_safe %></p>
+    <p><a href="<%= form.support_details.call_charges_url %>"><%= I18n.t('support_details.call_charges') %></a></p>
+  <% end %>
+
+  <% if form.support_details.email.present? %>
+    <p><a href="mailto:<%= form.support_details.email %>"><%= form.support_details.email %></a></p>
+  <% end %>
+
+  <% if form.support_details.url.present? && form.support_details.url_text.present? %>
+    <p><a href="<%= form.support_details.url %>"><%= form.support_details.url_text %></a></p>
+  <% end %>
+<% else %>
+  <p><%= I18n.t("mailer.submission_confirmation.default_support_contact_details") %></p>
+<% end %>

--- a/app/views/aws_ses_submission_confirmation_mailer/_content.html.erb
+++ b/app/views/aws_ses_submission_confirmation_mailer/_content.html.erb
@@ -33,7 +33,7 @@
 
 <% if @include_copy_of_answers %>
   <h3><%= I18n.t("mailer.submission_confirmation.answers_submitted_heading") %></h3>
-  <%= @submission.answer_content_for_email_html.html_safe %>
+  <%= @submission.answer_content_for_email_html(heading_tag: "h4").html_safe %>
   <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
 <% end %>
 

--- a/app/views/aws_ses_submission_confirmation_mailer/_content.text.erb
+++ b/app/views/aws_ses_submission_confirmation_mailer/_content.text.erb
@@ -1,0 +1,55 @@
+<% if @submission.preview? %>
+<%= I18n.t("mailer.submission_confirmation.title_preview") %>
+
+<%= I18n.t("mailer.submission_confirmation.this_is_a_test") %>
+<% else %>
+<%= I18n.t("mailer.submission_confirmation.title") %>
+<% end %>
+
+<%= I18n.t("mailer.submission_confirmation.submitted_at", form_name: form.name,
+              time: format_time(@submission.submission_time),
+              date: format_date(@submission.submission_time)) %>
+
+<%= I18n.t("mailer.submission_confirmation.reference_number", reference: @submission.reference) %>
+
+<%= I18n.t("mailer.submission_confirmation.you_cannot_reply") %>
+
+<% if form.payment_url.present? %>
+<%= I18n.t("mailer.submission_confirmation.payment_link_heading") %>
+
+<%= strip_tags(I18n.t("mailer.submission_confirmation.payment_link_html", payment_link: form.payment_url_with_reference(@submission.reference))) %>
+
+<% end %>
+<%= I18n.t("mailer.submission_confirmation.what_happens_next_heading") %>
+
+<% if form.what_happens_next_markdown.present? %>
+<%= markdown_to_plain_text(form.what_happens_next_markdown) %>
+<% else %>
+<%= I18n.t("mailer.submission_confirmation.default_what_happens_next") %>
+<% end %>
+
+<% if @include_copy_of_answers %>
+<%= I18n.t("mailer.submission_confirmation.answers_submitted_heading") %>
+
+<%= @submission.answer_content_for_email_plain_text(locale: locale) %>
+
+<% end %>
+<%= I18n.t("mailer.submission_confirmation.contact_details_heading") %>
+
+<% if form.support_details.phone || form.support_details.email || form.support_details.url %>
+  <% if form.support_details.phone.present? %>
+<%= normalize_whitespace(form.support_details.phone).html_safe %>
+
+<%= I18n.t('support_details.call_charges') %>: <%= form.support_details.call_charges_url %>
+  <% end %>
+
+  <% if form.support_details.email.present? %>
+<%= form.support_details.email %>
+  <% end %>
+
+  <% if form.support_details.url.present? && form.support_details.url_text.present? %>
+<%= form.support_details.url_text %>: <%= form.support_details.url %>
+  <% end %>
+<% else %>
+  <%= I18n.t("mailer.submission_confirmation.default_support_contact_details") %>
+<% end %>

--- a/app/views/aws_ses_submission_confirmation_mailer/_content.text.erb
+++ b/app/views/aws_ses_submission_confirmation_mailer/_content.text.erb
@@ -31,7 +31,7 @@
 <% if @include_copy_of_answers %>
 <%= I18n.t("mailer.submission_confirmation.answers_submitted_heading") %>
 
-<%= @submission.answer_content_for_email_plain_text(locale: locale) %>
+<%= @submission.answer_content_for_email_plain_text(locale: locale, confirmation_email: true) %>
 
 <% end %>
 <%= I18n.t("mailer.submission_confirmation.contact_details_heading") %>

--- a/app/views/aws_ses_submission_confirmation_mailer/submission_confirmation_email.html.erb
+++ b/app/views/aws_ses_submission_confirmation_mailer/submission_confirmation_email.html.erb
@@ -1,0 +1,8 @@
+<%= render partial: "content", locals: { form: @form } %>
+
+<% if @submission_locale == :cy %>
+  <% I18n.with_locale(:cy) do %>
+    <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
+    <%= render partial: "content", locals: { form: @welsh_form } %>
+  <% end %>
+<% end %>

--- a/app/views/aws_ses_submission_confirmation_mailer/submission_confirmation_email.html.erb
+++ b/app/views/aws_ses_submission_confirmation_mailer/submission_confirmation_email.html.erb
@@ -1,8 +1,8 @@
-<%= render partial: "content", locals: { form: @form } %>
+<%= render partial: "content", locals: { form: @form, locale: :en } %>
 
 <% if @submission_locale == :cy %>
   <% I18n.with_locale(:cy) do %>
     <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
-    <%= render partial: "content", locals: { form: @welsh_form } %>
+    <%= render partial: "content", locals: { form: @welsh_form, locale: :cy } %>
   <% end %>
 <% end %>

--- a/app/views/aws_ses_submission_confirmation_mailer/submission_confirmation_email.text.erb
+++ b/app/views/aws_ses_submission_confirmation_mailer/submission_confirmation_email.text.erb
@@ -1,0 +1,8 @@
+<%= render partial: "content", locals: { form: @form } %>
+<% if @submission_locale == :cy %>
+  <% I18n.with_locale(:cy) do %>
+---
+
+<%= render partial: "content", locals: { form: @welsh_form } %>
+  <% end %>
+<% end %>

--- a/app/views/aws_ses_submission_confirmation_mailer/submission_confirmation_email.text.erb
+++ b/app/views/aws_ses_submission_confirmation_mailer/submission_confirmation_email.text.erb
@@ -1,8 +1,8 @@
-<%= render partial: "content", locals: { form: @form } %>
+<%= render partial: "content", locals: { form: @form, locale: :en } %>
 <% if @submission_locale == :cy %>
   <% I18n.with_locale(:cy) do %>
 ---
 
-<%= render partial: "content", locals: { form: @welsh_form } %>
+<%= render partial: "content", locals: { form: @welsh_form, locale: :cy } %>
   <% end %>
 <% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -513,8 +513,21 @@ cy:
         subject: 'Weekly form submissions: ‘%{form_name}’ - %{begin_date} to %{end_date}'
         subject_preview: 'TEST WEEKLY FORM SUBMISSIONS: ‘%{form_name}’ - %{begin_date} to %{end_date}'
     submission_confirmation:
+      answers_submitted_heading: Atebion wedi’u cyflwyno
+      contact_details_heading: Manylion cyswllt
       default_support_contact_details: The form’s contact details for support will appear here once they’ve been added.
       default_what_happens_next: The form’s information about what happens next will appear here once it has been added.
+      payment_link_heading: Os ydych dal angen talu
+      payment_link_html: 'Os ydych angen gwneud taliad ac nad ydych wedi gwneud hynny eisoes, defnyddiwch y ddolen dalu hon i dalu nawr: <a href="%{payment_link}">%{payment_link}</a>'
+      reference_number: Rhif cyfeirnod eich ffurflen yw %{reference}.
+      subject: 'Mae eich ffurflen wedi’i chyflwyno’n llwyddiannus – cyfeirnod: %{reference}'
+      subject_preview: 'TEST EMAIL CONFIRMING SUBMISSION: Mae eich ffurflen wedi’i chyflwyno’n llwyddiannus – cyfeirnod: %{reference}'
+      submitted_at: Cyflwynwyd “%{form_name}” yn llwyddiannus ar %{time} ar %{date}.
+      this_is_a_test: This is a test email confirming that a form’s been submitted.
+      title: Mae eich ffurflen wedi’i chyflwyno’n llwyddiannus
+      title_preview: 'TEST EMAIL CONFIRMING SUBMISSION: Mae eich ffurflen wedi’i chyflwyno’n llwyddiannus'
+      what_happens_next_heading: Beth sy’n digwydd nesaf
+      you_cannot_reply: Ni allwch ymateb i’r e-bost hwn. Defnyddiwch y manylion cyswllt isod os ydych angen help gyda’ch ffurflen.
   mode:
     phase_banner_tag_preview-archived: Archived preview
     phase_banner_tag_preview-draft: Draft preview

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -517,6 +517,7 @@ cy:
       contact_details_heading: Manylion cyswllt
       default_support_contact_details: The form’s contact details for support will appear here once they’ve been added.
       default_what_happens_next: The form’s information about what happens next will appear here once it has been added.
+      file_answer: Rydych wedi llwytho ffeil o’r enw %{filename}
       payment_link_heading: Os ydych dal angen talu
       payment_link_html: 'Os ydych angen gwneud taliad ac nad ydych wedi gwneud hynny eisoes, defnyddiwch y ddolen dalu hon i dalu nawr: <a href="%{payment_link}">%{payment_link}</a>'
       reference_number: Rhif cyfeirnod eich ffurflen yw %{reference}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -513,8 +513,21 @@ en:
         subject: 'Weekly form submissions: ‘%{form_name}’ - %{begin_date} to %{end_date}'
         subject_preview: 'TEST WEEKLY FORM SUBMISSIONS: ‘%{form_name}’ - %{begin_date} to %{end_date}'
     submission_confirmation:
+      answers_submitted_heading: Answers submitted
+      contact_details_heading: Contact details
       default_support_contact_details: The form’s contact details for support will appear here once they’ve been added.
       default_what_happens_next: The form’s information about what happens next will appear here once it has been added.
+      payment_link_heading: If you still need to pay
+      payment_link_html: 'If you need to make a payment and have not done so already, use this payment link to pay now: <a href="%{payment_link}">%{payment_link}</a>'
+      reference_number: Your form reference number is %{reference}.
+      subject: 'Your form has been successfully submitted – reference: %{reference}'
+      subject_preview: 'TEST EMAIL CONFIRMING SUBMISSION: Your form has been successfully submitted – reference: %{reference}'
+      submitted_at: "“%{form_name}” was successfully submitted at %{time} on %{date}."
+      this_is_a_test: This is a test email confirming that a form's been submitted.
+      title: Your form has been successfully submitted
+      title_preview: 'TEST EMAIL CONFIRMING SUBMISSION: Your form has been successfully submitted'
+      what_happens_next_heading: What happens next
+      you_cannot_reply: You cannot reply to this email. Use the contact details below if you need help with your form.
   mode:
     phase_banner_tag_preview-archived: Archived preview
     phase_banner_tag_preview-draft: Draft preview

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -517,6 +517,7 @@ en:
       contact_details_heading: Contact details
       default_support_contact_details: The form’s contact details for support will appear here once they’ve been added.
       default_what_happens_next: The form’s information about what happens next will appear here once it has been added.
+      file_answer: You uploaded a file called %{filename}
       payment_link_heading: If you still need to pay
       payment_link_html: 'If you need to make a payment and have not done so already, use this payment link to pay now: <a href="%{payment_link}">%{payment_link}</a>'
       reference_number: Your form reference number is %{reference}.

--- a/spec/factories/models/forms.rb
+++ b/spec/factories/models/forms.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
       end
 
       form_document_steps do
-        Array.new(steps_count) { association(:form_document_step) }
+        Array.new(steps_count) { association(:step) }
       end
     end
 

--- a/spec/helpers/email_format_helper_spec.rb
+++ b/spec/helpers/email_format_helper_spec.rb
@@ -45,4 +45,29 @@ RSpec.describe EmailFormatHelper, type: :helper do
       expect(helper.format_time(date_time)).to eq(expected_output)
     end
   end
+
+  describe "#markdown_to_html" do
+    it "renders markdown to sanitized html" do
+      input = "# Heading\n\nThis is *italic* and **bold**"
+      output = helper.markdown_to_html(input)
+      expected = "<p>Heading</p>\n<p>This is italic and bold</p>"
+      expect(output).to eq(expected)
+    end
+
+    it "strips disallowed HTML tags from the rendered markdown" do
+      input = "This is safe\n\n<script>alert('x')</script>\n\n**bold**"
+      output = helper.markdown_to_html(input)
+      expected = "<p>This is safe</p>\n<p>&lt;script&gt;alert('x')&lt;/script&gt;</p>\n<p>bold</p>"
+      expect(output).to eq(expected)
+    end
+  end
+
+  describe "#markdown_to_plain_text" do
+    it "renders markdown to plain text" do
+      input = "# Heading\n\nThis is *italic* and **bold**\n\n- List item\n- Other item\n[Link text](https://www.link.com)"
+      plain = helper.markdown_to_plain_text(input)
+      expected = "Heading\n\nThis is italic and bold\n• List item\n• Other item\nLink text: https://www.link.com"
+      expect(plain).to eq(expected)
+    end
+  end
 end

--- a/spec/jobs/send_confirmation_email_job_spec.rb
+++ b/spec/jobs/send_confirmation_email_job_spec.rb
@@ -109,6 +109,22 @@ RSpec.describe SendConfirmationEmailJob, type: :job do
       expect(mail.to).to eq(["testing@gov.uk"])
       expect(mail.html_part.body).to include "What is your favourite colour?"
     end
+
+    context "when the Job was enqueued with Welsh locale" do
+      it "uses English as the default locale for the email" do
+        I18n.with_locale(:cy) do
+          described_class.perform_now(
+            submission:,
+            notify_response_id:,
+            confirmation_email_address:,
+            include_copy_of_answers: true,
+          )
+        end
+
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.subject).to eq(I18n.t("mailer.submission_confirmation.subject", reference: submission.reference))
+      end
+    end
   end
 
   context "when there is an error during processing" do

--- a/spec/jobs/send_confirmation_email_job_spec.rb
+++ b/spec/jobs/send_confirmation_email_job_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe SendConfirmationEmailJob, type: :job do
     build(
       :v2_form_document,
       name: "Form 1",
+      steps: [
+        build(:v2_question_step, :with_text_settings, question_text: "What is your favourite colour?", id: "q1", next_step_id: "q2"),
+        build(:v2_question_step, :with_name_settings, question_text: "What is your name?", id: "q2"),
+      ],
+      start_page: "q1",
       what_happens_next_markdown: "Please wait for a response",
       support_phone: "0203 222 2222",
       support_email: "help@example.gov.uk",
@@ -14,10 +19,12 @@ RSpec.describe SendConfirmationEmailJob, type: :job do
       payment_url: "https://www.gov.uk/payments/test-service/pay-for-licence",
     )
   end
+  let(:answers) { { "q1" => { text: "blue" }, "q2" => { first_name: "Jane", last_name: "Doe" } } }
   let(:submission) do
     create(
       :submission,
       form_document:,
+      answers:,
       created_at: submission_created_at,
       reference: "ABC12345",
       submission_locale: "en",
@@ -26,62 +33,81 @@ RSpec.describe SendConfirmationEmailJob, type: :job do
   let(:notify_response_id) { "confirmation-ref" }
   let(:confirmation_email_address) { "testing@gov.uk" }
 
-  before do
-    Settings.govuk_notify.form_filler_confirmation_email_template_id = "123456"
-    Settings.govuk_notify.form_filler_confirmation_email_welsh_template_id = "7891011"
-  end
-
-  it "sends the confirmation email" do
-    expect {
-      described_class.perform_now(
-        submission:,
-        notify_response_id:,
-        confirmation_email_address:,
-      )
-    }.to change(ActionMailer::Base.deliveries, :count).by(1)
-
-    mail = ActionMailer::Base.deliveries.last
-    expect(mail.to).to eq(["testing@gov.uk"])
-  end
-
-  it "builds mailer arguments from the submission" do
-    allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email).and_call_original
-
-    described_class.perform_now(
-      submission:,
-      notify_response_id:,
-      confirmation_email_address:,
-    )
-
-    expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
-      submission:,
-      notify_response_id: "confirmation-ref",
-      confirmation_email_address: "testing@gov.uk",
-    )
-  end
-
-  context "when submission locale is Welsh" do
-    let(:welsh_form_document) { build(:v2_form_document, name: "Welsh Form") }
-
+  context "when include_copy_of_answers is false" do
     before do
-      submission.update!(submission_locale: "cy")
-      allow(Api::V2::FormDocumentRepository).to receive(:find_with_mode).and_call_original
-      allow(Api::V2::FormDocumentRepository).to receive(:find_with_mode).with(
-        form_id: anything,
-        mode: anything,
-        language: :cy,
-      ).and_return(welsh_form_document)
+      Settings.govuk_notify.form_filler_confirmation_email_template_id = "123456"
+      Settings.govuk_notify.form_filler_confirmation_email_welsh_template_id = "7891011"
     end
 
-    it "uses the bilingual template" do
+    it "sends the confirmation email" do
+      expect {
+        described_class.perform_now(
+          submission:,
+          notify_response_id:,
+          confirmation_email_address:,
+        )
+      }.to change(ActionMailer::Base.deliveries, :count).by(1)
+
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.to).to eq(["testing@gov.uk"])
+    end
+
+    it "builds mailer arguments from the submission" do
+      allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email).and_call_original
+
       described_class.perform_now(
         submission:,
         notify_response_id:,
         confirmation_email_address:,
       )
 
+      expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
+        submission:,
+        notify_response_id: "confirmation-ref",
+        confirmation_email_address: "testing@gov.uk",
+      )
+    end
+
+    context "when submission locale is Welsh" do
+      let(:welsh_form_document) { build(:v2_form_document, name: "Welsh Form") }
+
+      before do
+        submission.update!(submission_locale: "cy")
+        allow(Api::V2::FormDocumentRepository).to receive(:find_with_mode).and_call_original
+        allow(Api::V2::FormDocumentRepository).to receive(:find_with_mode).with(
+          form_id: anything,
+          mode: anything,
+          language: :cy,
+        ).and_return(welsh_form_document)
+      end
+
+      it "uses the bilingual template" do
+        described_class.perform_now(
+          submission:,
+          notify_response_id:,
+          confirmation_email_address:,
+        )
+
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.govuk_notify_template).to eq("7891011")
+      end
+    end
+  end
+
+  context "when include_copy_of_answers is true" do
+    it "sends the confirmation email including the answers" do
+      expect {
+        described_class.perform_now(
+          submission:,
+          notify_response_id:,
+          confirmation_email_address:,
+          include_copy_of_answers: true,
+        )
+      }.to change(ActionMailer::Base.deliveries, :count).by(1)
+
       mail = ActionMailer::Base.deliveries.last
-      expect(mail.govuk_notify_template).to eq("7891011")
+      expect(mail.to).to eq(["testing@gov.uk"])
+      expect(mail.html_part.body).to include "What is your favourite colour?"
     end
   end
 

--- a/spec/jobs/send_confirmation_email_job_spec.rb
+++ b/spec/jobs/send_confirmation_email_job_spec.rb
@@ -54,8 +54,6 @@ RSpec.describe SendConfirmationEmailJob, type: :job do
     )
 
     expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
-      form: submission.form,
-      welsh_form: nil,
       submission:,
       notify_response_id: "confirmation-ref",
       confirmation_email_address: "testing@gov.uk",
@@ -84,20 +82,6 @@ RSpec.describe SendConfirmationEmailJob, type: :job do
 
       mail = ActionMailer::Base.deliveries.last
       expect(mail.govuk_notify_template).to eq("7891011")
-    end
-
-    it "passes the Welsh form to the mailer" do
-      allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email).and_call_original
-
-      described_class.perform_now(
-        submission:,
-        notify_response_id:,
-        confirmation_email_address:,
-      )
-
-      expect(FormSubmissionConfirmationMailer).to have_received(:send_confirmation_email).with(
-        hash_including(welsh_form: have_attributes(name: welsh_form_document.name)),
-      )
     end
   end
 

--- a/spec/lib/html_markdown_sanitizer_spec.rb
+++ b/spec/lib/html_markdown_sanitizer_spec.rb
@@ -82,6 +82,39 @@ RSpec.describe HtmlMarkdownSanitizer do
         )
       end
     end
+
+    context "when for_email is true" do
+      it "converts line breaks into <p> tags" do
+        expect(html_markdown_sanitizer.render_scrubbed_markdown(simple_multiline_string, for_email: true)).to eq("<p>This is a paragraph.</p>\n<p>This is another paragraph.\nThis is a new line within the same paragraph</p>")
+      end
+
+      it "sanitizes any markdown supplied to it" do
+        expected = <<~HTML
+          <p>This is a heading</p>
+          <table style="padding:0 0 20px 0;">
+            <tr>
+              <td style="font-family:Helvetica, Arial, sans-serif;">
+                <ul style="margin:0 0 0 20px;padding:0;list-style-type:disc;">
+                  <li style="margin:5px 0 5px;padding:0 0 0 5px;font-size:19px;line-height:25px;color:#0B0C0C;">
+                    this is a list item
+                  </li> <li style="margin:5px 0 5px;padding:0 0 0 5px;font-size:19px;line-height:25px;color:#0B0C0C;">
+                    This is another list item
+                  </li>
+                </ul>
+              </td>
+            </tr>
+          </table>
+        HTML
+
+        rendered = html_markdown_sanitizer.render_scrubbed_markdown(multiline_markdown_string_with_disallowed_content, for_email: true)
+        expect(rendered.gsub(/\s+/, " "))
+          .to eq(expected.gsub(/\s+/, " ").strip)
+      end
+
+      it "escapes any HTML supplied to it" do
+        expect(html_markdown_sanitizer.render_scrubbed_markdown(simple_string_with_disallowed_html, for_email: true)).to eq("<p>&lt;script&gt;alert(\"script\")&lt;/script&gt;</p>")
+      end
+    end
   end
 
   describe "#render_scrubbed_html" do

--- a/spec/lib/limited_html_scrubber_spec.rb
+++ b/spec/lib/limited_html_scrubber_spec.rb
@@ -80,4 +80,25 @@ RSpec.describe LimitedHtmlScrubber do
       end
     end
   end
+
+  context "when for_email is true" do
+    let(:limited_html_scrubber) { described_class.new(for_email: true) }
+
+    it "returns an array of html tags allowed including table tags" do
+      expect(limited_html_scrubber.tags).to eq %w[a ol ul li p br table tr td]
+    end
+
+    it "returns an array of html attributes allowed including style" do
+      expect(limited_html_scrubber.attributes).to eq %w[href class rel target title style]
+    end
+
+    context "when used with sanitize" do
+      let(:input) { "<a href=\"#\" style=\"color:#0B0C0C;\">A perfectly innocent link</a><table><tr><td><ul><li>An item</li></ul></td></tr></table>" }
+
+      it "returns the allowed markup unchanged" do
+        sanitized_string = ActionController::Base.helpers.sanitize(input, scrubber: limited_html_scrubber)
+        expect(sanitized_string).to eq "<a href=\"#\" style=\"color:#0B0C0C;\">A perfectly innocent link</a><table><tr><td><ul><li>An item</li></ul></td></tr></table>"
+      end
+    end
+  end
 end

--- a/spec/lib/ses_email_formatter_spec.rb
+++ b/spec/lib/ses_email_formatter_spec.rb
@@ -1,13 +1,16 @@
 require "rails_helper"
 
 RSpec.describe SesEmailFormatter do
-  subject(:ses_email_formatter) { described_class.new(submission_reference:, steps: steps) }
+  subject(:ses_email_formatter) { described_class.new(submission_reference:, steps:, confirmation_email:) }
 
+  let(:confirmation_email) { false }
   let(:submission_reference) { "SUB-12345" }
   let(:text_question) { build :text, question_text: "What is the meaning of life?", text: "42" }
   let(:text_step) { build :step, question: text_question }
   let(:name_question) { build :first_middle_last_name_question, question_text: "What is your name?" }
   let(:name_step) { build :step, question: name_question }
+  let(:file_question) { build :file, question_text: "Upload a file", original_filename: "a-file.txt" }
+  let(:file_step) { build :step, question: file_question }
   let(:none_of_the_above_question) do
     build(
       :selection,
@@ -93,6 +96,24 @@ RSpec.describe SesEmailFormatter do
       end
     end
 
+    context "when there is a file question" do
+      let(:steps) { [file_step] }
+
+      context "when formatting for a submission email" do
+        it "returns the content for a submission email" do
+          expect(ses_email_formatter.build_question_answers_section_html).to eq("<h3>Upload a file</h3><p>a-file_SUB-12345.txt (attached to this email)</p>")
+        end
+      end
+
+      context "when formatting for a confirmation email" do
+        let(:confirmation_email) { true }
+
+        it "returns the content for a confirmation email" do
+          expect(ses_email_formatter.build_question_answers_section_html).to eq("<h3>Upload a file</h3><p>You uploaded a file called a-file.txt</p>")
+        end
+      end
+    end
+
     context "when there is an error formatting an answer" do
       before do
         allow(text_step).to receive(:show_answer_in_email).and_raise(NoMethodError, "undefined method 'strip' for an instance of Array")
@@ -167,6 +188,24 @@ RSpec.describe SesEmailFormatter do
 
         it "returns the skipped none of the above answer text" do
           expect(ses_email_formatter.build_question_answers_section_plain_text).to eq("What sandwich do you want?\n\nNone of the above\n\nSpecify your desired sandwich (optional)\n\n[This question was skipped]")
+        end
+      end
+    end
+
+    context "when there is a file question" do
+      let(:steps) { [file_step] }
+
+      context "when formatting for a submission email" do
+        it "returns the content for a submission email" do
+          expect(ses_email_formatter.build_question_answers_section_plain_text).to eq("Upload a file\n\na-file_SUB-12345.txt (attached to this email)")
+        end
+      end
+
+      context "when formatting for a confirmation email" do
+        let(:confirmation_email) { true }
+
+        it "returns the content for a confirmation email" do
+          expect(ses_email_formatter.build_question_answers_section_plain_text).to eq("Upload a file\n\nYou uploaded a file called a-file.txt")
         end
       end
     end

--- a/spec/lib/ses_email_formatter_spec.rb
+++ b/spec/lib/ses_email_formatter_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe SesEmailFormatter do
       it "returns question and and answer HTML" do
         expect(ses_email_formatter.build_question_answers_section_html).to eq("<h3>What is the meaning of life?</h3><p>42</p>")
       end
+
+      it "uses the heading level provided" do
+        expect(ses_email_formatter.build_question_answers_section_html(heading_tag: "h2")).to eq("<h2>What is the meaning of life?</h2><p>42</p>")
+      end
     end
 
     context "when the answer has multiple attributes" do

--- a/spec/mailers/README.md
+++ b/spec/mailers/README.md
@@ -1,3 +1,3 @@
 # Previewing emails
 
-To preview emails listed in `aws_ses_form_submission_mailer_preview.rb` locally, use the route `/rails/mailers` while the rails server is running.
+To preview emails locally, use the route `/rails/mailers` while the rails server is running.

--- a/spec/mailers/aws_ses_form_submission_mailer_spec.rb
+++ b/spec/mailers/aws_ses_form_submission_mailer_spec.rb
@@ -114,6 +114,10 @@ describe AwsSesFormSubmissionMailer, type: :mailer do
             it "includes the Welsh submission text" do
               expect(part.body).to match("Welsh")
             end
+
+            it "uses the English question text" do
+              expect(part.body).to have_css("h3", text: "What is the meaning of life?")
+            end
           end
         end
       end

--- a/spec/mailers/aws_ses_submission_confirmation_mailer_preview.rb
+++ b/spec/mailers/aws_ses_submission_confirmation_mailer_preview.rb
@@ -1,0 +1,112 @@
+class AwsSesSubmissionConfirmationMailerPreview < ActionMailer::Preview
+  include FactoryBot::Syntax::Methods
+
+  def english_only
+    submission = build(:submission, form_document: form_document, answers: answers, is_preview: false)
+
+    AwsSesSubmissionConfirmationMailer.submission_confirmation_email(
+      submission:,
+      confirmation_email_address: "foo@example.com",
+      include_copy_of_answers: true,
+    )
+  end
+
+  def with_welsh
+    submission = build(:submission,
+                       form_document: form_document,
+                       welsh_form_document: welsh_form_document,
+                       answers: answers,
+                       is_preview: false,
+                       submission_locale: "cy")
+
+    AwsSesSubmissionConfirmationMailer.submission_confirmation_email(
+      submission:,
+      confirmation_email_address: "foo@example.com",
+      include_copy_of_answers: true,
+    )
+  end
+
+  def without_copy_of_answers
+    submission = build(:submission, form_document: form_document, is_preview: false)
+
+    AwsSesSubmissionConfirmationMailer.submission_confirmation_email(
+      submission:,
+      confirmation_email_address: "foo@example.com",
+      include_copy_of_answers: false,
+    )
+  end
+
+  def test_submission
+    submission = build(:submission,
+                       form_document: form_document,
+                       welsh_form_document: welsh_form_document,
+                       is_preview: true,
+                       submission_locale: "cy")
+
+    AwsSesSubmissionConfirmationMailer.submission_confirmation_email(
+      submission:,
+      confirmation_email_address: "foo@example.com",
+      include_copy_of_answers: false,
+    )
+  end
+
+  def without_what_happens_next_and_support_contact_details_and_payment_link
+    form_document = build(:v2_form_document,
+                          payment_url: nil,
+                          what_happens_next_markdown: nil,
+                          support_phone: nil,
+                          support_email: nil,
+                          support_url: nil,
+                          support_url_text: nil)
+    submission = build(:submission, form_document:, is_preview: false)
+
+    AwsSesSubmissionConfirmationMailer.submission_confirmation_email(
+      submission:,
+      confirmation_email_address: "foo@example.com",
+      include_copy_of_answers: false,
+    )
+  end
+
+private
+
+  def form_document
+    steps = [
+      build(:v2_question_step, :with_text_settings, id: "a1", next_step_id: "a2"),
+      build(:v2_question_step, :with_name_settings, id: "a2"),
+    ]
+    build(:v2_form_document,
+          steps: steps,
+          start_page: "a1",
+          name: "English form",
+          payment_url: "https://www.gov.uk/payments/test-service/pay-for-licence?reference=W38SFV3S",
+          what_happens_next_markdown: "Some text about what happens next\n\n- With a list\n- Of things\n- To do\n[A link](https://wwww.link.example.com)",
+          support_phone: "0203 222 2222\r\nLines are open 8am - 6pm Monday to Friday",
+          support_email: "help@example.gov.uk",
+          support_url: "https://example.gov.uk/help",
+          support_url_text: "Get help")
+  end
+
+  def welsh_form_document
+    welsh_steps = [
+      build(:v2_question_step, :with_text_settings, question_text: "Welsh question 1", id: "a1", next_step_id: "a2"),
+      build(:v2_question_step, :with_name_settings, question_text: "Welsh question 2", id: "a2"),
+    ]
+    build(:v2_form_document,
+          steps: welsh_steps,
+          start_page: "a1",
+          name: "Welsh Form",
+          payment_url: "https://www.gov.wales/payments/test-service/pay-for-licence?reference=W38SFV3S",
+          what_happens_next_markdown: "Rhywfaint o destun am yr hyn sy'n digwydd nesaf\n\n- Gyda rhestr\n- O bethau\n- I'w gwneud",
+          support_phone: "0203 333 3333\r\nMae'r llinellau ar agor 8am - 6pm o ddydd Llun i ddydd Gwener",
+          support_email: "help@example.gov.wales",
+          support_url: "https://example.gov.wales/help",
+          support_url_text: "Cael help")
+  end
+
+  def answers
+    {
+      "a1" => { text: "First answer/nSecond line of first answer" },
+      "a2" => { first_name: "Joe", last_name: "Bloggs" },
+    }
+  end
+end

--- a/spec/mailers/aws_ses_submission_confirmation_mailer_preview.rb
+++ b/spec/mailers/aws_ses_submission_confirmation_mailer_preview.rb
@@ -72,7 +72,8 @@ private
   def form_document
     steps = [
       build(:v2_question_step, :with_text_settings, id: "a1", next_step_id: "a2"),
-      build(:v2_question_step, :with_name_settings, id: "a2"),
+      build(:v2_question_step, :with_name_settings, id: "a2", next_step_id: "a3"),
+      build(:v2_question_step, :with_file_upload_settings, id: "a3"),
     ]
     build(:v2_form_document,
           steps: steps,
@@ -88,8 +89,9 @@ private
 
   def welsh_form_document
     welsh_steps = [
-      build(:v2_question_step, :with_text_settings, question_text: "Welsh question 1", id: "a1", next_step_id: "a2"),
-      build(:v2_question_step, :with_name_settings, question_text: "Welsh question 2", id: "a2"),
+      build(:v2_question_step, :with_text_settings, question_text: "Welsh text", id: "a1", next_step_id: "a2"),
+      build(:v2_question_step, :with_name_settings, question_text: "Welsh name", id: "a2", next_step_id: "a3"),
+      build(:v2_question_step, :with_file_upload_settings, question_text: "Welsh file upload", id: "a3"),
     ]
     build(:v2_form_document,
           steps: welsh_steps,
@@ -107,6 +109,7 @@ private
     {
       "a1" => { text: "First answer/nSecond line of first answer" },
       "a2" => { first_name: "Joe", last_name: "Bloggs" },
+      "a3" => { original_filename: "test.txt" },
     }
   end
 end

--- a/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
@@ -1,0 +1,289 @@
+require "rails_helper"
+
+RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
+  subject(:mail) do
+    described_class.submission_confirmation_email(
+      submission: submission,
+      confirmation_email_address: confirmation_email_address,
+      include_copy_of_answers: include_copy_of_answers,
+    )
+  end
+
+  let(:confirmation_email_address) { "testing@example.gov.uk" }
+  let(:include_copy_of_answers) { true }
+  let(:welsh_form) { Form.new(welsh_form_document) if welsh_form_document }
+  let(:welsh_form_document) { nil }
+  let(:submission_locale) { "en" }
+  let(:is_preview) { false }
+  let(:submission_reference) { Faker::Alphanumeric.alphanumeric(number: 8).upcase }
+  let(:submission_timestamp) { Time.zone.now }
+  let(:submission) do
+    build(:submission,
+          form_document:,
+          welsh_form_document:,
+          created_at: submission_timestamp,
+          reference: submission_reference,
+          submission_locale:,
+          answers:,
+          is_preview:)
+  end
+  let(:answers) { { "q1" => { text: "blue" }, "q2" => { first_name: "Jane", last_name: "Doe" } } }
+  let(:what_happens_next_markdown) { "Please wait for a response\nA list:\n\n- Item one\n- Item two" }
+  let(:payment_url) { "https://pay.example.gov" }
+  let(:form_document) do
+    build(:v2_form_document,
+          name: "My form",
+          steps: [
+            build(:v2_question_step, :with_text_settings, question_text: "What is your favourite colour?", id: "q1", next_step_id: "q2"),
+            build(:v2_question_step, :with_name_settings, question_text: "What is your name?", id: "q2"),
+          ],
+          start_page: "q1",
+          payment_url:,
+          what_happens_next_markdown:,
+          support_phone: "0203 222 2222",
+          support_email: "help@example.gov.uk",
+          support_url: "https://example.gov.uk/help",
+          support_url_text: "Get help")
+  end
+
+  context "when optional content is present" do
+    it "sends to the requested address" do
+      expect(mail.to).to eq([confirmation_email_address])
+    end
+
+    it "has the expected subject" do
+      expect(mail.subject).to eq(I18n.t("mailer.submission_confirmation.subject", reference: submission_reference))
+    end
+
+    describe "the text part" do
+      let(:part) { mail.text_part }
+
+      it "includes the what happens next text formatted as plain text from the markdown" do
+        expect(part.body).to include("Please wait for a response\nA list:\n• Item one\n• Item two")
+      end
+
+      it "includes the payment link with the reference" do
+        expect(part.body).to include(I18n.t("mailer.submission_confirmation.payment_link_heading"))
+        expect(part.body).to include("#{form_document.payment_url}?reference=#{submission_reference}")
+      end
+
+      it "includes support contact details" do
+        expect(part.body).to include("0203 222 2222")
+        expect(part.body).to include("help@example.gov.uk")
+        expect(part.body).to include("Get help: https://example.gov.uk/help")
+      end
+
+      it "includes the answers content" do
+        expect(part.body).to include("What is your favourite colour?")
+        expect(part.body).to include("blue")
+        expect(part.body).to include("What is your name?")
+        expect(part.body).to include("First name: Jane")
+        expect(part.body).to include("Last name: Doe")
+      end
+    end
+
+    describe "the html part" do
+      let(:part) { mail.html_part }
+
+      it "includes the what happens next formatted as html from the markdown" do
+        expect(part.body).to have_css("p", text: "Please wait for a response")
+        expect(part.body).to have_css("p", text: "A list:")
+        expect(part.body).to have_css("ul li", text: "Item one")
+        expect(part.body).to have_css("ul li", text: "Item two")
+      end
+
+      it "includes the payment link with the reference" do
+        expect(part.body).to have_css("h3", text: I18n.t("mailer.submission_confirmation.payment_link_heading"))
+        expect(part.body).to have_link("#{form_document.payment_url}?reference=#{submission_reference}")
+      end
+
+      it "includes support contact details" do
+        expect(part.body).to have_text("0203 222 2222")
+        expect(part.body).to have_link("help@example.gov.uk", href: "mailto:help@example.gov.uk")
+        expect(part.body).to have_link("Get help", href: "https://example.gov.uk/help")
+      end
+
+      it "includes the question headings and answers" do
+        expect(part.body).to have_css("h4", text: "What is your favourite colour?")
+        expect(part.body).to have_text("blue")
+        expect(part.body).to have_css("h4", text: "What is your name?")
+        expect(part.body).to have_text("First name: Jane")
+        expect(part.body).to have_text("Last name: Doe")
+      end
+    end
+  end
+
+  context "when the submission is a preview" do
+    let(:is_preview) { true }
+
+    it "has the subject for a preview submission" do
+      expect(mail.subject).to eq(I18n.t("mailer.submission_confirmation.subject_preview", reference: submission_reference))
+    end
+
+    it "has content for a preview submission in the text part" do
+      expect(mail.text_part.body).to include(I18n.t("mailer.submission_confirmation.title_preview"))
+      expect(mail.text_part.body).to include(I18n.t("mailer.submission_confirmation.this_is_a_test"))
+    end
+
+    it "has the content for a preview submission in the html part" do
+      expect(mail.html_part.body).to have_css("h2", text: I18n.t("mailer.submission_confirmation.title_preview"))
+      expect(mail.html_part.body).to have_css("p", text: I18n.t("mailer.submission_confirmation.this_is_a_test"))
+    end
+  end
+
+  context "when the what happens next markdown is not set" do
+    let(:what_happens_next_markdown) { nil }
+
+    it "falls back to default what happens next text for the text part" do
+      expect(mail.text_part.body).to include(I18n.t("mailer.submission_confirmation.default_what_happens_next"))
+    end
+
+    it "falls back to default what happens next html" do
+      expect(mail.html_part.body).to have_text(I18n.t("mailer.submission_confirmation.default_what_happens_next"))
+    end
+  end
+
+  context "when the support details are not set" do
+    let(:part) { mail.text_part }
+
+    let(:form_document) do
+      build(:v2_form_document,
+            name: "My form",
+            support_phone: nil,
+            support_email: nil,
+            support_url: nil,
+            support_url_text: nil)
+    end
+    let(:include_copy_of_answers) { false }
+
+    it "renders the default support contact details text for the text part" do
+      expect(part.body).to include(I18n.t("mailer.submission_confirmation.contact_details_heading"))
+      expect(part.body).to include(I18n.t("mailer.submission_confirmation.default_support_contact_details"))
+    end
+
+    it "renders the default support contact details html" do
+      expect(mail.html_part.body).to have_text(I18n.t("mailer.submission_confirmation.contact_details_heading"))
+      expect(mail.html_part.body).to have_text(I18n.t("mailer.submission_confirmation.default_support_contact_details"))
+    end
+  end
+
+  context "when the payment url is not set" do
+    let(:payment_url) { nil }
+
+    it "does not include the payment link heading for the text part" do
+      expect(mail.text_part.body).not_to include(I18n.t("mailer.submission_confirmation.payment_link_heading"))
+    end
+
+    it "does not include the payment link html" do
+      expect(mail.html_part.body).not_to include(I18n.t("mailer.submission_confirmation.payment_link_heading"))
+    end
+  end
+
+  context "when include_copy_of_answers is false" do
+    let(:include_copy_of_answers) { false }
+
+    it "does not include the answers content for the text part" do
+      expect(mail.text_part.body).not_to include(I18n.t("mailer.submission_confirmation.answers_submitted_heading"))
+      expect(mail.text_part.body).not_to include("What is your name?")
+    end
+
+    it "does not include the answers content for the html part" do
+      expect(mail.html_part.body).not_to include("What is your name?")
+    end
+  end
+
+  context "when submission_locale is Welsh" do
+    let(:welsh_form_document) do
+      build(:v2_form_document,
+            name: "Welsh form",
+            steps: [
+              build(:v2_question_step, :with_text_settings, question_text: "Beth yw eich hoff liw?", id: "q1", next_step_id: "q2"),
+              build(:v2_question_step, :with_name_settings, question_text: "Beth yw dy enw?", id: "q2"),
+            ],
+            start_page: "q1",
+            what_happens_next_markdown: "Arhoswch am ymateb\nRhestr:\n\n- Eitem un\n- Eitem dau",
+            support_phone: "02920 111 222",
+            support_email: "help-cy@example.gov.uk",
+            support_url: "https://example.gov.uk/help-cy",
+            support_url_text: "Cael cymorth",
+            payment_url: "https://pay.example.gov.uk/cy")
+    end
+    let(:submission_locale) { "cy" }
+
+    it "includes the Welsh in the subject" do
+      english = I18n.t("mailer.submission_confirmation.subject", reference: submission_reference)
+      welsh = I18n.t("mailer.submission_confirmation.subject", reference: submission_reference, locale: :cy)
+      expect(mail.subject).to eq("#{english} | #{welsh}")
+    end
+
+    context "when the submission is a preview" do
+      let(:is_preview) { true }
+
+      it "has the subject for a preview including the Welsh" do
+        english = I18n.t("mailer.submission_confirmation.subject_preview", reference: submission_reference)
+        welsh = I18n.t("mailer.submission_confirmation.subject", reference: submission_reference, locale: :cy)
+        expect(mail.subject).to eq("#{english} | #{welsh}")
+      end
+    end
+
+    describe "the text part" do
+      let(:part) { mail.text_part }
+
+      it "includes the English and Welsh what happens next" do
+        expect(part.body).to include("Please wait for a response\nA list:\n• Item one\n• Item two")
+        expect(part.body).to have_text("Arhoswch am ymateb\nRhestr:\n• Eitem un\n• Eitem dau")
+      end
+
+      it "includes both the English and Welsh contact details" do
+        expect(part.body).to include("0203 222 2222")
+        expect(part.body).to include("help@example.gov.uk")
+        expect(part.body).to include("Get help: https://example.gov.uk/help")
+
+        expect(part.body).to include("02920 111 222")
+        expect(part.body).to include("help-cy@example.gov.uk")
+        expect(part.body).to include("Cael cymorth: https://example.gov.uk/help-cy")
+      end
+
+      it "includes both the English and Welsh payment URLs" do
+        expect(part.body).to include(I18n.t("mailer.submission_confirmation.payment_link_heading"))
+        expect(part.body).to include("https://pay.example.gov?reference=#{submission_reference}")
+
+        expect(part.body).to include(I18n.t("mailer.submission_confirmation.payment_link_heading", locale: :cy))
+        expect(part.body).to include("https://pay.example.gov.uk/cy?reference=#{submission_reference}")
+      end
+    end
+
+    describe "the html part" do
+      let(:part) { mail.html_part }
+
+      it "includes the English and Welsh what happens next" do
+        expect(part.body).to have_css("p", text: "Please wait for a response")
+        expect(part.body).to have_css("p", text: "A list:")
+        expect(part.body).to have_css("ul li", text: "Item one")
+        expect(part.body).to have_css("ul li", text: "Item two")
+        expect(part.body).to have_css("p", text: "Arhoswch am ymateb")
+        expect(part.body).to have_css("p", text: "Rhestr:")
+        expect(part.body).to have_css("ul li", text: "Eitem un")
+        expect(part.body).to have_css("ul li", text: "Eitem dau")
+      end
+
+      it "includes both the English and Welsh contact details" do
+        expect(part.body).to have_text("0203 222 2222")
+        expect(part.body).to have_link("help@example.gov.uk", href: "mailto:help@example.gov.uk")
+        expect(part.body).to have_link("Get help", href: "https://example.gov.uk/help")
+
+        expect(part.body).to have_text("02920 111 222")
+        expect(part.body).to have_link("help-cy@example.gov.uk", href: "mailto:help-cy@example.gov.uk")
+        expect(part.body).to have_link("Cael cymorth", href: "https://example.gov.uk/help-cy")
+      end
+
+      it "includes both the English and Welsh payment URLs" do
+        expect(part.body).to have_css("h3", text: I18n.t("mailer.submission_confirmation.payment_link_heading"))
+        expect(part.body).to have_link("https://pay.example.gov?reference=#{submission_reference}")
+
+        expect(part.body).to have_css("h3", text: I18n.t("mailer.submission_confirmation.payment_link_heading", locale: :cy))
+        expect(part.body).to have_link("https://pay.example.gov.uk/cy?reference=#{submission_reference}")
+      end
+    end
+  end
+end

--- a/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
@@ -224,6 +224,20 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
         welsh = I18n.t("mailer.submission_confirmation.subject", reference: submission_reference, locale: :cy)
         expect(mail.subject).to eq("#{english} | #{welsh}")
       end
+
+      it "has content for a preview submission in both English and Welsh in the text part" do
+        expect(mail.text_part.body).to include(I18n.t("mailer.submission_confirmation.title_preview"))
+        expect(mail.text_part.body).to include(I18n.t("mailer.submission_confirmation.this_is_a_test"))
+        expect(mail.text_part.body).to include(I18n.t("mailer.submission_confirmation.title_preview", locale: :cy))
+        expect(mail.text_part.body).to include(I18n.t("mailer.submission_confirmation.this_is_a_test", locale: :cy))
+      end
+
+      it "has the content for a preview submission in both English and Welsh in the html part" do
+        expect(mail.html_part.body).to have_css("h2", text: I18n.t("mailer.submission_confirmation.title_preview"))
+        expect(mail.html_part.body).to have_css("p", text: I18n.t("mailer.submission_confirmation.this_is_a_test"))
+        expect(mail.html_part.body).to have_css("h2", text: I18n.t("mailer.submission_confirmation.title_preview", locale: :cy))
+        expect(mail.html_part.body).to have_css("p", text: I18n.t("mailer.submission_confirmation.this_is_a_test", locale: :cy))
+      end
     end
 
     describe "the text part" do
@@ -250,6 +264,14 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
 
         expect(part.body).to include(I18n.t("mailer.submission_confirmation.payment_link_heading", locale: :cy))
         expect(part.body).to include("https://pay.example.gov.uk/cy?reference=#{submission_reference}")
+      end
+
+      it "includes the English and Welsh answers" do
+        expect(part.body).to include("What is your favourite colour?")
+        expect(part.body).to include("What is your name?")
+
+        expect(part.body).to include("Beth yw eich hoff liw?")
+        expect(part.body).to include("Beth yw dy enw?")
       end
     end
 
@@ -283,6 +305,14 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
 
         expect(part.body).to have_css("h3", text: I18n.t("mailer.submission_confirmation.payment_link_heading", locale: :cy))
         expect(part.body).to have_link("https://pay.example.gov.uk/cy?reference=#{submission_reference}")
+      end
+
+      it "includes the English and Welsh answers" do
+        expect(part.body).to have_css("h4", text: "What is your favourite colour?")
+        expect(part.body).to have_css("h4", text: "What is your name?")
+
+        expect(part.body).to have_css("h4", text: "Beth yw eich hoff liw?")
+        expect(part.body).to have_css("h4", text: "Beth yw dy enw?")
       end
     end
   end

--- a/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
           answers:,
           is_preview:)
   end
-  let(:answers) { { "q1" => { text: "blue" }, "q2" => { first_name: "Jane", last_name: "Doe" } } }
+  let(:answers) { { "q1" => { text: "blue" }, "q2" => { first_name: "Jane", last_name: "Doe" }, "q3" => { original_filename: "test.txt" } } }
   let(:what_happens_next_markdown) { "Please wait for a response\nA list:\n\n- Item one\n- Item two" }
   let(:payment_url) { "https://pay.example.gov" }
   let(:form_document) do
@@ -35,7 +35,8 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
           name: "My form",
           steps: [
             build(:v2_question_step, :with_text_settings, question_text: "What is your favourite colour?", id: "q1", next_step_id: "q2"),
-            build(:v2_question_step, :with_name_settings, question_text: "What is your name?", id: "q2"),
+            build(:v2_question_step, :with_name_settings, question_text: "What is your name?", id: "q2", next_step_id: "q3"),
+            build(:v2_question_step, :with_file_upload_settings, question_text: "Upload a file", id: "q3"),
           ],
           start_page: "q1",
           payment_url:,
@@ -79,6 +80,8 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
         expect(part.body).to include("What is your name?")
         expect(part.body).to include("First name: Jane")
         expect(part.body).to include("Last name: Doe")
+        expect(part.body).to include("Upload a file")
+        expect(part.body).to include(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt"))
       end
     end
 
@@ -109,6 +112,8 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
         expect(part.body).to have_css("h4", text: "What is your name?")
         expect(part.body).to have_text("First name: Jane")
         expect(part.body).to have_text("Last name: Doe")
+        expect(part.body).to have_css("h4", text: "Upload a file")
+        expect(part.body).to have_text(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt"))
       end
     end
   end
@@ -198,7 +203,8 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
             name: "Welsh form",
             steps: [
               build(:v2_question_step, :with_text_settings, question_text: "Beth yw eich hoff liw?", id: "q1", next_step_id: "q2"),
-              build(:v2_question_step, :with_name_settings, question_text: "Beth yw dy enw?", id: "q2"),
+              build(:v2_question_step, :with_name_settings, question_text: "Beth yw dy enw?", id: "q2", next_step_id: "q3"),
+              build(:v2_question_step, :with_file_upload_settings, question_text: "Llwythwch ffeil i fyny", id: "q3"),
             ],
             start_page: "q1",
             what_happens_next_markdown: "Arhoswch am ymateb\nRhestr:\n\n- Eitem un\n- Eitem dau",
@@ -269,9 +275,13 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
       it "includes the English and Welsh answers" do
         expect(part.body).to include("What is your favourite colour?")
         expect(part.body).to include("What is your name?")
+        expect(part.body).to include("Upload a file")
+        expect(part.body).to include(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt"))
 
         expect(part.body).to include("Beth yw eich hoff liw?")
         expect(part.body).to include("Beth yw dy enw?")
+        expect(part.body).to include("Llwythwch ffeil i fyny")
+        expect(part.body).to include(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt", locale: :cy))
       end
     end
 
@@ -310,9 +320,13 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
       it "includes the English and Welsh answers" do
         expect(part.body).to have_css("h4", text: "What is your favourite colour?")
         expect(part.body).to have_css("h4", text: "What is your name?")
+        expect(part.body).to have_css("h4", text: "Upload a file")
+        expect(part.body).to have_text(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt"))
 
         expect(part.body).to have_css("h4", text: "Beth yw eich hoff liw?")
         expect(part.body).to have_css("h4", text: "Beth yw dy enw?")
+        expect(part.body).to have_css("h4", text: "Llwythwch ffeil i fyny")
+        expect(part.body).to have_text(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt", locale: :cy))
       end
     end
   end

--- a/spec/mailers/form_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/form_submission_confirmation_mailer_spec.rb
@@ -3,9 +3,7 @@ require "rails_helper"
 describe FormSubmissionConfirmationMailer, type: :mailer do
   let(:submission_locale) { :en }
   let(:mail) do
-    described_class.send_confirmation_email(form:,
-                                            welsh_form:,
-                                            submission:,
+    described_class.send_confirmation_email(submission:,
                                             notify_response_id: "for-my-ref",
                                             confirmation_email_address:)
   end
@@ -22,6 +20,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
   let(:submission) do
     build :submission,
           form_document:,
+          welsh_form_document:,
           created_at: submission_timestamp,
           reference: submission_reference,
           submission_locale:,
@@ -37,7 +36,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
           payment_url:
   end
   let(:form) { Form.new(form_document) }
-  let(:welsh_form) { nil }
+  let(:welsh_form_document) { nil }
 
   context "when form filler wants an form submission confirmation email" do
     before do
@@ -60,7 +59,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
     end
 
     context "when a Welsh form is provided" do
-      let(:welsh_form) { Form.new(build(:v2_form_document, name: "Ffurflen 1")) }
+      let(:welsh_form_document) { build(:v2_form_document, name: "Ffurflen 1") }
 
       it "uses the Welsh form name as title_cy" do
         expect(mail.govuk_notify_personalisation[:title_cy]).to eq("Ffurflen 1")
@@ -125,7 +124,7 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
 
       context "when the Welsh form has a payment url" do
         let(:welsh_payment_url) { "https://www.gov.uk/payments/welsh-service/pay-for-licence" }
-        let(:welsh_form) { Form.new(build(:v2_form_document, payment_url: welsh_payment_url)) }
+        let(:welsh_form_document) { build(:v2_form_document, payment_url: welsh_payment_url) }
 
         it "sets payment_link_cy to the Welsh payment url with reference" do
           expect(mail.govuk_notify_personalisation[:payment_link_cy]).to eq("#{welsh_payment_url}?reference=#{submission_reference}")
@@ -167,8 +166,8 @@ describe FormSubmissionConfirmationMailer, type: :mailer do
       context "when a Welsh version of the form is present" do
         let(:welsh_what_happens_next_markdown) { "Arhoswch am ymateb" }
         let(:welsh_support_phone) { "0291 111 1111" }
-        let(:welsh_form) do
-          build :form,
+        let(:welsh_form_document) do
+          build :v2_form_document,
                 what_happens_next_markdown: welsh_what_happens_next_markdown,
                 support_phone: welsh_support_phone
         end

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -173,18 +173,30 @@ RSpec.describe Question::File, type: :model do
     end
 
     context "when the original_filename has a value" do
-      it "returns the filename containing the submission reference with the email attachment text" do
-        expect(question.show_answer_in_email(submission_reference:)).to eq I18n.t("mailer.submission.file_attached", filename: "a-file_#{submission_reference}.png")
+      context "when formatting for a submission email" do
+        it "returns the filename containing the submission reference with the email attachment text" do
+          expect(question.show_answer_in_email(submission_reference:)).to eq I18n.t("mailer.submission.file_attached", filename: "a-file_#{submission_reference}.png")
+        end
+
+        context "when the filename is long enough to be truncated" do
+          let(:filename_suffix) { "_1" }
+          let(:original_filename) { "an_unusual_and_atypically_long_filename_that_is_just_about_long_enough_to_be_truncated.doc" }
+
+          it "returns a hash with a truncated filename containing the submission reference" do
+            truncated_filename_with_suffix_and_reference = "an_unusual_and_atypically_long_filename_that_is_just_about_long_enough_to_be_truncated_1_#{submission_reference}.doc"
+
+            expect(question.show_answer_in_email(submission_reference:)).to eq(I18n.t("mailer.submission.file_attached", filename: truncated_filename_with_suffix_and_reference))
+          end
+        end
       end
 
-      context "when the filename is long enough to be truncated" do
-        let(:filename_suffix) { "_1" }
-        let(:original_filename) { "an_unusual_and_atypically_long_filename_that_is_just_about_long_enough_to_be_truncated.doc" }
+      context "when formatting for a confirmation email" do
+        let(:filename_suffix) { "_1" } # ensure the suffix isn't used
 
-        it "returns a hash with a truncated filename containing the submission reference" do
-          truncated_filename_with_suffix_and_reference = "an_unusual_and_atypically_long_filename_that_is_just_about_long_enough_to_be_truncated_1_#{submission_reference}.doc"
-
-          expect(question.show_answer_in_email(submission_reference:)).to eq(I18n.t("mailer.submission.file_attached", filename: truncated_filename_with_suffix_and_reference))
+        it "returns content for the confirmation email with the original filename" do
+          expect(question.show_answer_in_email(submission_reference:, confirmation_email: true)).to eq(
+            I18n.t("mailer.submission_confirmation.file_answer", filename: original_filename),
+          )
         end
       end
     end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -162,6 +162,56 @@ RSpec.describe Submission, type: :model do
     end
   end
 
+  describe "answer content methods" do
+    subject(:submission) { create(:submission, form_document:, welsh_form_document:, answers:) }
+
+    let(:form_document) do
+      build(:v2_form_document,
+            steps: [
+              build(:v2_question_step, :with_text_settings, question_text: "What is your favourite colour?", id: "q1", next_step_id: "q2"),
+              build(:v2_question_step, :with_name_settings, question_text: "What is your name?", id: "q2"),
+            ],
+            start_page: "q1")
+    end
+    let(:welsh_form_document) do
+      build(:v2_form_document,
+            steps: [
+              build(:v2_question_step, :with_text_settings, question_text: "Beth yw eich hoff liw?", id: "q1", next_step_id: "q2"),
+              build(:v2_question_step, :with_name_settings, question_text: "Beth yw dy enw?", id: "q2"),
+            ],
+            start_page: "q1")
+    end
+    let(:answers) { { "q1" => { text: "blue" }, "q2" => { first_name: "Jane", last_name: "Doe" } } }
+
+    describe "#answer_content_for_email_html" do
+      it "uses the English form document to construct the HTML by default" do
+        result = submission.answer_content_for_email_html(heading_tag: "h4")
+
+        expect(result).to start_with("<h4>What is your favourite colour?</h4>")
+      end
+
+      it "uses the Welsh form document to construct the HTML when the locale is :cy" do
+        result = submission.answer_content_for_email_html(heading_tag: "h4", locale: :cy)
+
+        expect(result).to start_with("<h4>Beth yw eich hoff liw?</h4>")
+      end
+    end
+
+    describe "#answer_content_for_email_plain_text" do
+      it "uses the English form document to construct the answer content by default" do
+        result = submission.answer_content_for_email_plain_text
+
+        expect(result).to start_with("What is your favourite colour?")
+      end
+
+      it "uses the Welsh form document to construct the answer content when the locale is :cy" do
+        result = submission.answer_content_for_email_plain_text(locale: :cy)
+
+        expect(result).to start_with("Beth yw eich hoff liw?")
+      end
+    end
+  end
+
   describe "#sent?" do
     context "when the submission is sent" do
       let(:submission) { create :submission, :sent }

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -78,7 +78,13 @@ RSpec.describe FormSubmissionService, :capture_logging do
     }
   end
   let(:locales_used) { [:en] }
-  let(:current_context) { instance_double(Flow::Context, form:, journey:, completed_steps: all_steps, answers:, locales_used:) }
+  let(:wants_copy_of_answers) { false }
+  let(:copy_of_answers_email_address) { nil }
+  let(:current_context) do
+    instance_double(Flow::Context, form:, journey:, completed_steps: all_steps, answers:, locales_used:,
+                                   wants_copy_of_answers?: wants_copy_of_answers,
+                                   get_copy_of_answers_email_address: copy_of_answers_email_address)
+  end
 
   before do
     allow(ReferenceNumberService).to receive(:generate).and_return(reference)
@@ -316,8 +322,7 @@ RSpec.describe FormSubmissionService, :capture_logging do
       context "when form is not in english" do
         let(:submission_type) { "email" }
         let(:submission_format) { [] }
-
-        let(:current_context) { instance_double(Flow::Context, form: welsh_form, journey:, completed_steps: all_steps, answers:, locales_used:) }
+        let(:form) { welsh_form }
 
         before do
           ActiveResource::HttpMock.respond_to do |mock|
@@ -355,70 +360,102 @@ RSpec.describe FormSubmissionService, :capture_logging do
     end
 
     describe "sending the confirmation email to the user" do
-      it "enqueues a job to send the confirmation email" do
-        assert_enqueued_with(job: SendConfirmationEmailJob) do
-          service.submit
-        end
-      end
-
-      context "when the confirmation email job fails to enqueue" do
-        let(:enqueue_error) { nil }
-
-        before do
-          allow(SendConfirmationEmailJob).to receive(:perform_later).and_yield(instance_double(SendConfirmationEmailJob, successfully_enqueued?: false, enqueue_error:))
-        end
-
-        context "and there is no enqueue error" do
-          it "raises an error" do
-            expect { service.submit }.to change(Submission, :count).by(1).and raise_error(StandardError, "Failed to enqueue confirmation email for reference #{reference}")
-          end
-        end
-
-        context "and there is an enqueue error" do
-          let(:enqueue_error) { ActiveJob::EnqueueError.new("An error occurred enqueueing job") }
-
-          it "raises an error" do
-            expect { service.submit }.to change(Submission, :count).by(1).and raise_error(StandardError, "Failed to enqueue confirmation email for reference #{reference}: An error occurred enqueueing job")
-          end
-        end
-      end
-
-      context "when the to email address is rejected by ActionMailer" do
-        let(:confirmation_email_address) { "rejected-email@gov.uk\n" }
-
-        it "raises a ConfirmationEmailToAddressError" do
-          expect {
+      context "when the user has not asked for a copy of their answers" do
+        it "enqueues a job to send the confirmation email without a copy of the answers" do
+          assert_enqueued_with(job: SendConfirmationEmailJob) do
             service.submit
-          }.to raise_error(FormSubmissionService::ConfirmationEmailToAddressError)
+          end
+
+          args = enqueued_jobs.last["arguments"].first
+
+          expect(args).to include(
+            "submission" => hash_including("_aj_globalid"),
+            "notify_response_id" => email_confirmation_input.confirmation_email_reference,
+            "confirmation_email_address" => confirmation_email_address,
+            "include_copy_of_answers" => false,
+          )
         end
 
-        it "sends an error to Sentry" do
-          expect(Sentry).to receive(:capture_message).with("ActionMailer error for To email address in confirmation email", {
-            extra: {
-              action_mailer_error: /Mail::AddressList can not parse |r\*\*\*\*\*\*\*-e\*\*\*\*(at)g\*\*.u\*\n|: Only able to parse up to "r\*\*\*\*\*\*\*-e\*\*\*\*@g\*\*.u\*\\/,
-            },
-          })
-          service.submit
-        rescue FormSubmissionService::ConfirmationEmailToAddressError
-          nil
+        context "when the confirmation email job fails to enqueue" do
+          let(:enqueue_error) { nil }
+
+          before do
+            allow(SendConfirmationEmailJob).to receive(:perform_later).and_yield(instance_double(SendConfirmationEmailJob, successfully_enqueued?: false, enqueue_error:))
+          end
+
+          context "and there is no enqueue error" do
+            it "raises an error" do
+              expect { service.submit }.to change(Submission, :count).by(1).and raise_error(StandardError, "Failed to enqueue confirmation email for reference #{reference}")
+            end
+          end
+
+          context "and there is an enqueue error" do
+            let(:enqueue_error) { ActiveJob::EnqueueError.new("An error occurred enqueueing job") }
+
+            it "raises an error" do
+              expect { service.submit }.to change(Submission, :count).by(1).and raise_error(StandardError, "Failed to enqueue confirmation email for reference #{reference}: An error occurred enqueueing job")
+            end
+          end
         end
 
-        it "does not queue sending the submission email" do
-          assert_no_enqueued_jobs do
+        context "when the to email address is rejected by ActionMailer" do
+          let(:confirmation_email_address) { "rejected-email@gov.uk\n" }
+
+          it "raises a ConfirmationEmailToAddressError" do
+            expect {
+              service.submit
+            }.to raise_error(FormSubmissionService::ConfirmationEmailToAddressError)
+          end
+
+          it "sends an error to Sentry" do
+            expect(Sentry).to receive(:capture_message).with("ActionMailer error for To email address in confirmation email", {
+              extra: {
+                action_mailer_error: /Mail::AddressList can not parse |r\*\*\*\*\*\*\*-e\*\*\*\*(at)g\*\*.u\*\n|: Only able to parse up to "r\*\*\*\*\*\*\*-e\*\*\*\*@g\*\*.u\*\\/,
+              },
+            })
             service.submit
           rescue FormSubmissionService::ConfirmationEmailToAddressError
             nil
           end
+
+          it "does not queue sending the submission email" do
+            assert_no_enqueued_jobs do
+              service.submit
+            rescue FormSubmissionService::ConfirmationEmailToAddressError
+              nil
+            end
+          end
+        end
+
+        context "when user does not want a confirmation email" do
+          let(:email_confirmation_input) { build :email_confirmation_input }
+
+          it "does not call FormSubmissionConfirmationMailer" do
+            allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email)
+            service.submit
+            expect(FormSubmissionConfirmationMailer).not_to have_received(:send_confirmation_email)
+          end
         end
       end
 
-      context "when user does not want a confirmation email" do
+      context "when the user has asked for a copy of their answers" do
+        let(:wants_copy_of_answers) { true }
+        let(:copy_of_answers_email_address) { "copy-of-answers@example.com" }
         let(:email_confirmation_input) { build :email_confirmation_input }
 
-        it "does not call FormSubmissionConfirmationMailer" do
-          allow(FormSubmissionConfirmationMailer).to receive(:send_confirmation_email)
-          service.submit
-          expect(FormSubmissionConfirmationMailer).not_to have_received(:send_confirmation_email)
+        it "enqueues a job to send the confirmation email to the copy of answers email with a copy of the answers" do
+          assert_enqueued_with(job: SendConfirmationEmailJob) do
+            service.submit
+          end
+
+          args = enqueued_jobs.last["arguments"].first
+
+          expect(args).to include(
+            "submission" => hash_including("_aj_globalid"),
+            "notify_response_id" => email_confirmation_input.confirmation_email_reference,
+            "confirmation_email_address" => copy_of_answers_email_address,
+            "include_copy_of_answers" => true,
+          )
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/hCWhyMOm

Send a confirmation email using Amazon SES containing a copy of the user's answers if they have signed in with One Login and asked for a copy of their answers.

If they have not asked for a copy of their answers, continue sending the confirmation email using Notify. However, the mailer for sending with SES accepts an option for including a copy of the answers or not, so switching over down the line to use SES for all confirmation emails should be easy.

### Email styling

We're not currently explicitly specifying the style for headings, as per the submission email. We probably should, especially as we're now introducing h4s. I'd welcome comments on the best way to do this - but might raise a follow up PR to look at this as this PR is already very big.

### Testing

You'll need to configure your GOV.UK One Login test service (ask me how if you haven't)

Then run locally, in an AWS shell for the dev-readonly role with the following environment variables:
```
gds aws forms-dev-readonly --shell

SETTINGS__GOVUK_ONE_LOGIN__CLIENT_ID=your-client-id SETTINGS__GOVUK_ONE_LOGIN__PRIVATE_KEY=your-base64-encoded-private-key ASSUME_DEV_IAM_ROLE=true bundle exec rails s
```

<img width="431" height="995" alt="Screenshot 2026-05-27 at 12 08 13" src="https://github.com/user-attachments/assets/98da5224-350b-48e3-9727-eefcd44e90a2" />

<img width="433" height="988" alt="Screenshot 2026-05-27 at 12 08 25" src="https://github.com/user-attachments/assets/dba64b5c-563f-47b5-a9db-ca99900c0896" />

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
