### PR TITLE
Fix none of the above option for autocomplete selection question

### DIFF
--- a/app/components/question/selection_component/view.html.erb
+++ b/app/components/question/selection_component/view.html.erb
@@ -4,7 +4,7 @@
     attribute_name: :selection,
     form_field: form_builder.govuk_collection_select(:selection,
                                           question.selection_options_with_none_of_the_above,
-                                          :name,
+                                          :value,
                                           :name,
                                           options: { prompt: t("autocomplete.prompt") },
                                           label: { text: question_text_with_extra_suffix, **question_text_size_and_tag },

--- a/spec/features/fill_in_autocomplete_question_spec.rb
+++ b/spec/features/fill_in_autocomplete_question_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Fill in and submit a form with an autocomplete question", type: :feature do
-  let(:steps) { [build(:v2_selection_question_step, id: 1, routing_conditions: [], question_text:, selection_options:)] }
+  let(:steps) { [build(:v2_selection_question_step, id: 1, routing_conditions: [], question_text:, selection_options:, is_optional: true)] }
   let(:form) { build :v2_form_document, :live, form_id: 1, name: "Fill in this form", steps:, start_page: 1, send_copy_of_answers: "enabled" }
   let(:selection_options) { Array.new(31).each_with_index.map { |_element, index| { name: "Answer #{index}", value: "Answer #{index}" } } }
   let(:question_text) { Faker::Lorem.question }
@@ -39,6 +39,21 @@ feature "Fill in and submit a form with an autocomplete question", type: :featur
     and_i_should_receive_a_reference_number
   end
 
+  scenario "As a form filler choosing 'None of the above'" do
+    when_i_visit_the_form_start_page
+    then_i_should_see_the_first_question
+
+    when_i_start_typing_none_of_the_above
+    then_i_should_see_the_none_of_the_above_option
+    when_i_choose_none_of_the_above
+    and_i_click_on_continue
+    then_i_should_see_the_copy_of_answers_page
+
+    when_i_choose_not_to_receive_a_copy
+    and_i_click_on_continue
+    then_i_should_see_the_check_your_answers_page_with_none_of_the_above
+  end
+
   def when_i_visit_the_form_start_page
     visit form_path(mode: "form", form_id: 1, form_slug: "fill-in-this-form")
     expect_page_to_have_no_axe_errors(page)
@@ -64,6 +79,18 @@ feature "Fill in and submit a form with an autocomplete question", type: :featur
 
   def when_i_choose_an_option
     page.find('li[role="option"]', exact_text: answer_text).click
+  end
+
+  def when_i_start_typing_none_of_the_above
+    fill_in question_text, with: "None"
+  end
+
+  def then_i_should_see_the_none_of_the_above_option
+    expect(page).to have_css('li[role="option"]', text: I18n.t("page.none_of_the_above"))
+  end
+
+  def when_i_choose_none_of_the_above
+    page.find('li[role="option"]', exact_text: I18n.t("page.none_of_the_above")).click
   end
 
   def and_i_click_on_continue
@@ -101,5 +128,13 @@ feature "Fill in and submit a form with an autocomplete question", type: :featur
 
   def and_i_should_receive_a_reference_number
     expect(page).to have_text reference
+  end
+
+  def then_i_should_see_the_check_your_answers_page_with_none_of_the_above
+    expect(page.find("h1")).to have_text "Check your answers before submitting your form"
+    expect(page).to have_text question_text
+    expect(page).to have_text I18n.t("page.none_of_the_above")
+    expect(page).not_to have_text I18n.t("activemodel.errors.models.question/selection.attributes.selection.inclusion")
+    expect_page_to_have_no_axe_errors(page)
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Form fillers were seeing "Select an answer from the list" error when trying to answer "None of the above" for a selection question with an autocomplete input (more than 30 options).

This was happening because the Selection question model was expecting `none_of_the_above` as the value of the input, but the selection component was using the text of the option, "None of the above", erroneously.

This commit fixes things by telling the select input to use `#value` as the value method for each option, instead of the `#name` method which returns the text for the option.

This change also affects submissions to Welsh forms; the value is always in English whereas the name is localised.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
