### PR TITLE
Add inline styles to email headings

### DIFF
--- a/app/lib/ses_email_formatter.rb
+++ b/app/lib/ses_email_formatter.rb
@@ -12,9 +12,9 @@ class SesEmailFormatter
     @confirmation_email = confirmation_email
   end
 
-  def build_question_answers_section_html(heading_tag: "h3")
+  def build_question_answers_section_html(heading_level: 3)
     @steps.map { |step|
-      [prep_question_title_html(step, heading_tag),
+      [prep_question_title_html(step, heading_level),
        prep_answer_text_html(step)].join
     }.join(H_RULE)
   end
@@ -28,8 +28,15 @@ class SesEmailFormatter
 
 private
 
-  def prep_question_title_html(step, heading_tag)
-    "<#{heading_tag}>#{prep_question_title_plain_text(step)}</#{heading_tag}>"
+  def prep_question_title_html(step, heading_level)
+    case heading_level
+    when 3
+      "<h3 style=\"font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;\">#{prep_question_title_plain_text(step)}</h3>"
+    when 4
+      "<h4 style=\"font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;\">#{prep_question_title_plain_text(step)}</h4>"
+    else
+      raise FormattingError, "unsupported heading level: #{heading_level}"
+    end
   end
 
   def prep_answer_text_html(step)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -59,8 +59,8 @@ class Submission < ApplicationRecord
     Mode.new(mode)
   end
 
-  def answer_content_for_email_html(heading_tag:, locale: :en, confirmation_email: false)
-    ses_email_formatter(locale, confirmation_email).build_question_answers_section_html(heading_tag:)
+  def answer_content_for_email_html(heading_level:, locale: :en, confirmation_email: false)
+    ses_email_formatter(locale, confirmation_email).build_question_answers_section_html(heading_level:)
   end
 
   def answer_content_for_email_plain_text(locale: :en, confirmation_email: false)

--- a/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
+++ b/app/views/aws_ses_form_submission_mailer/submission_email.html.erb
@@ -30,7 +30,7 @@
 
 <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
 
-<h2><%= I18n.t("mailer.submission.answers_submitted") %></h2>
+<h2 style="font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;"><%= I18n.t("mailer.submission.answers_submitted") %></h2>
 
 <% if @csv_filename.present? %>
   <p><%= I18n.t("mailer.submission.csv_file", filename: @csv_filename) %></p>
@@ -40,7 +40,7 @@
   <p><%= I18n.t("mailer.submission.json_file", filename: @json_filename) %></p>
 <% end %>
 
-<%= @submission.answer_content_for_email_html(heading_tag: "h3").html_safe %>
+<%= @submission.answer_content_for_email_html(heading_level: 3).html_safe %>
 
 <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
 
@@ -48,7 +48,7 @@
   style="margin: 0 0 20px 0; border-left: 10px solid #B1B4B6;
     padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;"
 >
-  <h2><%= I18n.t("mailer.cannot_reply.heading") %></h2>
+  <h2 style="font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;"><%= I18n.t("mailer.cannot_reply.heading") %></h2>
   <%= I18n.t("mailer.cannot_reply.contact_form_filler_html").html_safe %>
   <%= I18n.t("mailer.cannot_reply.contact_forms_team_html").html_safe %>
 </div>

--- a/app/views/aws_ses_submission_batch_mailer/daily_submission_batch_email.html.erb
+++ b/app/views/aws_ses_submission_batch_mailer/daily_submission_batch_email.html.erb
@@ -32,6 +32,6 @@
   style="margin: 0 0 20px 0; border-left: 10px solid #B1B4B6;
     padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;"
 >
-  <h2><%= I18n.t("mailer.cannot_reply.heading") %></h2>
+  <h2 style="font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;"><%= I18n.t("mailer.cannot_reply.heading") %></h2>
   <%= I18n.t("mailer.cannot_reply.contact_forms_team_html").html_safe %>
 </div>

--- a/app/views/aws_ses_submission_batch_mailer/weekly_submission_batch_email.html.erb
+++ b/app/views/aws_ses_submission_batch_mailer/weekly_submission_batch_email.html.erb
@@ -32,6 +32,6 @@
   style="margin: 0 0 20px 0; border-left: 10px solid #B1B4B6;
     padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;"
 >
-  <h2><%= I18n.t("mailer.cannot_reply.heading") %></h2>
+  <h2 style="font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;"><%= I18n.t("mailer.cannot_reply.heading") %></h2>
   <%= I18n.t("mailer.cannot_reply.contact_forms_team_html").html_safe %>
 </div>

--- a/app/views/aws_ses_submission_confirmation_mailer/_content.html.erb
+++ b/app/views/aws_ses_submission_confirmation_mailer/_content.html.erb
@@ -1,8 +1,8 @@
 <% if @submission.preview? %>
-  <h2><%= I18n.t("mailer.submission_confirmation.title_preview") %></h2>
+  <h2 style="font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;"><%= I18n.t("mailer.submission_confirmation.title_preview") %></h2>
   <p><%= I18n.t("mailer.submission_confirmation.this_is_a_test") %></p>
 <% else %>
-  <h2><%= I18n.t("mailer.submission_confirmation.title") %></h2>
+  <h2 style="font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;"><%= I18n.t("mailer.submission_confirmation.title") %></h2>
 <% end %>
 
 <p><%= I18n.t("mailer.submission_confirmation.submitted_at", form_name: form.name,
@@ -20,11 +20,11 @@
 
 
 <% if form.payment_url.present? %>
-  <h3><%= I18n.t("mailer.submission_confirmation.payment_link_heading") %></h3>
+  <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;"><%= I18n.t("mailer.submission_confirmation.payment_link_heading") %></h3>
   <p><%= I18n.t("mailer.submission_confirmation.payment_link_html", payment_link: form.payment_url_with_reference(@submission.reference)).html_safe %></p>
 <% end %>
 
-<h3><%= I18n.t("mailer.submission_confirmation.what_happens_next_heading") %></h3>
+<h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;"><%= I18n.t("mailer.submission_confirmation.what_happens_next_heading") %></h3>
 <% if form.what_happens_next_markdown.present? %>
   <%= markdown_to_html(form.what_happens_next_markdown) %>
 <% else %>
@@ -32,12 +32,12 @@
 <% end %>
 
 <% if @include_copy_of_answers %>
-  <h3><%= I18n.t("mailer.submission_confirmation.answers_submitted_heading") %></h3>
-  <%= @submission.answer_content_for_email_html(heading_tag: "h4", locale: locale, confirmation_email: true).html_safe %>
+  <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;"><%= I18n.t("mailer.submission_confirmation.answers_submitted_heading") %></h3>
+  <%= @submission.answer_content_for_email_html(heading_level: 4, locale: locale, confirmation_email: true).html_safe %>
   <hr style="border: 0; height: 1px; background: #B1B4B6; margin: 30px 0 30px 0;">
 <% end %>
 
-<h3><%= I18n.t("mailer.submission_confirmation.contact_details_heading") %></h3>
+<h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;"><%= I18n.t("mailer.submission_confirmation.contact_details_heading") %></h3>
 
 <% if form.support_details.phone || form.support_details.email || form.support_details.url %>
   <% if form.support_details.phone.present? %>

--- a/spec/lib/ses_email_formatter_spec.rb
+++ b/spec/lib/ses_email_formatter_spec.rb
@@ -30,11 +30,25 @@ RSpec.describe SesEmailFormatter do
   describe "#build_question_answers_section_html" do
     context "when there is one step" do
       it "returns question and and answer HTML" do
-        expect(ses_email_formatter.build_question_answers_section_html).to eq("<h3>What is the meaning of life?</h3><p>42</p>")
+        expected = <<~HTML.strip.gsub("\n", "")
+          <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">What is the meaning of life?</h3>
+          <p>42</p>
+        HTML
+        expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
       end
 
-      it "uses the heading level provided" do
-        expect(ses_email_formatter.build_question_answers_section_html(heading_tag: "h2")).to eq("<h2>What is the meaning of life?</h2><p>42</p>")
+      it "formats with heading level 4" do
+        expected = <<~HTML.strip.gsub("\n", "")
+          <h4 style="font-size: 19px; line-height: 25px; font-weight: bold; color: #0B0C0C;">What is the meaning of life?</h4>
+          <p>42</p>
+        HTML
+        expect(ses_email_formatter.build_question_answers_section_html(heading_level: 4)).to eq(expected)
+      end
+
+      it "raises an error if the heading level is unsupported" do
+        expect {
+          ses_email_formatter.build_question_answers_section_html(heading_level: 2)
+        }.to raise_error(SesEmailFormatter::FormattingError, "unsupported heading level: 2")
       end
     end
 
@@ -42,7 +56,11 @@ RSpec.describe SesEmailFormatter do
       let(:steps) { [name_step] }
 
       it "inserts line breaks between answer attributes" do
-        expect(ses_email_formatter.build_question_answers_section_html).to eq("<h3>What is your name?</h3><p>First name: #{name_question.first_name}<br/><br/>Last name: #{name_question.last_name}</p>")
+        expected = <<~HTML.strip.gsub("\n", "")
+          <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">What is your name?</h3>
+          <p>First name: #{name_question.first_name}<br/><br/>Last name: #{name_question.last_name}</p>
+        HTML
+        expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
       end
     end
 
@@ -51,7 +69,11 @@ RSpec.describe SesEmailFormatter do
       let(:steps) { [text_step] }
 
       it "returns the blank answer text" do
-        expect(ses_email_formatter.build_question_answers_section_html).to eq("<h3>What is the meaning of life?</h3><p>[This question was skipped]</p>")
+        expected = <<~HTML.strip.gsub("\n", "")
+          <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">What is the meaning of life?</h3>
+          <p>[This question was skipped]</p>
+        HTML
+        expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
       end
     end
 
@@ -59,7 +81,14 @@ RSpec.describe SesEmailFormatter do
       let(:steps) { [text_step, name_step] }
 
       it "returns all question an answers separated by a horizontal rule" do
-        expect(ses_email_formatter.build_question_answers_section_html).to eq("<h3>What is the meaning of life?</h3><p>42</p><hr style=\"border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;\"><h3>What is your name?</h3><p>First name: #{name_question.first_name}<br/><br/>Last name: #{name_question.last_name}</p>")
+        expected = <<~HTML.strip.gsub("\n", "")
+          <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">What is the meaning of life?</h3>
+          <p>42</p>
+          <hr style="border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;">
+          <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">What is your name?</h3>
+          <p>First name: #{name_question.first_name}<br/><br/>Last name: #{name_question.last_name}</p>
+        HTML
+        expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
       end
     end
 
@@ -74,7 +103,11 @@ RSpec.describe SesEmailFormatter do
         ].each do |test_case|
           text_question.text = test_case[:input]
 
-          expect(ses_email_formatter.build_question_answers_section_html).to eq("<h3>What is the meaning of life?</h3><p>#{test_case[:output]}</p>")
+          expected = <<~HTML.strip.gsub("\n", "")
+            <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">What is the meaning of life?</h3>
+            <p>#{test_case[:output]}</p>
+          HTML
+          expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
         end
       end
     end
@@ -83,7 +116,13 @@ RSpec.describe SesEmailFormatter do
       let(:steps) { [none_of_the_above_step] }
 
       it "returns the sanitized answer including the none of the above answer" do
-        expect(ses_email_formatter.build_question_answers_section_html).to eq("<h3>What sandwich do you want?</h3><p>None of the above</p><h4>Specify your desired sandwich</h4><p>Cheese and pickle</p>")
+        expected = <<~HTML.strip.gsub("\n", "")
+          <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">What sandwich do you want?</h3>
+          <p>None of the above</p>
+          <h4>Specify your desired sandwich</h4>
+          <p>Cheese and pickle</p>
+        HTML
+        expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
       end
 
       context "when the none of the above question has no answer is provided" do
@@ -91,7 +130,13 @@ RSpec.describe SesEmailFormatter do
         let(:none_of_the_above_question_is_optional) { "true" }
 
         it "returns the skipped none of the above answer text" do
-          expect(ses_email_formatter.build_question_answers_section_html).to eq("<h3>What sandwich do you want?</h3><p>None of the above</p><h4>Specify your desired sandwich (optional)</h4><p>[This question was skipped]</p>")
+          expected = <<~HTML.strip.gsub("\n", "")
+            <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">What sandwich do you want?</h3>
+            <p>None of the above</p>
+            <h4>Specify your desired sandwich (optional)</h4>
+            <p>[This question was skipped]</p>
+          HTML
+          expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
         end
       end
     end
@@ -101,7 +146,11 @@ RSpec.describe SesEmailFormatter do
 
       context "when formatting for a submission email" do
         it "returns the content for a submission email" do
-          expect(ses_email_formatter.build_question_answers_section_html).to eq("<h3>Upload a file</h3><p>a-file_SUB-12345.txt (attached to this email)</p>")
+          expected = <<~HTML.strip.gsub("\n", "")
+            <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">Upload a file</h3>
+            <p>a-file_SUB-12345.txt (attached to this email)</p>
+          HTML
+          expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
         end
       end
 
@@ -109,7 +158,11 @@ RSpec.describe SesEmailFormatter do
         let(:confirmation_email) { true }
 
         it "returns the content for a confirmation email" do
-          expect(ses_email_formatter.build_question_answers_section_html).to eq("<h3>Upload a file</h3><p>You uploaded a file called a-file.txt</p>")
+          expected = <<~HTML.strip.gsub("\n", "")
+            <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">Upload a file</h3>
+            <p>You uploaded a file called a-file.txt</p>
+          HTML
+          expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
         end
       end
     end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -185,15 +185,15 @@ RSpec.describe Submission, type: :model do
 
     describe "#answer_content_for_email_html" do
       it "uses the English form document to construct the HTML by default" do
-        result = submission.answer_content_for_email_html(heading_tag: "h4")
+        result = submission.answer_content_for_email_html(heading_level: 4)
 
-        expect(result).to start_with("<h4>What is your favourite colour?</h4>")
+        expect(result).to include("What is your favourite colour?")
       end
 
       it "uses the Welsh form document to construct the HTML when the locale is :cy" do
-        result = submission.answer_content_for_email_html(heading_tag: "h4", locale: :cy)
+        result = submission.answer_content_for_email_html(heading_level: 4, locale: :cy)
 
-        expect(result).to start_with("<h4>Beth yw eich hoff liw?</h4>")
+        expect(result).to include("Beth yw eich hoff liw?")
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/hCWhyMOm

As we're adding in h4 headings to the confirmation emails for the questions, we want to ensure that these are displayed consistently across email clients.

Add inline styles to all headings included in emails using the font sizes for design system type scales for small screens https://design-system.service.gov.uk/styles/type-scale/

Use the sizes as follows:
- h2: 27px (govuk-heading-l)
- h3: 21px (govuk-heading-m)
- h4: 19px (govuk-heading-s)

This is consistent with Notify's approach. Use the line height used by Notify for the different headings.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
