### PR TITLE
Handle bounces and complaints for confirmation emails

### DIFF
--- a/app/jobs/receive_confirmation_bounces_and_complaints_job.rb
+++ b/app/jobs/receive_confirmation_bounces_and_complaints_job.rb
@@ -1,0 +1,34 @@
+class ReceiveConfirmationBouncesAndComplaintsJob < ApplicationJob
+  def perform(*)
+    CloudWatchService.record_job_started_metric(self.class.name)
+    CurrentJobLoggingAttributes.job_class = self.class.name
+    CurrentJobLoggingAttributes.job_id = job_id
+
+    poller = AwsSesMessagePoller.new(
+      queue_name: Settings.aws.confirmation_email_bounces_and_complaints_sqs_queue_name,
+      job_class_name: self.class.name,
+      job_id: job_id,
+    )
+
+    poller.poll do |ses_message_id, ses_message|
+      CurrentJobLoggingAttributes.confirmation_email_id = ses_message_id
+      ses_event_type = ses_message["eventType"]
+
+      if ses_event_type == "Bounce"
+        bounce_object = ses_message["bounce"] || {}
+        ses_bounce = {
+          bounce_type: bounce_object["bounceType"],
+          bounce_sub_type: bounce_object["bounceSubType"],
+          reporting_mta: bounce_object["reportingMTA"],
+          timestamp: bounce_object["timestamp"],
+          feedback_id: bounce_object["feedbackId"],
+        }
+        Rails.logger.info "Bounce notification received for confirmation email", { ses_bounce: }
+      elsif ses_event_type == "Complaint"
+        Rails.logger.info "Complaint notification received for confirmation email"
+      else
+        raise "Unexpected event type:#{ses_event_type}"
+      end
+    end
+  end
+end

--- a/app/jobs/receive_submission_bounces_and_complaints_job.rb
+++ b/app/jobs/receive_submission_bounces_and_complaints_job.rb
@@ -14,7 +14,9 @@ class ReceiveSubmissionBouncesAndComplaintsJob < ApplicationJob
       job_id: job_id,
     )
 
-    poller.poll do |delivery, ses_message|
+    poller.poll do |ses_message_id, ses_message|
+      CurrentJobLoggingAttributes.delivery_reference = ses_message_id
+      delivery = Delivery.find_by!(delivery_reference: ses_message_id)
       submission = delivery.submissions.first
       ses_event_type = ses_message["eventType"]
 

--- a/app/jobs/receive_submission_bounces_and_complaints_job.rb
+++ b/app/jobs/receive_submission_bounces_and_complaints_job.rb
@@ -1,15 +1,13 @@
 class ReceiveSubmissionBouncesAndComplaintsJob < ApplicationJob
   queue_as :background
 
-  SQS_QUEUE_NAME = "submission_email_ses_bounces_and_complaints_queue".freeze
-
   def perform
     CloudWatchService.record_job_started_metric(self.class.name)
     CurrentJobLoggingAttributes.job_class = self.class.name
     CurrentJobLoggingAttributes.job_id = job_id
 
     poller = AwsSesMessagePoller.new(
-      queue_name: SQS_QUEUE_NAME,
+      queue_name: Settings.aws.submission_email_bounces_and_complaints_sqs_queue_name,
       job_class_name: self.class.name,
       job_id: job_id,
     )

--- a/app/jobs/receive_submission_deliveries_job.rb
+++ b/app/jobs/receive_submission_deliveries_job.rb
@@ -14,7 +14,9 @@ class ReceiveSubmissionDeliveriesJob < ApplicationJob
       job_id: job_id,
     )
 
-    poller.poll do |delivery, ses_message|
+    poller.poll do |ses_message_id, ses_message|
+      CurrentJobLoggingAttributes.delivery_reference = ses_message_id
+      delivery = Delivery.find_by!(delivery_reference: ses_message_id)
       submission = delivery.submissions.first
       ses_event_type = ses_message["eventType"]
 

