### PR TITLE
Include skipped optional questions in confirmation emails

### DIFF
--- a/app/lib/ses_email_formatter.rb
+++ b/app/lib/ses_email_formatter.rb
@@ -8,12 +8,8 @@ class SesEmailFormatter
 
   def initialize(submission_reference:, steps:, confirmation_email:)
     @submission_reference = submission_reference
-    @steps = confirmation_email ? answered_steps(steps) : steps
+    @steps = steps
     @confirmation_email = confirmation_email
-  end
-
-  def answered_steps(steps)
-    steps.filter { |step| step.show_answer.present? }
   end
 
   def build_question_answers_section_html(heading_level: 3)

--- a/app/lib/ses_email_formatter.rb
+++ b/app/lib/ses_email_formatter.rb
@@ -68,7 +68,7 @@ private
   def prep_answer_text(step)
     answer = step.show_answer_in_email(submission_reference: @submission_reference, confirmation_email: @confirmation_email)
 
-    return "[#{I18n.t('mailer.submission.question_skipped')}]" if answer.blank?
+    return skipped_question_text if answer.blank?
 
     sanitize(answer)
   rescue StandardError
@@ -78,7 +78,7 @@ private
   def prep_none_of_the_above_answer_text(step)
     answer = step.question.none_of_the_above_answer
 
-    return "[#{I18n.t('mailer.submission.question_skipped')}]" if answer.blank?
+    return skipped_question_text if answer.blank?
 
     sanitize(answer)
   rescue StandardError
@@ -104,5 +104,13 @@ private
   def sanitize(text)
     text
       .then { normalize_whitespace _1 }
+  end
+
+  def skipped_question_text
+    if @confirmation_email
+      I18n.t("mailer.submission_confirmation.not_completed")
+    else
+      "[#{I18n.t('mailer.submission.question_skipped')}]"
+    end
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -518,6 +518,7 @@ cy:
       default_support_contact_details: The form’s contact details for support will appear here once they’ve been added.
       default_what_happens_next: The form’s information about what happens next will appear here once it has been added.
       file_answer: Rydych wedi llwytho ffeil o’r enw %{filename}
+      not_completed: Heb ei gwblhau
       payment_link_heading: Os ydych dal angen talu
       payment_link_html: 'Os ydych angen gwneud taliad ac nad ydych wedi gwneud hynny eisoes, defnyddiwch y ddolen dalu hon i dalu nawr: <a href="%{payment_link}">%{payment_link}</a>'
       reference_number: Rhif cyfeirnod eich ffurflen yw %{reference}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -518,6 +518,7 @@ en:
       default_support_contact_details: The form’s contact details for support will appear here once they’ve been added.
       default_what_happens_next: The form’s information about what happens next will appear here once it has been added.
       file_answer: You uploaded a file called %{filename}
+      not_completed: Not completed
       payment_link_heading: If you still need to pay
       payment_link_html: 'If you need to make a payment and have not done so already, use this payment link to pay now: <a href="%{payment_link}">%{payment_link}</a>'
       reference_number: Your form reference number is %{reference}.

--- a/spec/lib/ses_email_formatter_spec.rb
+++ b/spec/lib/ses_email_formatter_spec.rb
@@ -68,25 +68,12 @@ RSpec.describe SesEmailFormatter do
       let(:text_question) { build :text, question_text: "What is the meaning of life?", text: nil }
       let(:steps) { [text_step] }
 
-      context "when formatting for a submission email" do
-        it "returns the blank answer text" do
-          expected = <<~HTML.strip.gsub("\n", "")
-            <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">What is the meaning of life?</h3>
-            <p>[This question was skipped]</p>
-          HTML
-          expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
-        end
-      end
-
-      context "when formatting for a confirmation email" do
-        let(:confirmation_email) { true }
-        let(:steps) { [text_step, name_step] }
-
-        it "does not include the un-answered question" do
-          html = ses_email_formatter.build_question_answers_section_html
-          expect(html).not_to include("What is the meaning of life?")
-          expect(html).to include("What is your name?")
-        end
+      it "returns the blank answer text" do
+        expected = <<~HTML.strip.gsub("\n", "")
+          <h3 style="font-size: 21px; line-height: 25px; font-weight: bold; color: #0B0C0C;">What is the meaning of life?</h3>
+          <p>[This question was skipped]</p>
+        HTML
+        expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
       end
     end
 
@@ -214,17 +201,6 @@ RSpec.describe SesEmailFormatter do
 
       it "returns the blank answer text" do
         expect(ses_email_formatter.build_question_answers_section_plain_text).to eq("What is the meaning of life?\n\n[This question was skipped]")
-      end
-
-      context "when formatting for a confirmation email" do
-        let(:confirmation_email) { true }
-        let(:steps) { [text_step, name_step] }
-
-        it "does not include the un-answered question" do
-          text = ses_email_formatter.build_question_answers_section_plain_text
-          expect(text).not_to include("What is the meaning of life?")
-          expect(text).to include("What is your name?")
-        end
       end
     end
 

