### PR TITLE
Fix 'None of the above' for selection questions in Welsh forms

### DIFF
--- a/app/components/question/selection_component/view.rb
+++ b/app/components/question/selection_component/view.rb
@@ -37,7 +37,7 @@ module Question
         return nil unless question.is_optional?
 
         option = form_builder.govuk_radio_button :selection,
-                                                 I18n.t("page.none_of_the_above"),
+                                                 Question::Selection::NONE_OF_THE_ABOVE_VALUE,
                                                  label: { text: I18n.t("page.none_of_the_above") },
                                                  &method(:none_of_the_above_question_field)
         safe_join([divider, option])
@@ -47,7 +47,7 @@ module Question
         return nil unless question.is_optional?
 
         option = form_builder.govuk_check_box :selection,
-                                              I18n.t("page.none_of_the_above"),
+                                              Question::Selection::NONE_OF_THE_ABOVE_VALUE,
                                               exclusive: true,
                                               label: { text: I18n.t("page.none_of_the_above") },
                                               &method(:none_of_the_above_question_field)

--- a/app/jobs/send_submission_job.rb
+++ b/app/jobs/send_submission_job.rb
@@ -5,15 +5,19 @@ class SendSubmissionJob < SubmissionDeliveryJob
   retry_on Aws::SESV2::Errors::ServiceError, wait: :polynomially_longer, attempts: TOTAL_ATTEMPTS
 
   def perform(submission)
-    delivery = submission.single_submission_delivery
-    set_submission_logging_attributes(submission:, delivery:)
+    # The job will use the locale at the time it was created. Force it to be "en" as we always send submission emails in
+    # English.
+    I18n.with_locale("en") do
+      delivery = submission.single_submission_delivery
+      set_submission_logging_attributes(submission:, delivery:)
 
-    delivery.new_attempt!
+      delivery.new_attempt!
 
-    message_id = AwsSesSubmissionService.new(submission:).submit
+      message_id = AwsSesSubmissionService.new(submission:).submit
 
-    delivery.update!(delivery_reference: message_id)
-    record_submission_sent!
+      delivery.update!(delivery_reference: message_id)
+      record_submission_sent!
+    end
   rescue StandardError
     CloudWatchService.record_job_failure_metric(self.class.name)
     raise

--- a/app/models/question/selection.rb
+++ b/app/models/question/selection.rb
@@ -104,6 +104,21 @@ module Question
       "#{none_of_the_above_question.question_text} #{I18n.t('page.optional')}"
     end
 
+    def selection=(value)
+      # TODO: This setter can be removed after 15/06/2026
+      if allow_multiple_answers?
+        if value.include?(I18n.t("page.none_of_the_above", locale: :en)) || value.include?(I18n.t("page.none_of_the_above", locale: :cy))
+          super([NONE_OF_THE_ABOVE_VALUE])
+          return
+        end
+      elsif value == I18n.t("page.none_of_the_above", locale: :en) || value == I18n.t("page.none_of_the_above", locale: :cy)
+        super(NONE_OF_THE_ABOVE_VALUE)
+        return
+      end
+
+      super(value)
+    end
+
   private
 
     def clear_none_of_the_above_answer_if_not_selected

--- a/app/models/question/selection.rb
+++ b/app/models/question/selection.rb
@@ -18,12 +18,14 @@ module Question
               if: :validate_none_of_the_above_answer_presence?,
               unless: -> { validation_context == :skip_none_of_the_above_question_validation }
 
+    NONE_OF_THE_ABOVE_VALUE = "none_of_the_above".freeze
+
     def allow_multiple_answers?
       answer_settings.only_one_option != "true"
     end
 
     def with_none_of_the_above_selected
-      self.selection = allow_multiple_answers? ? [I18n.t("page.none_of_the_above")] : I18n.t("page.none_of_the_above")
+      self.selection = allow_multiple_answers? ? [NONE_OF_THE_ABOVE_VALUE] : NONE_OF_THE_ABOVE_VALUE
     end
 
     def answered?
@@ -33,15 +35,15 @@ module Question
     end
 
     def show_answer