--- a/app/jobs/receive_submission_deliveries_job.rb
+++ b/app/jobs/receive_submission_deliveries_job.rb
@@ -1,15 +1,13 @@
 class ReceiveSubmissionDeliveriesJob < ApplicationJob
   queue_as :background
 
-  SQS_QUEUE_NAME = "submission_email_ses_successful_deliveries_queue".freeze
-
   def perform
     CloudWatchService.record_job_started_metric(self.class.name)
     CurrentJobLoggingAttributes.job_class = self.class.name
     CurrentJobLoggingAttributes.job_id = job_id
 
     poller = AwsSesMessagePoller.new(
-      queue_name: SQS_QUEUE_NAME,
+      queue_name: Settings.aws.submission_email_deliveries_sqs_queue_name,
       job_class_name: self.class.name,
       job_id: job_id,
     )

--- a/app/lib/aws_ses_message_poller.rb
+++ b/app/lib/aws_ses_message_poller.rb
@@ -55,12 +55,9 @@ private
 
       ses_message = JSON.parse(sns_message["Message"])
       ses_message_id = ses_message["mail"]["messageId"]
-      CurrentJobLoggingAttributes.delivery_reference = ses_message_id
 
-      delivery = Delivery.find_by!(delivery_reference: ses_message_id)
-
-      # Call the provided block with the delivery and ses_message
-      block.call(delivery, ses_message)
+      # Call the provided block with the SES message ID and contents
+      block.call(ses_message_id, ses_message)
 
       sqs_client.delete_message(queue_url: queue_url, receipt_handle: receipt_handle)
     rescue StandardError => e

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -11,6 +11,9 @@ production:
   receive_submission_deliveries_job:
     class: ReceiveSubmissionDeliveriesJob
     schedule: every 10 minutes
+  receive_confirmation_bounces_and_complaints_job:
+    class: ReceiveConfirmationBouncesAndComplaintsJob
+    schedule: every 10 minutes
   schedule_daily_batch_deliveries_job:
     class: ScheduleDailyBatchDeliveriesJob
     schedule: every day at 2am Europe/London

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,6 +45,9 @@ aws:
   file_upload_s3_bucket_name: changeme
   ses_submission_email_configuration_set_name: changeme
   ses_confirmation_email_configuration_set_name: changeme
+  submission_email_bounces_and_complaints_sqs_queue_name: changeme
+  submission_email_deliveries_sqs_queue_name: changeme
+  confirmation_email_bounces_and_complaints_sqs_queue_name: changeme
 
 ses_submission_email:
   from_email_address: changeme

