### PR TITLE
Fix empty string filename_suffix triggering answered?

### DIFF
--- a/app/models/question/file.rb
+++ b/app/models/question/file.rb
@@ -117,6 +117,10 @@ module Question
       [caption, question_text_with_optional_suffix].join(" ")
     end
 
+    def answered?
+      @attributes.to_hash.reject { |key, value| key == "filename_suffix" && value == "" }.any? { |_key, value| !value.nil? }
+    end
+
   private
 
     def filename_for_submission(submission_reference:, is_s3_submission:)

--- a/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
     {
       "q1" => { text: "blue" },
       "q2" => { first_name: "Jane", last_name: "Doe" },
-      "q3" => "",
+      "q3" => { original_filename: "" },
       "q4" => { original_filename: "test.txt" },
     }
   end

--- a/spec/models/question/file_spec.rb
+++ b/spec/models/question/file_spec.rb
@@ -400,6 +400,24 @@ RSpec.describe Question::File, type: :model do
     end
   end
 
+  describe "#answered?" do
+    context "when a question has attributes with values" do
+      let(:attributes) { { original_filename: "a-file.png" } }
+
+      it "returns true" do
+        expect(question).to be_answered
+      end
+    end
+
+    context "when a question only has the filename_suffix with a value" do
+      let(:attributes) { { filename_suffix: "" } }
+
+      it "returns false" do
+        expect(question).not_to be_answered
+      end
+    end
+  end
+
   describe "validations" do
     context "when the question is mandatory" do
       context "when no file is set" do


### PR DESCRIPTION
This change arose from a bug that occurred when a file upload question sits behind a route. If the routing question's answer value is changed form the check your answers page so that the file upload question is unlocked, the user would be brought straight back to the check your answers page, rather than to the file upload question.

This happened because when a file upload question was initially skipped, the default value for the `filename_suffix` is set as an empty string, "". This meant that when the `answered?` method is used to check whether the file upload question needed to be answered, it was always returning true, as the empty string in "filename_suffix" would return true when `nil?` was called on it.

This change avoids checking the filename_suffix entirely when considering whether a question is `answered?`, as it's not a user generated value, so shouldn't have any bearing on this calculation.

### What problem does this pull request solve?

https://trello.com/c/jAkCdQEj/3133-file-upload-question-treated-as-skipped-when-mandatory

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