-      return selection_without_blanks.map { |selected| name_from_value(selected) }.join(", ") if allow_multiple_answers?
+      return selection_names.join(", ") if allow_multiple_answers?
 
       selection_name
     end
 
     def show_answer_in_email(*)
-      return selection_without_blanks.join("\n\n") if allow_multiple_answers?
+      return selection_names.join("\n\n") if allow_multiple_answers?
 
-      selection
+      selection_name
     end
 
     def show_answer_in_csv(*)
@@ -56,9 +58,9 @@ module Question
       hash = {}
 
       if allow_multiple_answers?
-        hash[:selections] = selection_without_blanks
+        hash[:selections] = selection_names
       elsif has_none_of_the_above_question?
-        hash[:selection] = selection
+        hash[:selection] = selection_name
       end
 
       if show_none_of_the_above_question?
@@ -69,20 +71,6 @@ module Question
       end
 
       hash
-    end
-
-    def selection_name
-      return nil if selection.nil?
-      return "" if selection.blank?
-
-      name_from_value(selection)
-    end
-
-    # Show the selection option name, which can be different to the value. Value
-    # should stay the same across FormDocuments in different languages.
-    def name_from_value(selected)
-      @options_by_value ||= selection_options_with_none_of_the_above.index_by(&:value)
-      @options_by_value[selected]&.name
     end
 
     def show_optional_suffix
@@ -127,7 +115,7 @@ module Question
     end
 
     def none_of_the_above_option
-      OpenStruct.new(name: I18n.t("page.none_of_the_above"), value: I18n.t("page.none_of_the_above"))
+      OpenStruct.new(name: I18n.t("page.none_of_the_above"), value: NONE_OF_THE_ABOVE_VALUE)
     end
 
     def selection_without_blanks
@@ -136,13 +124,31 @@ module Question
       selection.reject(&:blank?)
     end
 
+    def selection_name
+      return nil if selection.nil?
+      return "" if selection.blank?
+
+      name_from_value(selection)
+    end
+
+    def selection_names
+      selection_without_blanks.map { |selected| name_from_value(selected) }
+    end
+
+    # Show the selection option name, which can be different to the value. Value
+    # should stay the same across FormDocuments in different languages.
+    def name_from_value(selected)
+      @options_by_value ||= selection_options_with_none_of_the_above.index_by(&:value)
+      @options_by_value[selected]&.name
+    end
+
     def validate_radio
       errors.add(:selection, :inclusion) if allowed_options.exclude?(selection)
     end
 
     def validate_checkbox
       return errors.add(:selection, is_optional? ? :both_none_and_value_selected : :checkbox_blank) if selection_without_blanks.empty?
-      return errors.add(:selection, :both_none_and_value_selected) if selection_without_blanks.count > 1 && I18n.t("page.none_of_the_above").in?(selection_without_blanks)
+      return errors.add(:selection, :both_none_and_value_selected) if selection_without_blanks.count > 1 && NONE_OF_THE_ABOVE_VALUE.in?(selection_without_blanks)
 
       errors.add(:selection, :inclusion) if selection_without_blanks.any? { |item| allowed_options.exclude?(item) }
     end
@@ -160,9 +166,9 @@ module Question
     end
 
     def none_of_the_above_selected?
-      return selection_without_blanks.include?(I18n.t("page.none_of_the_above")) if allow_multiple_answers?
+      return selection_without_blanks.include?(NONE_OF_THE_ABOVE_VALUE) if allow_multiple_answers?
 
-      selection == I18n.t("page.none_of_the_above")
+      selection == NONE_OF_THE_ABOVE_VALUE
     end
 
     def show_answer_with_none_of_the_above

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -148,7 +148,7 @@ private
   end
 
   def condition_matches?(condition)
-    return question.selection == I18n.t("page.none_of_the_above") if condition.answer_value == :none_of_the_above.to_s
+    return question.selection == Question::Selection::NONE_OF_THE_ABOVE_VALUE if condition.answer_value == :none_of_the_above.to_s
 
     condition.answer_value == question.selection
   end

--- a/spec/components/check_your_answers_component/view_spec.rb
+++ b/spec/components/check_your_answers_component/view_spec.rb
@@ -107,14 +107,14 @@ RSpec.describe CheckYourAnswersComponent::View, type: :component do
     end
 
     context "when 'None of the above' is selected" do