--- a/spec/jobs/receive_confirmation_bounces_and_complaints_job_spec.rb
+++ b/spec/jobs/receive_confirmation_bounces_and_complaints_job_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+# rubocop:disable RSpec/InstanceVariable
+RSpec.describe ReceiveConfirmationBouncesAndComplaintsJob do
+  include ActiveJob::TestHelper
+
+  let(:sqs_client) { instance_double(Aws::SQS::Client) }
+  let(:aws_account_id) { "123456789012" }
+  let(:queue_name) { "bounces-queue" }
+  let(:receipt_handle) { "bounce-receipt-handle" }
+  let(:sqs_message_id) { "sqs-message-id" }
+  let(:sqs_message) { instance_double(Aws::SQS::Types::Message, message_id: sqs_message_id, receipt_handle:, body: sns_message_body) }
+  let(:messages) { [] }
+  let(:message_id) { Faker::Alphanumeric.alphanumeric }
+
+  let(:sns_message_timestamp) { "2025-05-09T10:25:43.972Z" }
+  let(:sns_message_body) { { "Message" => ses_message_body.to_json, "Timestamp" => sns_message_timestamp }.to_json }
+  let(:event_type) { "Bounce" }
+  let(:bounce_timestamp) { "2023-01-01T12:00:00Z" }
+  let(:ses_message_body) do
+    {
+      "mail" => { "messageId" => message_id },
+      "eventType" => event_type,
+      "bounce" => bounce,
+    }
+  end
+  let(:bounce) do
+    {
+      "bounceType" => "Permanent",
+      "bounceSubType" => "General",
+      "reportingMTA" => "Some MTA",
+      "feedbackId" => "feedback-id",
+      "timestamp" => bounce_timestamp,
+    }
+  end
+
+  before do
+    allow(Settings.aws).to receive(:confirmation_email_bounces_and_complaints_sqs_queue_name).and_return(queue_name)
+
+    sts_client = instance_double(Aws::STS::Client)
+    allow(Aws::STS::Client).to receive(:new).and_return(sts_client)
+    allow(sts_client).to receive(:get_caller_identity).and_return(OpenStruct.new(account: aws_account_id))
+
+    allow(Aws::SQS::Client).to receive(:new).and_return(sqs_client)
+    allow(sqs_client).to receive(:receive_message).and_return(OpenStruct.new(messages: messages), OpenStruct.new(messages: []))
+    allow(sqs_client).to receive(:delete_message)
+
+    allow(CloudWatchService).to receive(:record_job_started_metric)
+
+    job = described_class.perform_later
+    @job_id = job.job_id
+  end
+
+  it "calls SQS with the expected queue URL" do
+    perform_enqueued_jobs
+    expect(sqs_client).to have_received(:receive_message).with(
+      hash_including(queue_url: "https://sqs.eu-west-2.amazonaws.com/#{aws_account_id}/#{queue_name}"),
+    ).once
+  end
+
+  it "sends job started metric" do
+    perform_enqueued_jobs
+    expect(CloudWatchService).to have_received(:record_job_started_metric).with("ReceiveConfirmationBouncesAndComplaintsJob")
+  end
+
+  context "when handling a bounce", :capture_logging do
+    let(:messages) { [sqs_message] }
+
+    it "logs with details of the bounce" do
+      perform_enqueued_jobs
+
+      expect(log_lines).to include(hash_including(
+                                     "level" => "INFO",
+                                     "message" => "Bounce notification received for confirmation email",
+                                     "job_id" => @job_id,
+                                     "job_class" => "ReceiveConfirmationBouncesAndComplaintsJob",
+                                     "confirmation_email_id" => message_id,
+                                     "ses_bounce" => {
+                                       "bounce_type" => "Permanent",
+                                       "bounce_sub_type" => "General",
+                                       "reporting_mta" => "Some MTA",
+                                       "timestamp" => bounce_timestamp,
+                                       "feedback_id" => "feedback-id",
+                                     },
+                                   ))
+    end
+  end
+
+  context "when handling a complaint", :capture_logging do
+    let(:event_type) { "Complaint" }
+    let(:messages) { [sqs_message] }
+
+    it "logs with details of the complaint" do
+      perform_enqueued_jobs
+
+      expect(log_lines).to include(hash_including(
+                                     "level" => "INFO",
+                                     "message" => "Complaint notification received for confirmation email",
+                                     "job_id" => @job_id,
+                                     "job_class" => "ReceiveConfirmationBouncesAndComplaintsJob",
+                                     "confirmation_email_id" => message_id,
+                                   ))
+    end
+  end
+
+  describe "handling unexpected event types" do
+    let(:event_type) { "Some other event type" }
+    let(:messages) { [sqs_message] }
+
+    it "raises an error with the unexpected event type" do
+      allow(Sentry).to receive(:capture_exception)
+
+      perform_enqueued_jobs
+
+      expect(Sentry).to have_received(:capture_exception) do |error|
+        expect(error.message).to eq("Unexpected event type:#{event_type}")
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/InstanceVariable

--- a/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
+++ b/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
@@ -314,5 +314,19 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
       end
     end
   end
