### PR TITLE
Enable PKCE for One Login authorization requests

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -21,7 +21,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     scope: "openid email",
     ui_locales: "en cy",
     vtr: ["Cl.Cm"],
-    pkce: false,
+    pkce: true,
     userinfo_claims: [],
   }
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/QkLZra3G

To help protect against ‘Authorization Code’ interception attacks on authorisation requests, enable PKCE (Proof Key for Code Exchange) for the omniauth_govuk_one_login gem. This will allow us to turn on the enforce PKCE setting for our One Login service as per their recommendations.

See
https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/authenticate-your-user/ https://datatracker.ietf.org/doc/html/rfc7636

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
