### PR TITLE
Stop sending bounce events to Sentry

### DIFF
--- a/app/jobs/receive_submission_bounces_and_complaints_job.rb
+++ b/app/jobs/receive_submission_bounces_and_complaints_job.rb
@@ -69,64 +69,11 @@ private
 
     case delivery.delivery_schedule
     when "immediate"
-      process_immediate_delivery_bounce(delivery, submission, ses_bounce, bounced_recipients)
+      EventLogger.log_form_event("submission_bounced", ses_bounce: ses_bounce.merge(bounced_recipients:))
     when "daily"
-      process_daily_delivery_bounce(delivery, submission, ses_bounce, bounced_recipients)
+      EventLogger.log_form_event("daily_batch_email_bounced", ses_bounce: ses_bounce.merge(bounced_recipients:))
     when "weekly"
-      process_weekly_delivery_bounce(delivery, submission, ses_bounce, bounced_recipients)
-    end
-  end
-
-  def process_immediate_delivery_bounce(delivery, submission, ses_bounce, bounced_recipients)
-    EventLogger.log_form_event("submission_bounced", ses_bounce: ses_bounce.merge(bounced_recipients:))
-
-    unless submission.preview?
-      Sentry.capture_message("Submission email bounced for form #{submission.form_id} - #{self.class.name}:",
-                             fingerprint: ["{{ default }}", submission.form_id],
-                             extra: {
-                               form_id: submission.form_id,
-                               submission_reference: submission.reference,
-                               delivery_reference: delivery.delivery_reference,
-                               delivery_id: delivery.id,
-                               job_id:,
-                               ses_bounce:,
-                             })
-    end
-  end
-
-  def process_daily_delivery_bounce(delivery, submission, ses_bounce, bounced_recipients)
-    EventLogger.log_form_event("daily_batch_email_bounced", ses_bounce: ses_bounce.merge(bounced_recipients:))
-
-    unless submission.preview?
-      Sentry.capture_message("Daily submission batch email bounced for form #{submission.form_id} - #{self.class.name}:",
-                             fingerprint: ["{{ default }}", submission.form_id],
-                             extra: {
-                               form_id: submission.form_id,
-                               delivery_reference: delivery.delivery_reference,
-                               delivery_id: delivery.id,
-                               delivery_schedule: delivery.delivery_schedule,
-                               batch_begin_at: delivery.batch_begin_at,
-                               job_id:,
-                               ses_bounce:,
-                             })
-    end
-  end
-
-  def process_weekly_delivery_bounce(delivery, submission, ses_bounce, bounced_recipients)
-    EventLogger.log_form_event("weekly_batch_email_bounced", ses_bounce: ses_bounce.merge(bounced_recipients:))
-
-    unless submission.preview?
-      Sentry.capture_message("Weekly submission batch email bounced for form #{submission.form_id} - #{self.class.name}:",
-                             fingerprint: ["{{ default }}", submission.form_id],
-                             extra: {
-                               form_id: submission.form_id,
-                               delivery_reference: delivery.delivery_reference,
-                               delivery_id: delivery.id,
-                               delivery_schedule: delivery.delivery_schedule,
-                               batch_begin_at: delivery.batch_begin_at,
-                               job_id:,
-                               ses_bounce:,
-                             })
+      EventLogger.log_form_event("weekly_batch_email_bounced", ses_bounce: ses_bounce.merge(bounced_recipients:))
     end
   end
 

--- a/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
+++ b/spec/jobs/receive_submission_bounces_and_complaints_job_spec.rb
@@ -65,34 +65,6 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
     end
   end
 
-  shared_examples "alerting Sentry about a bounced delivery" do |message_prefix|
-    it "alerts to Sentry that there was a bounced delivery" do
-      allow(Sentry).to receive(:capture_message)
-      perform_enqueued_jobs
-      expect(Sentry).to have_received(:capture_message).with(
-        a_string_including("#{message_prefix} for form #{submission.form_id} - ReceiveSubmissionBouncesAndComplaintsJob"),
-        fingerprint: ["{{ default }}", submission.form_id],
-        extra: hash_including(
-          ses_bounce: hash_including(
-            bounce_type: "Permanent",
-            bounce_sub_type: "General",
-          ),
-        ),
-      )
-    end
-
-    it "does not include bounced recipients in the Sentry event" do
-      allow(Sentry).to receive(:capture_message)
-      perform_enqueued_jobs
-      expect(Sentry).not_to have_received(:capture_message).with(
-        anything,
-        extra: hash_including(
-          ses_bounce: hash_including(:bounced_recipients),
-        ),
-      )
-    end
-  end
-
   shared_examples "logging a bounce event" do |event_name|
     it "logs form event with correct details" do
       perform_enqueued_jobs
@@ -177,7 +149,6 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
 
         it_behaves_like "recording bounce details on delivery"
         it_behaves_like "logging a bounce event", "form_submission_bounced"
-        it_behaves_like "alerting Sentry about a bounced delivery", "Submission email bounced"
       end
 
       context "when it is for a preview submission" do
@@ -243,7 +214,6 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
 
           it_behaves_like "recording bounce details on delivery"
           it_behaves_like "logging a bounce event", "form_daily_batch_email_bounced"
-          it_behaves_like "alerting Sentry about a bounced delivery", "Daily submission batch email bounced"
         end
 
         context "when it is for a preview submission" do
@@ -292,7 +262,6 @@ RSpec.describe ReceiveSubmissionBouncesAndComplaintsJob, type: :job do
 
           it_behaves_like "recording bounce details on delivery"
           it_behaves_like "logging a bounce event", "form_weekly_batch_email_bounced"
-          it_behaves_like "alerting Sentry about a bounced delivery", "Weekly submission batch email bounced"
         end
 
         context "when it is for a preview submission" do


### PR DESCRIPTION
### What problem does this pull request solve?

We now automatically send emails about bounces to group/org admins for a form, so don't need to by alerted by Sentry about them as we do not need to take any action until admins reply to the emails we send them.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
