### PR TITLE
Fix errors when a date question tries to load answer for repeatable step from store

### DIFF
--- a/app/lib/flow/journey.rb
+++ b/app/lib/flow/journey.rb
@@ -120,7 +120,7 @@ module Flow
 
       begin
         step.load_from_store(@answer_store)
-      rescue ActiveModel::UnknownAttributeError, ArgumentError
+      rescue Step::StoredAnswerMismatch
         original_step
       end
     end

--- a/app/models/question/date.rb
+++ b/app/models/question/date.rb
@@ -8,6 +8,10 @@ module Question
     validate :date_valid
 
     def assign_attributes(new_attributes)
+      unless new_attributes.respond_to?(:transform_keys)
+        raise ArgumentError, "When assigning attributes, you must pass a hash as an argument, #{new_attributes.class} passed."
+      end
+
       translated_attrs = new_attributes.transform_keys { |key| date_field_to_attribute(key) }
       super(translated_attrs)
     end

--- a/app/models/repeatable_step.rb
+++ b/app/models/repeatable_step.rb
@@ -27,12 +27,18 @@ class RepeatableStep < Step
     question_attrs = answer_store.get_stored_answer(self)
 
     unless question_attrs.is_a?(Array)
-      raise ArgumentError
+      raise StoredAnswerMismatch
     end
 
     @questions = question_attrs.map do |attrs|
       q = @question.dup
-      q.assign_attributes(attrs || {})
+
+      begin
+        q.assign_attributes(attrs || {})
+      rescue ActiveModel::UnknownAttributeError
+        raise StoredAnswerMismatch
+      end
+
       q
     end
 

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -4,6 +4,8 @@ class Step
 
   GOTO_PAGE_ERROR_NAMES = %w[cannot_have_goto_page_before_routing_page goto_page_doesnt_exist].freeze
 
+  class StoredAnswerMismatch < StandardError; end
+
   def initialize(form_document_step:, question:)
     @form_document_step = form_document_step
     @question = question
@@ -45,7 +47,17 @@ class Step
 
   def load_from_store(answer_store)
     attrs = answer_store.get_stored_answer(self)
-    question.assign_attributes(attrs || {})
+
+    if attrs.is_a?(Array)
+      raise StoredAnswerMismatch
+    end
+
+    begin
+      question.assign_attributes(attrs || {})
+    rescue ActiveModel::UnknownAttributeError
+      raise StoredAnswerMismatch
+    end
+
     self
   end
 

--- a/spec/lib/flow/journey_spec.rb
+++ b/spec/lib/flow/journey_spec.rb
@@ -186,6 +186,18 @@ RSpec.describe Flow::Journey do
         end
       end
 
+      context "when the answer store has data in the format for a repeatable question but the question is not repeatable" do
+        let(:store) { { answers: { form_id.to_s => { first_step_id => { selection: "Option 2" }, second_step_id => [{ text: "Example text" }, { text: "Another answer" }], third_step_id => { selection: "Option 1" } } } } }
+
+        it "includes only steps before the answer with the wrong type" do
+          expect(journey.completed_steps.to_json).to eq [first_step_in_journey].to_json
+        end
+
+        it "includes the answer data in the question steps" do
+          expect(journey.completed_steps.map(&:question)).to all be_answered
+        end
+      end
+
       context "when step has a cannot_have_goto_page_before_routing_page error" do
         let(:validation_errors) { [{ name: "cannot_have_goto_page_before_routing_page" }] }
 

--- a/spec/models/question/date_spec.rb
+++ b/spec/models/question/date_spec.rb
@@ -267,6 +267,37 @@ RSpec.describe Question::Date, type: :model do
     end
   end
 
+  describe "#assign_attributes" do
+    let(:new_attributes) { { date_day: "26", date_month: "5", date_year: "2020" } }
+
+    it "assigns the date attributes" do
+      question.assign_attributes new_attributes
+      expect(question).to have_attributes date_year: "2020", date_month: "5", date_day: "26"
+    end
+
+    context "when the attributes are from form input" do
+      let(:new_attributes) { { "date(3i)" => "26", "date(2i)" => "5", "date(1i)" => "2020" } }
+
+      it "assigns the date attributes" do
+        question.assign_attributes new_attributes
+        expect(question).to have_attributes date_year: "2020", date_month: "5", date_day: "26"
+      end
+    end
+
+    context "when new_attributes is not a hash" do
+      let(:new_attributes) { [{ date_day: "26", date_month: "5", date_year: "2020" }] }
+
+      it "raises an error" do
+        expect {
+          question.assign_attributes new_attributes
+        }.to raise_error(
+          ArgumentError,
+          "When assigning attributes, you must pass a hash as an argument, Array passed.",
+        )
+      end
+    end
+  end
+
   describe "#date_of_birth?" do
     let(:options) { { answer_settings: OpenStruct.new({ input_type: }) } }
 

--- a/spec/models/repeatable_step_spec.rb
+++ b/spec/models/repeatable_step_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe RepeatableStep, type: :model do
     let(:answer_store) { instance_double(Store::SessionAnswerStore) }
 
     context "when form context contains a non-array questions attribute" do
-      it "raises an argument error" do
+      it "raises an error" do
         allow(answer_store).to receive(:get_stored_answer).with(repeatable_step).and_return("a string")
-        expect { repeatable_step.load_from_store(answer_store) }.to raise_error(ArgumentError)
+        expect { repeatable_step.load_from_store(answer_store) }.to raise_error(Step::StoredAnswerMismatch)
       end
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Fixes an error we're seeing in production, see https://govuk-forms.sentry.io/issues/7446683762

If a form creator is half-way through filling in a preview of a draft form, and changes a date question in that form from "more than one answer" to "only one answer", this can cause a server error.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