-      let(:selection) { "None of the above" }
+      let(:selection) { Question::Selection::NONE_OF_THE_ABOVE_VALUE }
 
       context "and an answer is provided for the 'None of the above' question" do
         let(:none_of_the_above_answer) { "This one" }
 
         it "displays the 'None of the above' question and answer in the answers" do
           expect(page).to have_css(".govuk-summary-list__key", text: question_text)
-          expect(page).to have_css(".govuk-summary-list__value", text: selection)
+          expect(page).to have_css(".govuk-summary-list__value", text: I18n.t("page.none_of_the_above"))
           expect(page).to have_css(".govuk-summary-list__key", text: none_of_the_above_question_text)
           expect(page).to have_css(".govuk-summary-list__value", text: none_of_the_above_answer)
         end

--- a/spec/jobs/send_submission_job_spec.rb
+++ b/spec/jobs/send_submission_job_spec.rb
@@ -6,25 +6,27 @@ RSpec.describe SendSubmissionJob, type: :job do
 
   let(:submission_created_at) { Time.utc(2022, 12, 14, 13, 0o0, 0o0) }
   let(:submission) do
-    create(:submission, :sent, form_document:, created_at: submission_created_at)
+    create(:submission, :sent, form_document:, created_at: submission_created_at, answers:)
   end
-  let(:form_document) { build(:v2_form_document, name: "Form 1") }
-  let(:question) { build :text, question_text: "What is the meaning of life?", text: "42" }
-  let(:step) { build :step, question: }
-  let(:all_steps) { [step] }
-  let(:journey) { instance_double(Flow::Journey, completed_steps: all_steps, all_steps:) }
+  let(:form_document) do
+    build(:v2_form_document,
+          :ready_for_live,
+          name: "Form 1",
+          steps: [build(:v2_selection_question_step, is_optional: true, only_one_option: "true", id: "q1")],
+          start_page: "q1")
+  end
+  let(:answers) { { "q1" => { selection: Question::Selection::NONE_OF_THE_ABOVE_VALUE } } }
   let(:aws_ses_submission_service_spy) { instance_double(AwsSesSubmissionService) }
   let(:delivery_reference) { "1234" }
 
   before do
-    allow(Flow::Journey).to receive(:new).and_return(journey)
-    allow(AwsSesSubmissionService).to receive(:new).with(submission:).and_return(aws_ses_submission_service_spy)
     allow(CloudWatchService).to receive(:record_submission_sent_metric)
     allow(CloudWatchService).to receive(:record_job_failure_metric)
   end
 
   context "when the job is processed" do
     before do
+      allow(AwsSesSubmissionService).to receive(:new).with(submission:).and_return(aws_ses_submission_service_spy)
       allow(aws_ses_submission_service_spy).to receive(:submit).and_return(delivery_reference)
 
       described_class.perform_later(submission)
@@ -76,6 +78,7 @@ RSpec.describe SendSubmissionJob, type: :job do
   context "when there is an error during processing" do
     context "and the error is an Aws::SESV2::Errors::ServiceError" do
       before do
+        allow(AwsSesSubmissionService).to receive(:new).with(submission:).and_return(aws_ses_submission_service_spy)
         allow(aws_ses_submission_service_spy).to receive(:submit).and_raise(Aws::SESV2::Errors::ServiceError.new(nil, "Test SES error", nil))
         allow(CloudWatchService).to receive(:record_job_failure_metric)
       end
@@ -123,6 +126,19 @@ RSpec.describe SendSubmissionJob, type: :job do
       rescue StandardError # If we don't catch the error, the test aborts prematurely
         nil
       end
+    end
+  end
+
+  context "when the job was enqueued with Welsh locale" do
+    it "uses English I18n translations in the submission email" do
+      I18n.with_locale(:cy) do
+        described_class.perform_later(submission)
+        perform_enqueued_jobs
+      end
+
+      mail = ActionMailer::Base.deliveries.last
+      # We don't have Welsh translations for most email content, but we do for the "None of the above" answer
+      expect(mail.body.parts[0].decoded).to include(I18n.t("page.none_of_the_above", locale: :en))
     end
   end
 end

