### PR TITLE
Revert "Add backwards compatibility for old none of the above value"

### DIFF
--- a/app/models/question/selection.rb
+++ b/app/models/question/selection.rb
@@ -104,21 +104,6 @@ module Question
       "#{none_of_the_above_question.question_text} #{I18n.t('page.optional')}"
     end
 
-    def selection=(value)
-      # TODO: This setter can be removed after 15/06/2026
-      if allow_multiple_answers?
-        if value.include?(I18n.t("page.none_of_the_above", locale: :en)) || value.include?(I18n.t("page.none_of_the_above", locale: :cy))
-          super([NONE_OF_THE_ABOVE_VALUE])
-          return
-        end
-      elsif value == I18n.t("page.none_of_the_above", locale: :en) || value == I18n.t("page.none_of_the_above", locale: :cy)
-        super(NONE_OF_THE_ABOVE_VALUE)
-        return
-      end
-
-      super(value)
-    end
-
   private
 
     def clear_none_of_the_above_answer_if_not_selected

--- a/spec/models/question/selection_spec.rb
+++ b/spec/models/question/selection_spec.rb
@@ -761,36 +761,4 @@ RSpec.describe Question::Selection, type: :model do
       end
     end
   end
-
-  describe "backwards compatibility for none of the above option" do
-    let(:is_optional) { true }
-
-    context "when the selection question is a checkbox" do
-      let(:only_one_option) { "false" }
-
-      it "sets the selection to ['none_of_the_above'] when attempting to set to the English localised translation" do
-        question.selection = [I18n.t("page.none_of_the_above")]
-        expect(question.selection).to eq([Question::Selection::NONE_OF_THE_ABOVE_VALUE])
-      end
-
-      it "sets the selection to ['none_of_the_above'] when attempting to set to the Welsh localised translation" do
-        question.selection = [I18n.t("page.none_of_the_above", locale: :cy)]
-        expect(question.selection).to eq([Question::Selection::NONE_OF_THE_ABOVE_VALUE])
-      end
-    end
-
-    context "when the selection question is a radio button" do
-      let(:only_one_option) { "true" }
-
-      it "sets the selection to 'none_of_the_above' when attempting to set to the English localised translation" do
-        question.selection = I18n.t("page.none_of_the_above")
-        expect(question.selection).to eq(Question::Selection::NONE_OF_THE_ABOVE_VALUE)
-      end
-
-      it "sets the selection to 'none_of_the_above' when attempting to set to the Welsh localised translation" do
-        question.selection = I18n.t("page.none_of_the_above", locale: :cy)
-        expect(question.selection).to eq(Question::Selection::NONE_OF_THE_ABOVE_VALUE)
-      end
-    end
-  end
 end


### PR DESCRIPTION
This reverts commit 8550e8dc42600d2c820e4b4184130f7a42204b6a.

We replaced storing the localised translation of "None of the above" with using a constant "none_of_the_above` regardless of the current language. All submissions including batch deliveries that contained the old value in the answers will have now been delivered so we can remove the fallback to support the old values.

Merge this after 6th July, as some submission soft-bounced on 2nd June and may have contained "None of the above" in their answers. Once these can no longer be re-sent we should be safe to merge.