+
+  context "when the delivery is not found" do
+    let(:messages) { [sqs_message] }
+    let(:delivery) { nil }
+
+    it "captures the error and does not delete the message" do
+      allow(Sentry).to receive(:capture_exception)
+
+      described_class.perform_now
+
+      expect(Sentry).to have_received(:capture_exception).with(an_instance_of(ActiveRecord::RecordNotFound))
+      expect(sqs_client).not_to have_received(:delete_message)
+    end
+  end
 end
 # rubocop:enable RSpec/InstanceVariable

--- a/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
+++ b/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
   include ActiveJob::TestHelper
 
   let(:sqs_client) { instance_double(Aws::SQS::Client) }
+  let(:aws_account_id) { "123456789012" }
+  let(:queue_name) { "bounces-queue" }
   let(:receipt_handle) { "bounce-receipt-handle" }
   let(:sqs_message_id) { "sqs-message-id" }
   let(:sqs_message) { instance_double(Aws::SQS::Types::Message, message_id: sqs_message_id, receipt_handle:, body: sns_message_body) }
@@ -40,9 +42,11 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
   let!(:delivery) { create :delivery, delivery_reference:, submissions: [submission] }
 
   before do
+    allow(Settings.aws).to receive(:submission_email_bounces_and_complaints_sqs_queue_name).and_return(queue_name)
+
     sts_client = instance_double(Aws::STS::Client)
     allow(Aws::STS::Client).to receive(:new).and_return(sts_client)
-    allow(sts_client).to receive(:get_caller_identity).and_return(OpenStruct.new(account: "123456789012"))
+    allow(sts_client).to receive(:get_caller_identity).and_return(OpenStruct.new(account: aws_account_id))
 
     allow(Aws::SQS::Client).to receive(:new).and_return(sqs_client)
     allow(sqs_client).to receive(:receive_message).and_return(OpenStruct.new(messages: messages), OpenStruct.new(messages: []))
@@ -141,6 +145,13 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
       perform_enqueued_jobs
       expect(Sentry).not_to have_received(:capture_message)
     end
+  end
+
+  it "calls SQS with the expected queue URL" do
+    described_class.perform_now
+    expect(sqs_client).to have_received(:receive_message).with(
+      hash_including(queue_url: "https://sqs.eu-west-2.amazonaws.com/#{aws_account_id}/#{queue_name}"),
+    ).once
   end
 
   describe "CloudWatch metrics" do

--- a/spec/jobs/receive_submission_deliveries_job_spec.rb
+++ b/spec/jobs/receive_submission_deliveries_job_spec.rb
@@ -172,5 +172,19 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
       end
     end
   end
+
+  context "when the delivery is not found" do
+    let(:messages) { [sqs_message] }
+    let(:submission) { nil }
+
+    it "captures the error and does not delete the message" do
+      allow(Sentry).to receive(:capture_exception)
+
+      described_class.perform_now
+
+      expect(Sentry).to have_received(:capture_exception).with(an_instance_of(ActiveRecord::RecordNotFound))
+      expect(sqs_client).not_to have_received(:delete_message)
+    end
+  end
 end
 # rubocop:enable RSpec/InstanceVariable

--- a/spec/jobs/receive_submission_deliveries_job_spec.rb
+++ b/spec/jobs/receive_submission_deliveries_job_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
   include ActiveJob::TestHelper
 
   let(:sqs_client) { instance_double(Aws::SQS::Client) }
+  let(:aws_account_id) { "123456789012" }
+  let(:queue_name) { "deliveries-queue" }
   let(:receipt_handle) { "delivery-receipt-handle" }
   let(:sqs_message_id) { "sqs-message-id" }
   let(:event_type) { "Delivery" }
@@ -19,15 +21,24 @@ RSpec.describe ReceiveSubmissionDeliveriesJob, type: :job do
   let!(:submission) { create :submission, :sent, delivery_reference:, reference:, created_at: Time.zone.parse("2025-05-09T10:25:35.001Z") }
 
   before do
+    allow(Settings.aws).to receive(:submission_email_deliveries_sqs_queue_name).and_return(queue_name)
+
     sts_client = instance_double(Aws::STS::Client)
     allow(Aws::STS::Client).to receive(:new).and_return(sts_client)
