### PR TITLE
update welsh translations for copy of answers flow

### DIFF
--- a/app/controllers/users/omniauth_controller.rb
+++ b/app/controllers/users/omniauth_controller.rb
@@ -7,7 +7,10 @@ module Users
       Sentry.capture_exception(exception)
 
       link_url = copy_of_answers_path(**auth_service.form_path_params)
-      render "errors/auth_error", locals: { link_url: }, status: :bad_request
+      locale = auth_service.form_path_params[:locale] || I18n.default_locale
+      I18n.with_locale(locale) do
+        render "errors/auth_error", locals: { link_url: }, status: :bad_request
+      end
     rescue Store::ReturnFromOneLoginStore::MissingReturnParamsError
       render "errors/return_from_one_login_session_missing", status: :bad_request
     end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -86,7 +86,7 @@ cy:
         copy_of_answers_input:
           attributes:
             copy_of_answers:
-              blank: PLACEHOLDER! Dewiswch ydw os hoffech dderbyn copi o'ch atebion
+              blank: Dewiswch ‘Ydw’ os ydych eisiau copi o’ch atebion
         email_confirmation_input:
           attributes:
             confirmation_email_address:
@@ -298,10 +298,10 @@ cy:
   errors:
     auth_error:
       body_html: |
-        <p>We could not confirm your email address using GOV.UK One Login.</p>
-        <p>You’ll need to go back to the form and submit your answers.</p>
-        <p><a href="%{link_url}">Back to form</a></p>
-      title: Sorry, something has gone wrong
+        <p>Nid oeddem yn gallu cadarnhau eich cyfeiriad e-bost gan ddefnyddio GOV.UK One Login.</p>
+        <p>Bydd angen i chi fynd yn ôl i’r ffurflen a chyflwyno’ch atebion.</p>
+        <p><a href="%{link_url}">Yn ôl i’r ffurflen</a></p>
+      title: Mae’n ddrwg gennym, mae rhywbeth wedi mynd o’i le
     goto_page_routing_error:
       cannot_have_goto_page_before_routing_page:
         body_html: |
@@ -337,9 +337,9 @@ cy:
       title: Er lles eich diogelwch, rydyn ni wedi dileu’ch atebion
     return_from_one_login_session_missing:
       body_html: |
-        <p>We could not confirm your email address using GOV.UK One Login.</p>
-        <p>You’ll need to go back to the form and submit your answers - try clicking the ‘Back’ button in your browser.</p>
-      title: Sorry, something has gone wrong
+        <p>Nid oeddem yn gallu cadarnhau eich cyfeiriad e-bost gan ddefnyddio GOV.UK One Login.</p>
+        <p>Bydd angen i chi fynd yn ôl i’r ffurflen a chyflwyno’ch atebion - ceisiwch glicio ar y botwm ‘Yn ôl’ yn eich porwr.</p>
+      title: Mae’n ddrwg gennym, mae rhywbeth wedi mynd o’i le
     submission_error:
       body: |
         Roedd yna broblem gyda’r gwasanaeth ac rydyn ni wedi methu cyflwyno’ch atebion.
@@ -691,5 +691,5 @@ cy:
     phone: Ffôn
   unknown_form_submitted:
     show:
-      email_sent: We’ve sent you a confirmation email with a copy of your answers.
-      title: Your form has been submitted
+      email_sent: Rydym wedi anfon e-bost cadarnhau atoch gyda chopi o’ch atebion.
+      title: Mae eich ffurflen wedi’i chyflwyno

--- a/spec/requests/users/omniauth_controller_spec.rb
+++ b/spec/requests/users/omniauth_controller_spec.rb
@@ -68,6 +68,9 @@ RSpec.describe Users::OmniauthController, type: :request do
     context "when data is missing on the auth details on the request" do
       let(:auth_hash) { {} }
 
+      welsh = I18n.t("errors.auth_error.title", locale: :cy)
+      english = I18n.t("errors.auth_error.title", locale: :en)
+
       it "renders the auth error page" do
         expect(response).to have_http_status(400)
         expect(response).to render_template("errors/auth_error")
@@ -82,6 +85,28 @@ RSpec.describe Users::OmniauthController, type: :request do
         expect(Sentry).to have_received(:capture_exception).with(
           an_instance_of(AuthService::DataMissingError),
         )
+      end
+
+      context "when the form is being used in welsh" do
+        let(:locale) { "cy" }
+
+        it "renders the auth error page in welsh" do
+          expect(response).to have_http_status(400)
+          expect(response).to render_template("errors/auth_error")
+          expect(response.body).to include(welsh)
+          expect(response.body).not_to include(english)
+        end
+      end
+
+      context "when the locale in form_path_params is nil" do
+        let(:locale) { nil }
+
+        it "renders the auth error page in english" do
+          expect(response).to have_http_status(400)
+          expect(response).to render_template("errors/auth_error")
+          expect(response.body).to include(english)
+          expect(response.body).not_to include(welsh)
+        end
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

this commit updates the welsh translations for parts of the copy your answers flow. it also updates the auth_error page to show the error page in the language the user is viewing the form in.


Trello card: https://trello.com/c/6niCHGis/2910-update-runner-content-for-copy-of-answers

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
