### PR TITLE
Don't include skipped questions in confirmation email

### DIFF
--- a/app/lib/ses_email_formatter.rb
+++ b/app/lib/ses_email_formatter.rb
@@ -8,8 +8,12 @@ class SesEmailFormatter
 
   def initialize(submission_reference:, steps:, confirmation_email:)
     @submission_reference = submission_reference
-    @steps = steps
+    @steps = confirmation_email ? answered_steps(steps) : steps
     @confirmation_email = confirmation_email
+  end
+
+  def answered_steps(steps)
+    steps.filter { |step| step.show_answer.present? }
   end
 
   def build_question_answers_section_html(heading_level: 3)

--- a/spec/lib/ses_email_formatter_spec.rb
+++ b/spec/lib/ses_email_formatter_spec.rb
@@ -68,12 +68,25 @@ RSpec.describe SesEmailFormatter do
       let(:text_question) { build :text, question_text: "What is the meaning of life?", text: nil }
       let(:steps) { [text_step] }
 
-      it "returns the blank answer text" do
-        expected = <<~HTML.strip.gsub("\n", "")
-          <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">What is the meaning of life?</h3>
-          <p>[This question was skipped]</p>
-        HTML
-        expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
+      context "when formatting for a submission email" do
+        it "returns the blank answer text" do
+          expected = <<~HTML.strip.gsub("\n", "")
+            <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">What is the meaning of life?</h3>
+            <p>[This question was skipped]</p>
+          HTML
+          expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
+        end
+      end
+
+      context "when formatting for a confirmation email" do
+        let(:confirmation_email) { true }
+        let(:steps) { [text_step, name_step] }
+
+        it "does not include the un-answered question" do
+          html = ses_email_formatter.build_question_answers_section_html
+          expect(html).not_to include("What is the meaning of life?")
+          expect(html).to include("What is your name?")
+        end
       end
     end
 
@@ -201,6 +214,17 @@ RSpec.describe SesEmailFormatter do
 
       it "returns the blank answer text" do
         expect(ses_email_formatter.build_question_answers_section_plain_text).to eq("What is the meaning of life?\n\n[This question was skipped]")
+      end
+
+      context "when formatting for a confirmation email" do
+        let(:confirmation_email) { true }
+        let(:steps) { [text_step, name_step] }
+
+        it "does not include the un-answered question" do
+          text = ses_email_formatter.build_question_answers_section_plain_text
+          expect(text).not_to include("What is the meaning of life?")
+          expect(text).to include("What is your name?")
+        end
       end
     end
 

--- a/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
@@ -27,7 +27,14 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
           answers:,
           is_preview:)
   end
-  let(:answers) { { "q1" => { text: "blue" }, "q2" => { first_name: "Jane", last_name: "Doe" }, "q3" => { original_filename: "test.txt" } } }
+  let(:answers) do
+    {
+      "q1" => { text: "blue" },
+      "q2" => { first_name: "Jane", last_name: "Doe" },
+      "q3" => "",
+      "q4" => { original_filename: "test.txt" },
+    }
+  end
   let(:what_happens_next_markdown) { "Please wait for a response\nA list:\n\n- Item one\n- Item two" }
   let(:payment_url) { "https://pay.example.gov" }
   let(:form_document) do
@@ -36,7 +43,8 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
           steps: [
             build(:v2_question_step, :with_text_settings, question_text: "What is your favourite colour?", id: "q1", next_step_id: "q2"),
             build(:v2_question_step, :with_name_settings, question_text: "What is your name?", id: "q2", next_step_id: "q3"),
-            build(:v2_question_step, :with_file_upload_settings, question_text: "Upload a file", id: "q3"),
+            build(:v2_question_step, :with_file_upload_settings, question_text: "Skipped question", id: "q3", next_step_id: "q4"),
+            build(:v2_question_step, :with_file_upload_settings, question_text: "Upload a file", id: "q4"),
           ],
           start_page: "q1",
           payment_url:,
@@ -83,6 +91,10 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
         expect(part.body).to include("Upload a file")
         expect(part.body).to include(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt"))
       end
+
+      it "does not include skipped questions" do
+        expect(part.body).not_to include("Skipped question")
+      end
     end
 
     describe "the html part" do
@@ -114,6 +126,10 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
         expect(part.body).to have_text("Last name: Doe")
         expect(part.body).to have_css("h4", text: "Upload a file")
         expect(part.body).to have_text(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt"))
+      end
+
+      it "does not include skipped questions" do
+        expect(part.body).not_to include("Skipped question")
       end
     end
   end
@@ -204,7 +220,8 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
             steps: [
               build(:v2_question_step, :with_text_settings, question_text: "Beth yw eich hoff liw?", id: "q1", next_step_id: "q2"),
               build(:v2_question_step, :with_name_settings, question_text: "Beth yw dy enw?", id: "q2", next_step_id: "q3"),
-              build(:v2_question_step, :with_file_upload_settings, question_text: "Llwythwch ffeil i fyny", id: "q3"),
+              build(:v2_question_step, :with_file_upload_settings, question_text: "Skipped question", id: "q3", next_step_id: "q4"),
+              build(:v2_question_step, :with_file_upload_settings, question_text: "Llwythwch ffeil i fyny", id: "q4"),
             ],
             start_page: "q1",
             what_happens_next_markdown: "Arhoswch am ymateb\nRhestr:\n\n- Eitem un\n- Eitem dau",


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/hCWhyMOm

When sending a user a copy of their answers in a confirmation email, do not include any questions that were skipped because they were optional or because they were routed over.

For submission emails we include these questions for consistency for processing the completed forms.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