-    allow(sts_client).to receive(:get_caller_identity).and_return(OpenStruct.new(account: "123456789012"))
+    allow(sts_client).to receive(:get_caller_identity).and_return(OpenStruct.new(account: aws_account_id))
 
     allow(Aws::SQS::Client).to receive(:new).and_return(sqs_client)
     allow(sqs_client).to receive(:receive_message).and_return(OpenStruct.new(messages: messages), OpenStruct.new(messages: []))
     allow(sqs_client).to receive(:delete_message)
 
     allow(CloudWatchService).to receive(:record_job_started_metric)
+  end
+
+  it "calls SQS with the expected queue URL" do
+    described_class.perform_now
+    expect(sqs_client).to have_received(:receive_message).with(
+      hash_including(queue_url: "https://sqs.eu-west-2.amazonaws.com/#{aws_account_id}/#{queue_name}"),
+    ).once
   end
 
   describe "CloudWatch metrics" do

--- a/spec/lib/aws_ses_message_poller_spec.rb
+++ b/spec/lib/aws_ses_message_poller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AwsSesMessagePoller do
   let(:sqs_message_id) { "sqs-message-id" }
   let(:receipt_handle) { "receipt-handle" }
   let(:sns_message_timestamp) { "2025-05-09T10:25:43.972Z" }
-  let(:delivery_reference) { "mail-message-id" }
+  let(:message_id) { "mail-message-id" }
 
   let(:sns_message_body) do
     {
@@ -31,7 +31,7 @@ RSpec.describe AwsSesMessagePoller do
 
   let(:ses_message_body) do
     {
-      "mail" => { "messageId" => delivery_reference },
+      "mail" => { "messageId" => message_id },
       "eventType" => "TestEvent",
     }
   end
@@ -44,8 +44,6 @@ RSpec.describe AwsSesMessagePoller do
       body: sns_message_body,
     )
   end
-
-  let!(:submission) { create :submission, :sent, delivery_reference: }
 
   before do
     allow(Aws::STS::Client).to receive(:new).and_return(sts_client)
@@ -71,17 +69,17 @@ RSpec.describe AwsSesMessagePoller do
 
       it "processes messages using the provided block" do
         block_called = false
-        received_delivery = nil
+        received_ses_message_id = nil
         received_ses_message = nil
 
-        poller.poll do |delivery, ses_message|
+        poller.poll do |ses_message_id, ses_message|
           block_called = true
-          received_delivery = delivery
+          received_ses_message_id = ses_message_id
           received_ses_message = ses_message
         end
 
         expect(block_called).to be true
-        expect(received_delivery).to eq submission.deliveries.first
+        expect(received_ses_message_id).to eq message_id
         expect(received_ses_message).to eq ses_message_body
       end
 
@@ -96,7 +94,7 @@ RSpec.describe AwsSesMessagePoller do
       end
 
       it "deletes the message after successful processing" do
