### PR TITLE
Add setting to globally disable asking for a copy of answers

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -65,6 +65,7 @@ class Form
   end
 
   def copy_of_answers_enabled?
+    return false unless Settings.copy_of_answers_enabled
     return false unless form_document.respond_to?(:send_copy_of_answers)
 
     form_document.send_copy_of_answers == "enabled"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -74,3 +74,6 @@ show_browser_during_tests: false
 cloudwatch_metrics_enabled: false
 
 analytics_enabled: false
+
+# Allows us to globally disable users getting a copy of their answers in the case that One Login is unavailable.
+copy_of_answers_enabled: true

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -186,6 +186,16 @@ RSpec.describe Form, type: :model do
       it "returns true" do
         expect(form.copy_of_answers_enabled?).to be true
       end
+
+      context "when the global copy_of_answers_enabled setting is set to false" do
+        before do
+          allow(Settings).to receive(:copy_of_answers_enabled).and_return(false)
+        end
+
+        it "returns false" do
+          expect(form.copy_of_answers_enabled?).to be false
+        end
+      end
     end
 
     context "when send_copy_of_answers is \"disabled\"" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/h4cqFw0X/3084-release-copy-of-form-fillers-answers-feature

There is a setting on the form to configure whether or not the user is asked if they want to ask for a copy of their answers by logging in with One Login.

Add a global setting to allow us to disable this feature for all forms in the case that One Login is unavailable.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