--- a/spec/lib/ses_email_formatter_spec.rb
+++ b/spec/lib/ses_email_formatter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SesEmailFormatter do
       :with_none_of_the_above_question,
       question_text: "What sandwich do you want?",
       none_of_the_above_question_text: "Specify your desired sandwich",
-      selection: "None of the above",
+      selection: Question::Selection::NONE_OF_THE_ABOVE_VALUE,
       none_of_the_above_answer:,
       none_of_the_above_question_is_optional:,
     )

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -761,4 +761,36 @@ RSpec.describe Question::Selection, type: :model do
       end
     end
   end
+
+  describe "backwards compatibility for none of the above option" do
+    let(:is_optional) { true }
+
+    context "when the selection question is a checkbox" do
+      let(:only_one_option) { "false" }
+
+      it "sets the selection to ['none_of_the_above'] when attempting to set to the English localised translation" do
+        question.selection = [I18n.t("page.none_of_the_above")]
+        expect(question.selection).to eq([Question::Selection::NONE_OF_THE_ABOVE_VALUE])
+      end
+
+      it "sets the selection to ['none_of_the_above'] when attempting to set to the Welsh localised translation" do
+        question.selection = [I18n.t("page.none_of_the_above", locale: :cy)]
+        expect(question.selection).to eq([Question::Selection::NONE_OF_THE_ABOVE_VALUE])
+      end
+    end
+
+    context "when the selection question is a radio button" do
+      let(:only_one_option) { "true" }
+
+      it "sets the selection to 'none_of_the_above' when attempting to set to the English localised translation" do
+        question.selection = I18n.t("page.none_of_the_above")
+        expect(question.selection).to eq(Question::Selection::NONE_OF_THE_ABOVE_VALUE)
+      end
+
+      it "sets the selection to 'none_of_the_above' when attempting to set to the Welsh localised translation" do
+        question.selection = I18n.t("page.none_of_the_above", locale: :cy)
+        expect(question.selection).to eq(Question::Selection::NONE_OF_THE_ABOVE_VALUE)
+      end
+    end
+  end
 end

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -152,13 +152,13 @@ RSpec.describe Question::Selection, type: :model do
       end
 
       it "returns valid with none of the above selected" do
-        question.selection = [I18n.t("page.none_of_the_above")]
+        question.selection = [Question::Selection::NONE_OF_THE_ABOVE_VALUE]
         expect(question).to be_valid
         expect(question.errors[:selection]).to be_empty
       end
 
       it "returns invalid with both an item and none selected" do
-        question.selection = ["Option 1", I18n.t("page.none_of_the_above")]
+        question.selection = ["Option 1", Question::Selection::NONE_OF_THE_ABOVE_VALUE]
         expect(question).not_to be_valid
         expect(question.errors[:selection]).to include(I18n.t("activemodel.errors.models.question/selection.attributes.selection.both_none_and_value_selected"))
       end
@@ -281,7 +281,7 @@ RSpec.describe Question::Selection, type: :model do
       let(:is_optional) { true }
 
       it "returns valid with none of the above selected" do
-        question.selection = I18n.t("page.none_of_the_above")
+        question.selection = Question::Selection::NONE_OF_THE_ABOVE_VALUE
         expect(question).to be_valid
         expect(question.errors[:selection]).to be_empty
       end
@@ -357,7 +357,7 @@ RSpec.describe Question::Selection, type: :model do
         context "when none_of_the_above_question is optional" do
           context "when 'None of the above' is selected" do
             before do
-              question.selection = [I18n.t("page.none_of_the_above")]
+              question.selection = [Question::Selection::NONE_OF_THE_ABOVE_VALUE]
             end
 
             it "is valid when there is no none_of_the_above_answer" do
@@ -441,7 +441,7 @@ RSpec.describe Question::Selection, type: :model do
 
           context "when 'None of the above' is selected" do
             before do
-              question.selection = [I18n.t("page.none_of_the_above")]
+              question.selection = [Question::Selection::NONE_OF_THE_ABOVE_VALUE]
             end
 
             it "is invalid when there is no none_of_the_above_answer" do
@@ -512,7 +512,7 @@ RSpec.describe Question::Selection, type: :model do
 
         context "when 'None of the above' is selected" do
           before do