--- a/spec/lib/ses_email_formatter_spec.rb
+++ b/spec/lib/ses_email_formatter_spec.rb
@@ -75,6 +75,14 @@ RSpec.describe SesEmailFormatter do
         HTML
         expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
       end
+
+      context "when formatting for a confirmation email" do
+        let(:confirmation_email) { true }
+
+        it "returns the blank answer text" do
+          expect(ses_email_formatter.build_question_answers_section_html).to include("<p>Not completed</p>")
+        end
+      end
     end
 
     context "when there is more than one step" do
@@ -137,6 +145,14 @@ RSpec.describe SesEmailFormatter do
             <p>[This question was skipped]</p>
           HTML
           expect(ses_email_formatter.build_question_answers_section_html).to eq(expected)
+        end
+
+        context "when formatting for a confirmation email" do
+          let(:confirmation_email) { true }
+
+          it "returns the skipped none of the above answer text for a confirmation email" do
+            expect(ses_email_formatter.build_question_answers_section_html).to include("<p>Not completed</p>")
+          end
         end
       end
     end
@@ -202,6 +218,14 @@ RSpec.describe SesEmailFormatter do
       it "returns the blank answer text" do
         expect(ses_email_formatter.build_question_answers_section_plain_text).to eq("What is the meaning of life?\n\n[This question was skipped]")
       end
+
+      context "when formatting for a confirmation email" do
+        let(:confirmation_email) { true }
+
+        it "returns the blank answer text" do
+          expect(ses_email_formatter.build_question_answers_section_plain_text).to include("Not completed")
+        end
+      end
     end
 
     context "when there is more than one step" do
@@ -241,6 +265,14 @@ RSpec.describe SesEmailFormatter do
 
         it "returns the skipped none of the above answer text" do
           expect(ses_email_formatter.build_question_answers_section_plain_text).to eq("What sandwich do you want?\n\nNone of the above\n\nSpecify your desired sandwich (optional)\n\n[This question was skipped]")
+        end
+
+        context "when formatting for a confirmation email" do
+          let(:confirmation_email) { true }
+
+          it "returns the skipped none of the above answer text" do
+            expect(ses_email_formatter.build_question_answers_section_plain_text).to include("Not completed")
+          end
         end
       end
     end

--- a/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
@@ -27,14 +27,7 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
           answers:,
           is_preview:)
   end
-  let(:answers) do
-    {
-      "q1" => { text: "blue" },
-      "q2" => { first_name: "Jane", last_name: "Doe" },
-      "q3" => "",
-      "q4" => { original_filename: "test.txt" },
-    }
-  end
+  let(:answers) { { "q1" => { text: "blue" }, "q2" => { first_name: "Jane", last_name: "Doe" }, "q3" => { original_filename: "test.txt" } } }
   let(:what_happens_next_markdown) { "Please wait for a response\nA list:\n\n- Item one\n- Item two" }
   let(:payment_url) { "https://pay.example.gov" }
   let(:form_document) do
@@ -43,8 +36,7 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
           steps: [
             build(:v2_question_step, :with_text_settings, question_text: "What is your favourite colour?", id: "q1", next_step_id: "q2"),
             build(:v2_question_step, :with_name_settings, question_text: "What is your name?", id: "q2", next_step_id: "q3"),
-            build(:v2_question_step, :with_file_upload_settings, question_text: "Skipped question", id: "q3", next_step_id: "q4"),
-            build(:v2_question_step, :with_file_upload_settings, question_text: "Upload a file", id: "q4"),
+            build(:v2_question_step, :with_file_upload_settings, question_text: "Upload a file", id: "q3"),
           ],
           start_page: "q1",
           payment_url:,