-        poller.poll { |_delivery, _ses_message| }
+        poller.poll { |_ses_message_id, _ses_message| }
 
         expect(sqs_client).to have_received(:delete_message).with(
           queue_url: queue_url,
@@ -105,7 +103,7 @@ RSpec.describe AwsSesMessagePoller do
       end
 
       it "resets logging attributes after processing" do
-        poller.poll { |_delivery, _ses_message| }
+        poller.poll { |_ses_message_id, _ses_message| }
 
         expect(CurrentJobLoggingAttributes.sqs_message_id).to be_nil
         expect(CurrentJobLoggingAttributes.sns_message_timestamp).to be_nil
@@ -126,13 +124,13 @@ RSpec.describe AwsSesMessagePoller do
 
       it "processes all messages" do
         call_count = 0
-        poller.poll { |_delivery, _ses_message| call_count += 1 }
+        poller.poll { |_ses_message_id, _ses_message| call_count += 1 }
 
         expect(call_count).to eq 5
       end
 
       it "deletes all messages" do
-        poller.poll { |_delivery, _ses_message| }
+        poller.poll { |_ses_message_id, _ses_message| }
 
         expect(sqs_client).to have_received(:delete_message).exactly(5).times
       end
@@ -150,7 +148,7 @@ RSpec.describe AwsSesMessagePoller do
 
       it "logs a warning" do
         call_count = 0
-        poller.poll do |_delivery, _ses_message|
+        poller.poll do |_ses_message_id, _ses_message|
           call_count += 1
           raise StandardError, "Test error" if call_count == 1
         end
@@ -164,7 +162,7 @@ RSpec.describe AwsSesMessagePoller do
 
       it "sends the error to Sentry" do
         call_count = 0
-        poller.poll do |_delivery, _ses_message|
+        poller.poll do |_ses_message_id, _ses_message|
           call_count += 1
           raise StandardError, "Test error" if call_count == 1
         end
@@ -173,14 +171,14 @@ RSpec.describe AwsSesMessagePoller do
       end
 
       it "does not delete the message when an error occurs" do
-        poller.poll { |_delivery, _ses_message| raise StandardError, "Test error" }
+        poller.poll { |_ses_message_id, _ses_message| raise StandardError, "Test error" }
 
         expect(sqs_client).not_to have_received(:delete_message)
       end
 
       it "continues processing subsequent messages" do
         call_count = 0
-        poller.poll do |_delivery, _ses_message|
+        poller.poll do |_ses_message_id, _ses_message|
           call_count += 1
           raise StandardError, "Test error" if call_count == 1
         end
@@ -189,38 +187,11 @@ RSpec.describe AwsSesMessagePoller do
       end
 
       it "resets logging attributes even after an error" do
-        poller.poll { |_delivery, _ses_message| raise StandardError, "Test error" }
+        poller.poll { |_ses_message_id, _ses_message| raise StandardError, "Test error" }
 
         expect(CurrentJobLoggingAttributes.sqs_message_id).to be_nil
         expect(CurrentJobLoggingAttributes.sns_message_timestamp).to be_nil
         expect(CurrentJobLoggingAttributes.delivery_reference).to be_nil
-      end
-    end
-
-    context "when the delivery is not found" do
-      let(:ses_message_body) do
-        {
-          "mail" => { "messageId" => "nonexistent-message-id" },
-          "eventType" => "TestEvent",
-        }
-      end
-
-      before do
-        allow(sqs_client).to receive(:receive_message).and_return(
-          OpenStruct.new(messages: [sqs_message]),
-          OpenStruct.new(messages: []),
-        )
-        allow(sqs_client).to receive(:delete_message)
-        allow(Sentry).to receive(:capture_exception)
-      end
-
-      it "captures the error and does not delete the message" do
-        poller.poll { |_delivery, _ses_message| }
-
-        expect(Sentry).to have_received(:capture_exception).with(
-          an_instance_of(ActiveRecord::RecordNotFound),
-        )
-        expect(sqs_client).not_to have_received(:delete_message)
       end
     end
 
@@ -233,7 +204,7 @@ RSpec.describe AwsSesMessagePoller do
 
       it "exits the polling loop immediately" do
         block_called = false
-        poller.poll { |_delivery, _ses_message| block_called = true }
+        poller.poll { |_ses_message_id, _ses_message| block_called = true }
 
         expect(block_called).to be false
       end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/hCWhyMOm

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Testing

I tested this on dev:
- That handling the delivery/bounce notifications still works after getting the queue names from the environment variables
- That bounces for confirmation emails are handled and logged

For testing confirmation emails, I pushed a temporary change to send all confirmation emails using SES on dev and requested a confirmation email to a non-existent email. You can see the logs in Splunk by searching for:

```
index="gds_dsp_dev_forms" confirmation_email_id=010b019e88634f68-1623a01f-3eca-4b86-9bcb-648991d5c655-000000
```

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