-            question.selection = I18n.t("page.none_of_the_above")
+            question.selection = Question::Selection::NONE_OF_THE_ABOVE_VALUE
           end
 
           it "is invalid when there is no none_of_the_above_answer" do
@@ -610,7 +610,7 @@ RSpec.describe Question::Selection, type: :model do
       end
 
       context "when 'None of the above' is selected" do
-        let(:selection) { I18n.t("page.none_of_the_above") }
+        let(:selection) { Question::Selection::NONE_OF_THE_ABOVE_VALUE }
 
         it "returns false when no none_of_the_above_answer is present" do
           question.none_of_the_above_answer = nil
@@ -653,7 +653,7 @@ RSpec.describe Question::Selection, type: :model do
       end
 
       context "when 'None of the above' is selected" do
-        let(:selection) { I18n.t("page.none_of_the_above") }
+        let(:selection) { Question::Selection::NONE_OF_THE_ABOVE_VALUE }
 
         it "returns true" do
           expect(question.answered?).to be true
@@ -664,7 +664,7 @@ RSpec.describe Question::Selection, type: :model do
 
   describe "#selection_options_with_none_of_the_above" do
     let(:only_one_option) { "true" }
-    let(:none_of_the_above_option) { OpenStruct.new(name: I18n.t("page.none_of_the_above"), value: I18n.t("page.none_of_the_above")) }
+    let(:none_of_the_above_option) { OpenStruct.new(name: I18n.t("page.none_of_the_above"), value: Question::Selection::NONE_OF_THE_ABOVE_VALUE) }
 
     context "when the user can select 'None of the above'" do
       let(:is_optional) { true }

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Step do
       end
 
       context "with a matching none_of_the_above condition" do
-        let(:selection) { "None of the above" }
+        let(:selection) { Question::Selection::NONE_OF_THE_ABOVE_VALUE }
         let(:routing_conditions) { [OpenStruct.new(answer_value: "none_of_the_above", goto_page_id: third_step_id)] }
 
         it "returns the goto_page_id of the condition" do

--- a/spec/requests/forms/step_controller_spec.rb
+++ b/spec/requests/forms/step_controller_spec.rb
@@ -991,7 +991,7 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
 
       context "when there are less than 31 options and none of the above is selected" do
         let(:selection_options) { [{ name: "Option 1", value: "Option 1" }, { name: "Option 2", value: "Option 2" }] }
-        let(:params) { { question: { selection: I18n.t("page.none_of_the_above"), none_of_the_above_answer: "Another option" }, changing_existing_answer: false } }
+        let(:params) { { question: { selection: Question::Selection::NONE_OF_THE_ABOVE_VALUE, none_of_the_above_answer: "Another option" }, changing_existing_answer: false } }
 
         it "redirects to the next step in the form" do
           expect(response).to redirect_to form_step_path(mode:, form_id: 2, form_slug: form_data.form_slug, step_slug: 2)
@@ -1010,7 +1010,7 @@ RSpec.describe Forms::StepController, :capture_logging, type: :request do
         let(:selection_options) { 31.times.map { |i| { name: "Option #{i}", value: "Option #{i}" } } }
 
         context "when none of the above is selected" do
-          let(:params) { { question: { selection: I18n.t("page.none_of_the_above") }, changing_existing_answer: false } }
+          let(:params) { { question: { selection: Question::Selection::NONE_OF_THE_ABOVE_VALUE }, changing_existing_answer: false } }
 
           it "redirects to the none of the above page" do
             expect(response).to redirect_to selection_none_of_the_above_path(mode:, form_id: 2, form_slug: form_data.form_slug, step_slug: first_step_id)


### PR DESCRIPTION
### What problem does this pull request solve?

The "None of the above" option for selection questions was using a localised translation for the value, which meant that if you switched language after selecting "None of the above", we wouldn't correctly identify that "None of the above" was selected, hiding the none of the above answer if one was present from the check your answers page and submission/confirmation emails.

It also meant we would include the localised translation of "None of the above" at time the question was answered in the submission email, when for other options we would always show the English value.

Fix this so the `value` is a constant regardless of the language, as for other selection options. Whenever we display the answer, use the `name` of the option, which will be localised as appropriate.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
