### PR TITLE
Use different configuration set for confirmation emails

### DIFF
--- a/app/mailers/aws_ses_delivery_method.rb
+++ b/app/mailers/aws_ses_delivery_method.rb
@@ -3,6 +3,7 @@ class AwsSesDeliveryMethod
 
   def initialize(settings)
     self.settings = settings
+    @configuration_set_name = settings[:configuration_set_name] || Settings.aws.ses_submission_email_configuration_set_name
   end
 
   def deliver!(message)
@@ -13,7 +14,7 @@ class AwsSesDeliveryMethod
           data: message.to_s,
         },
       },
-      configuration_set_name: Settings.aws.ses_submission_email_configuration_set_name,
+      configuration_set_name: @configuration_set_name,
     })
 
     # Overwrite the generated message_id with the id returned by SES.

--- a/app/mailers/aws_ses_submission_confirmation_mailer.rb
+++ b/app/mailers/aws_ses_submission_confirmation_mailer.rb
@@ -10,7 +10,13 @@ class AwsSesSubmissionConfirmationMailer < ApplicationMailer
     @submission = submission
     @include_copy_of_answers = include_copy_of_answers
 
-    mail(to: confirmation_email_address, subject: subject)
+    mail(
+      to: confirmation_email_address,
+      subject: subject,
+      delivery_method_options: {
+        configuration_set_name: Settings.aws.ses_confirmation_email_configuration_set_name,
+      },
+    )
   end
 
   def subject

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,6 +44,7 @@ aws:
   s3_submission_iam_role_arn: changeme
   file_upload_s3_bucket_name: changeme
   ses_submission_email_configuration_set_name: changeme
+  ses_confirmation_email_configuration_set_name: changeme
 
 ses_submission_email:
   from_email_address: changeme

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -9,6 +9,7 @@ active_record_encryption:
 aws:
   file_upload_s3_bucket_name: govuk-forms-dev-file-upload
   ses_submission_email_configuration_set_name: bounces_and_complaints_handling_rule
+  ses_confirmation_email_configuration_set_name: bounces_and_complaints_handling_rule
 
 ses_submission_email:
   from_email_address: "local-test@dev.forms.service.gov.uk"

--- a/spec/jobs/send_confirmation_email_job_spec.rb
+++ b/spec/jobs/send_confirmation_email_job_spec.rb
@@ -125,6 +125,39 @@ RSpec.describe SendConfirmationEmailJob, type: :job do
         expect(mail.subject).to eq(I18n.t("mailer.submission_confirmation.subject", reference: submission.reference))
       end
     end
+
+    describe "the SES configuration set" do
+      let(:mock_ses_client) { instance_double(Aws::SESV2::Client) }
+      let(:ses_response) { instance_double(Aws::SESV2::Types::SendEmailResponse, message_id: Faker::Alphanumeric.alphanumeric) }
+      let(:confirmation_email_configuration_set_name) { "test-confirmation-config-set" }
+
+      around do |example|
+        original_delivery_method = AwsSesSubmissionConfirmationMailer.delivery_method
+        AwsSesSubmissionConfirmationMailer.delivery_method = :aws_ses
+        example.run
+      ensure
+        AwsSesSubmissionConfirmationMailer.delivery_method = original_delivery_method
+      end
+
+      before do
+        allow(Aws::SESV2::Client).to receive(:new).and_return(mock_ses_client)
+        allow(mock_ses_client).to receive(:send_email).and_return(ses_response)
+        allow(Settings.aws).to receive(:ses_confirmation_email_configuration_set_name).and_return(confirmation_email_configuration_set_name)
+      end
+
+      it "passes the confirmation email configuration set name to SES" do
+        described_class.perform_now(
+          submission:,
+          notify_response_id:,
+          confirmation_email_address:,
+          include_copy_of_answers: true,
+        )
+
+        expect(mock_ses_client).to have_received(:send_email).with(
+          hash_including(configuration_set_name: confirmation_email_configuration_set_name),
+        )
+      end
+    end
   end
 
   context "when there is an error during processing" do

--- a/spec/mailers/aws_ses_delivery_method_spec.rb
+++ b/spec/mailers/aws_ses_delivery_method_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe AwsSesDeliveryMethod do
-  subject(:delivery) { described_class.new(settings: {}) }
+  subject(:delivery) { described_class.new({}) }
 
   describe "#deliver!" do
     let(:mock_ses_client) { Aws::SESV2::Client.new(stub_responses: true) }
@@ -21,19 +21,19 @@ RSpec.describe AwsSesDeliveryMethod do
         message_id: ses_message_id,
       )
     end
-    let(:configuration_set_name) { Faker::Lorem.word }
+    let(:submission_email_configuration_set_name) { Faker::Lorem.word }
 
     before do
       allow(Aws::SESV2::Client).to receive(:new).and_return(mock_ses_client)
       allow(mock_ses_client).to receive(:send_email).and_return(response)
       allow(message).to receive(:to_s).and_return(message_content)
       allow(message).to receive(:message_id=)
-      allow(Settings.aws).to receive(:ses_submission_email_configuration_set_name).and_return(configuration_set_name)
+      allow(Settings.aws).to receive(:ses_submission_email_configuration_set_name).and_return(submission_email_configuration_set_name)
 
       delivery.deliver!(message)
     end
 
-    it "calls AWS to send the email" do
+    it "calls AWS to send the email with the submissions configuration set" do
       expect(mock_ses_client).to have_received(:send_email).with(
         {
           content: {
@@ -41,13 +41,32 @@ RSpec.describe AwsSesDeliveryMethod do
               data: message_content,
             },
           },
-          configuration_set_name:,
+          configuration_set_name: submission_email_configuration_set_name,
         },
       )
     end
 
     it "sets the message ID to the message ID from SES" do
       expect(message).to have_received(:message_id=).with(ses_message_id)
+    end
+
+    context "when the delivery method options include a configuration set name" do
+      subject(:delivery) { described_class.new({ configuration_set_name: custom_configuration_set_name }) }
+
+      let(:custom_configuration_set_name) { "custom-name" }
+
+      it "calls AWS to send the email with the specified configuration set" do
+        expect(mock_ses_client).to have_received(:send_email).with(
+          {
+            content: {
+              raw: {
+                data: message_content,
+              },
+            },
+            configuration_set_name: custom_configuration_set_name,
+          },
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/c0e0lOuO

Update the SES delivery method to allow overriding the SES configuration set name to use.

This setting is passed into the delivery method in the mailer using delivery_method_options.

For confirmation emails, use the separate configuration set name defined in the settings.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
