### PR TITLE
Log delivered_at and delivery_latency for immediate email deliveries

### DIFF
--- a/app/jobs/receive_submission_deliveries_job.rb
+++ b/app/jobs/receive_submission_deliveries_job.rb
@@ -22,24 +22,25 @@ class ReceiveSubmissionDeliveriesJob < ApplicationJob
 
       delivered_at = Time.zone.parse(ses_message["delivery"]["timestamp"])
       process_delivery(delivery, submission, delivered_at:)
-
-      if delivery.immediate?
-        submission_duration_ms = ((delivered_at - submission.created_at) * 1000).round
-        CloudWatchService.record_submission_delivery_latency_metric(submission_duration_ms, "Email")
-      end
     end
   end
 
 private
 
-  def process_delivery(delivery, submission, **attributes)
-    set_submission_logging_attributes(submission:, delivery:) if delivery.immediate?
-    set_submission_batch_logging_attributes(form: submission.form, mode: submission.mode_object, delivery:) if delivery.daily? || delivery.weekly?
+  def process_delivery(delivery, submission, delivered_at:)
+    delivery.update!(delivered_at:)
 
-    delivery.update! attributes
-
-    form_event_name = delivery.immediate? ? "submission_delivered" : "submission_batch_delivered"
-
-    EventLogger.log_form_event(form_event_name)
+    if delivery.immediate?
+      delivery_latency = ((delivery.delivered_at - submission.created_at) * 1000).round
+      set_submission_logging_attributes(submission:, delivery:)
+      CloudWatchService.record_submission_delivery_latency_metric(delivery_latency, "Email")
+      EventLogger.log_form_event(
+        "submission_delivered",
+        { delivered_at: delivery.delivered_at, delivery_latency: },
+      )
+    elsif delivery.daily? || delivery.weekly?
+      set_submission_batch_logging_attributes(form: submission.form, mode: submission.mode_object, delivery:)
+      EventLogger.log_form_event("submission_batch_delivered")
+    end
   end
 end

--- a/app/jobs/receive_submission_deliveries_job.rb
+++ b/app/jobs/receive_submission_deliveries_job.rb
@@ -20,11 +20,11 @@ class ReceiveSubmissionDeliveriesJob < ApplicationJob
 
       raise "Unexpected event type:#{ses_event_type}" unless ses_event_type == "Delivery"
 
-      delivery_time = Time.zone.parse(ses_message["delivery"]["timestamp"])
-      process_delivery(delivery, submission, delivered_at: delivery_time)
+      delivered_at = Time.zone.parse(ses_message["delivery"]["timestamp"])
+      process_delivery(delivery, submission, delivered_at:)
 
       if delivery.immediate?
-        submission_duration_ms = ((delivery_time - submission.created_at) * 1000).round
+        submission_duration_ms = ((delivered_at - submission.created_at) * 1000).round
         CloudWatchService.record_submission_delivery_latency_metric(submission_duration_ms, "Email")
       end
     end

--- a/spec/jobs/receive_submission_deliveries_job_spec.rb
+++ b/spec/jobs/receive_submission_deliveries_job_spec.rb
@@ -99,6 +99,8 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
                                      "form_id" => submission.form_id,
                                      "submission_reference" => reference,
                                      "preview" => "false",
+                                     "delivered_at" => Time.zone.parse(ses_delivery_timestamp),
+                                     "delivery_latency" => 6122,
                                      "sns_message_timestamp" => sns_message_timestamp,
                                      "job_id" => @job_id,
                                      "job_class" => "ReceiveSubmissionDeliveriesJob",


### PR DESCRIPTION
Slow immediate email deliveries are hard to investigate when latency only lives in CloudWatch. This adds delivered_at and delivery_latency to job logs so we can spot patterns in log queries—e.g. whether delays cluster on a particular form—without cross-referencing metrics for every case.

Batch deliveries are unchanged. delivery_latency is milliseconds from submission creation to SES delivery confirmation.