@@ -91,10 +83,6 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
         expect(part.body).to include("Upload a file")
         expect(part.body).to include(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt"))
       end
-
-      it "does not include skipped questions" do
-        expect(part.body).not_to include("Skipped question")
-      end
     end
 
     describe "the html part" do
@@ -126,10 +114,6 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
         expect(part.body).to have_text("Last name: Doe")
         expect(part.body).to have_css("h4", text: "Upload a file")
         expect(part.body).to have_text(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt"))
-      end
-
-      it "does not include skipped questions" do
-        expect(part.body).not_to include("Skipped question")
       end
     end
   end
@@ -220,8 +204,7 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
             steps: [
               build(:v2_question_step, :with_text_settings, question_text: "Beth yw eich hoff liw?", id: "q1", next_step_id: "q2"),
               build(:v2_question_step, :with_name_settings, question_text: "Beth yw dy enw?", id: "q2", next_step_id: "q3"),
-              build(:v2_question_step, :with_file_upload_settings, question_text: "Skipped question", id: "q3", next_step_id: "q4"),
-              build(:v2_question_step, :with_file_upload_settings, question_text: "Llwythwch ffeil i fyny", id: "q4"),
+              build(:v2_question_step, :with_file_upload_settings, question_text: "Llwythwch ffeil i fyny", id: "q3"),
             ],
             start_page: "q1",
             what_happens_next_markdown: "Arhoswch am ymateb\nRhestr:\n\n- Eitem un\n- Eitem dau",

--- a/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
+++ b/spec/mailers/aws_ses_submission_confirmation_mailer_spec.rb
@@ -27,7 +27,14 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
           answers:,
           is_preview:)
   end
-  let(:answers) { { "q1" => { text: "blue" }, "q2" => { first_name: "Jane", last_name: "Doe" }, "q3" => { original_filename: "test.txt" } } }
+  let(:answers) do
+    {
+      "q1" => { text: "blue" },
+      "q2" => { first_name: "Jane", last_name: "Doe" },
+      "q3" => "",
+      "q4" => { original_filename: "test.txt" },
+    }
+  end
   let(:what_happens_next_markdown) { "Please wait for a response\nA list:\n\n- Item one\n- Item two" }
   let(:payment_url) { "https://pay.example.gov" }
   let(:form_document) do
@@ -36,7 +43,8 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
           steps: [
             build(:v2_question_step, :with_text_settings, question_text: "What is your favourite colour?", id: "q1", next_step_id: "q2"),
             build(:v2_question_step, :with_name_settings, question_text: "What is your name?", id: "q2", next_step_id: "q3"),
-            build(:v2_question_step, :with_file_upload_settings, question_text: "Upload a file", id: "q3"),
+            build(:v2_question_step, :with_file_upload_settings, question_text: "Skipped question", id: "q3", next_step_id: "q4"),
+            build(:v2_question_step, :with_file_upload_settings, question_text: "Upload a file", id: "q4"),
           ],
           start_page: "q1",
           payment_url:,
@@ -80,6 +88,8 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
         expect(part.body).to include("What is your name?")
         expect(part.body).to include("First name: Jane")
         expect(part.body).to include("Last name: Doe")
+        expect(part.body).to include("Skipped question")
+        expect(part.body).to include("Not completed")
         expect(part.body).to include("Upload a file")
         expect(part.body).to include(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt"))
       end
@@ -112,6 +122,8 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
         expect(part.body).to have_css("h4", text: "What is your name?")
         expect(part.body).to have_text("First name: Jane")
         expect(part.body).to have_text("Last name: Doe")
+        expect(part.body).to have_css("h4", text: "Skipped question")
+        expect(part.body).to have_css("p", text: "Not completed")
         expect(part.body).to have_css("h4", text: "Upload a file")
         expect(part.body).to have_text(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt"))
       end
@@ -204,7 +216,8 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
             steps: [
               build(:v2_question_step, :with_text_settings, question_text: "Beth yw eich hoff liw?", id: "q1", next_step_id: "q2"),
               build(:v2_question_step, :with_name_settings, question_text: "Beth yw dy enw?", id: "q2", next_step_id: "q3"),
-              build(:v2_question_step, :with_file_upload_settings, question_text: "Llwythwch ffeil i fyny", id: "q3"),
+              build(:v2_question_step, :with_file_upload_settings, question_text: "Wedi hepgor cwestiwn", id: "q3", next_step_id: "q4"),
+              build(:v2_question_step, :with_file_upload_settings, question_text: "Llwythwch ffeil i fyny", id: "q4"),
             ],
             start_page: "q1",
             what_happens_next_markdown: "Arhoswch am ymateb\nRhestr:\n\n- Eitem un\n- Eitem dau",
@@ -275,11 +288,15 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
       it "includes the English and Welsh answers" do
         expect(part.body).to include("What is your favourite colour?")
         expect(part.body).to include("What is your name?")
+        expect(part.body).to include("Skipped question")
+        expect(part.body).to include("Not completed")
         expect(part.body).to include("Upload a file")
         expect(part.body).to include(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt"))
 
         expect(part.body).to include("Beth yw eich hoff liw?")
         expect(part.body).to include("Beth yw dy enw?")
+        expect(part.body).to include("Wedi hepgor cwestiwn")
+        expect(part.body).to include("Heb ei gwblhau")
         expect(part.body).to include("Llwythwch ffeil i fyny")
         expect(part.body).to include(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt", locale: :cy))
       end
@@ -320,11 +337,15 @@ RSpec.describe AwsSesSubmissionConfirmationMailer, type: :mailer do
       it "includes the English and Welsh answers" do
         expect(part.body).to have_css("h4", text: "What is your favourite colour?")
         expect(part.body).to have_css("h4", text: "What is your name?")
+        expect(part.body).to have_css("h4", text: "Skipped question")
+        expect(part.body).to have_css("p", text: "Not completed")
         expect(part.body).to have_css("h4", text: "Upload a file")
         expect(part.body).to have_text(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt"))
 
         expect(part.body).to have_css("h4", text: "Beth yw eich hoff liw?")
         expect(part.body).to have_css("h4", text: "Beth yw dy enw?")
+        expect(part.body).to have_css("h4", text: "Wedi hepgor cwestiwn")
+        expect(part.body).to have_css("p", text: "Heb ei gwblhau")
         expect(part.body).to have_css("h4", text: "Llwythwch ffeil i fyny")
         expect(part.body).to have_text(I18n.t("mailer.submission_confirmation.file_answer", filename: "test.txt", locale: :cy))
       end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/hCWhyMOm

Use the text "Not completed", rather than "[This question was skipped]" which we use for submission emails to be consistent with the check your answers page.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
