### PR TITLE
Update send submission jobs to accept Delivery

### DIFF
--- a/app/jobs/send_s3_submission_job.rb
+++ b/app/jobs/send_s3_submission_job.rb
@@ -1,6 +1,6 @@
 class SendS3SubmissionJob < SubmissionDeliveryJob
-  def perform(submission)
-    delivery = submission.single_submission_delivery
+  def perform(delivery_or_submission)
+    delivery, submission = resolve_delivery_and_submission(delivery_or_submission)
     set_submission_logging_attributes(submission:, delivery:)
 
     delivery.new_attempt!

--- a/app/jobs/send_submission_job.rb
+++ b/app/jobs/send_submission_job.rb
@@ -4,11 +4,11 @@ class SendSubmissionJob < SubmissionDeliveryJob
 
   retry_on Aws::SESV2::Errors::ServiceError, wait: :polynomially_longer, attempts: TOTAL_ATTEMPTS
 
-  def perform(submission)
+  def perform(delivery_or_submission)
     # The job will use the locale at the time it was created. Force it to be "en" as we always send submission emails in
     # English.
     I18n.with_locale("en") do
-      delivery = submission.single_submission_delivery
+      delivery, submission = resolve_delivery_and_submission(delivery_or_submission)
       set_submission_logging_attributes(submission:, delivery:)
 
       delivery.new_attempt!

--- a/app/jobs/submission_delivery_job.rb
+++ b/app/jobs/submission_delivery_job.rb
@@ -3,6 +3,17 @@ class SubmissionDeliveryJob < ApplicationJob
 
 private
 
+  def resolve_delivery_and_submission(argument)
+    case argument
+    when Delivery
+      [argument, argument.submissions.sole]
+    when Submission
+      [argument.single_submission_delivery, argument]
+    else
+      raise ArgumentError, "Expected a Delivery or Submission, got #{argument.class}"
+    end
+  end
+
   def record_submission_sent!
     milliseconds_since_scheduled = (Time.current - scheduled_at_or_enqueued_at).in_milliseconds.round
     EventLogger.log_form_event("submission_sent", { milliseconds_since_scheduled: })

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -91,7 +91,7 @@ private
   end
 
   def create_submission_record
-    submission = Submission.create!(
+    Submission.create!(
       reference: submission_reference,
       form_id: form.id,
       answers: current_context.answers,
@@ -101,16 +101,13 @@ private
       submission_locale:,
       created_at: timestamp,
     )
-
-    submission.deliveries.create!(delivery_schedule: :immediate)
-
-    submission
   end
 
   def enqueue_deliver_submission_job(job_class)
     submission = create_submission_record
+    delivery = submission.deliveries.create!(delivery_schedule: :immediate)
 
-    job_class.perform_later(submission) do |job|
+    job_class.perform_later(delivery) do |job|
       next if job.successfully_enqueued?
 
       submission.destroy!

--- a/spec/features/fill_in_and_submit_form_with_csv_spec.rb
+++ b/spec/features/fill_in_and_submit_form_with_csv_spec.rb
@@ -85,7 +85,8 @@ feature "Fill in and submit a form with a CSV submission", type: :feature do
   end
 
   def and_an_email_submission_should_have_been_sent
-    expect(SendSubmissionJob).to have_been_enqueued.with(an_instance_of(Submission) do |submission|
+    expect(SendSubmissionJob).to have_been_enqueued.with(an_instance_of(Delivery) do |delivery|
+      submission = delivery.submissions.sole
       expect(submission.form_id).to eq(form.id)
       expect(submission.reference).to eq(reference)
       expect(submission.answers).to eq({ "1" => { "selection" => "Option 1" } })

--- a/spec/jobs/send_s3_submission_job_spec.rb
+++ b/spec/jobs/send_s3_submission_job_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe SendS3SubmissionJob, type: :job do
       submission.deliveries.create!
     end
   end
+  let(:delivery) { submission.single_submission_delivery }
   let(:journey) { instance_double(Flow::Journey) }
   let(:delivery_reference) { "s3-submission-key" }
   let(:s3_submission_service_spy) { instance_double(S3SubmissionService, submit: delivery_reference) }
@@ -22,10 +23,10 @@ RSpec.describe SendS3SubmissionJob, type: :job do
     allow(CloudWatchService).to receive(:record_job_failure_metric)
   end
 
-  context "when the job is processed" do
+  context "when the job is processed with a Delivery argument" do
     it "submits via S3" do
       perform_enqueued_jobs do
-        described_class.perform_later(submission)
+        described_class.perform_later(delivery)
       end
 
       expect(S3SubmissionService).to have_received(:new).with(submission:)
@@ -34,7 +35,7 @@ RSpec.describe SendS3SubmissionJob, type: :job do
 
     it "logs submission send timing event and metric" do
       perform_enqueued_jobs do
-        described_class.perform_later(submission)
+        described_class.perform_later(delivery)
       end
 
       expect(EventLogger).to have_received(:log_form_event).with(
@@ -49,22 +50,21 @@ RSpec.describe SendS3SubmissionJob, type: :job do
     it "updates the delivery last attempt time" do
       freeze_time do
         perform_enqueued_jobs do
-          described_class.perform_later(submission)
+          described_class.perform_later(delivery)
         end
 
-        expect(submission.reload.deliveries.sole.last_attempt_at).to eq(Time.zone.now)
+        expect(delivery.reload.last_attempt_at).to eq(Time.zone.now)
       end
     end
 
     it "sets the delivery reference and last attempt time" do
       freeze_time do
         perform_enqueued_jobs do
-          described_class.perform_later(submission)
+          described_class.perform_later(delivery)
         end
 
-        delivery = submission.reload.deliveries.first
-        expect(delivery.delivery_reference).to eq(delivery_reference)
-        expect(delivery.last_attempt_at).to eq(Time.zone.now)
+        expect(delivery.reload.delivery_reference).to eq(delivery_reference)
+        expect(delivery.reload.last_attempt_at).to eq(Time.zone.now)
       end
     end
 
@@ -81,7 +81,7 @@ RSpec.describe SendS3SubmissionJob, type: :job do
       it "does not create a new delivery record" do
         expect {
           perform_enqueued_jobs do
-            described_class.perform_later(submission)
+            described_class.perform_later(delivery)
           end
         }.not_to change(submission.deliveries, :count)
       end
@@ -89,10 +89,10 @@ RSpec.describe SendS3SubmissionJob, type: :job do
       it "updates the existing delivery record" do
         freeze_time do
           perform_enqueued_jobs do
-            described_class.perform_later(submission)
+            described_class.perform_later(delivery)
           end
 
-          updated_delivery = submission.deliveries.first.reload
+          updated_delivery = delivery.reload
           expect(updated_delivery.delivery_reference).to eq(delivery_reference)
           expect(updated_delivery.last_attempt_at).to eq(Time.zone.now)
           expect(updated_delivery.delivered_at).to be_nil
@@ -103,17 +103,38 @@ RSpec.describe SendS3SubmissionJob, type: :job do
     end
   end
 
+  context "when the job is processed with a Submission argument (backwards compatibility)" do
+    it "submits via S3" do
+      perform_enqueued_jobs do
+        described_class.perform_later(submission)
+      end
+
+      expect(S3SubmissionService).to have_received(:new).with(submission:)
+      expect(s3_submission_service_spy).to have_received(:submit)
+    end
+
+    it "sets the delivery reference" do
+      freeze_time do
+        perform_enqueued_jobs do
+          described_class.perform_later(submission)
+        end
+
+        expect(submission.reload.deliveries.sole.delivery_reference).to eq(delivery_reference)
+      end
+    end
+  end
+
   context "when there is an error during processing" do
     before do
       allow(s3_submission_service_spy).to receive(:submit).and_raise(StandardError, "Test error")
     end
 
     it "raises an error" do
-      expect { described_class.new.perform(submission) }.to raise_error(StandardError, "Test error")
+      expect { described_class.new.perform(delivery) }.to raise_error(StandardError, "Test error")
     end
 
     it "sends cloudwatch metric for failure" do
-      described_class.new.perform(submission)
+      described_class.new.perform(delivery)
       expect(CloudWatchService).to have_received(:record_job_failure_metric).with("SendS3SubmissionJob")
     rescue StandardError
       nil

--- a/spec/jobs/send_submission_job_spec.rb
+++ b/spec/jobs/send_submission_job_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe SendSubmissionJob, type: :job do
   let(:submission) do
     create(:submission, :sent, form_document:, created_at: submission_created_at, answers:)
   end
+  let(:delivery) { submission.single_submission_delivery }
   let(:form_document) do
     build(:v2_form_document,
           :ready_for_live,
@@ -24,7 +25,58 @@ RSpec.describe SendSubmissionJob, type: :job do
     allow(CloudWatchService).to receive(:record_job_failure_metric)
   end
 
-  context "when the job is processed" do
+  context "when the job is processed with a Delivery argument" do
+    before do
+      allow(AwsSesSubmissionService).to receive(:new).with(submission:).and_return(aws_ses_submission_service_spy)
+      allow(aws_ses_submission_service_spy).to receive(:submit).and_return(delivery_reference)
+
+      described_class.perform_later(delivery)
+      travel 5.seconds do
+        @job_ran_at = Time.zone.now
+        perform_enqueued_jobs
+      end
+    end
+
+    it "submits via AWS SES" do
+      expect(aws_ses_submission_service_spy).to have_received(:submit)
+    end
+
+    it "sets the delivery reference on the existing delivery record" do
+      expect(delivery.reload.delivery_reference).to eq(delivery_reference)
+    end
+
+    it "sets the last attempt time on the existing delivery record" do
+      expect(delivery.reload.last_attempt_at).to be_within(1.second).of(@job_ran_at)
+    end
+
+    it "sends cloudwatch metric for the submission being sent" do
+      expect(CloudWatchService).to have_received(:record_submission_sent_metric).with(
+        satisfy { |value| value.is_a?(Integer) && value >= 0 },
+      )
+    end
+
+    context "when the delivery is being retried" do
+      let(:submission) do
+        delivery = create(:delivery,
+                          delivery_reference: "old-ref",
+                          delivered_at: Time.zone.now,
+                          failed_at: Time.zone.now,
+                          failure_reason: "bounced")
+        create(:submission, form_document:, deliveries: [delivery])
+      end
+
+      it "clears the delivery status fields" do
+        updated_delivery = delivery.reload
+        expect(updated_delivery.delivery_reference).to eq(delivery_reference)
+        expect(updated_delivery.last_attempt_at).to be_within(1.second).of(@job_ran_at)
+        expect(updated_delivery.delivered_at).to be_nil
+        expect(updated_delivery.failed_at).to be_nil
+        expect(updated_delivery.failure_reason).to be_nil
+      end
+    end
+  end
+
+  context "when the job is processed with a Submission argument (backwards compatibility)" do
     before do
       allow(AwsSesSubmissionService).to receive(:new).with(submission:).and_return(aws_ses_submission_service_spy)
       allow(aws_ses_submission_service_spy).to receive(:submit).and_return(delivery_reference)
@@ -47,32 +99,6 @@ RSpec.describe SendSubmissionJob, type: :job do
     it "sets the last attempt time on the existing delivery record" do
       expect(submission.reload.deliveries.first.last_attempt_at).to be_within(1.second).of(@job_ran_at)
     end
-
-    it "sends cloudwatch metric for the submission being sent" do
-      expect(CloudWatchService).to have_received(:record_submission_sent_metric).with(
-        satisfy { |value| value.is_a?(Integer) && value >= 0 },
-      )
-    end
-
-    context "when the delivery is being retried" do
-      let(:submission) do
-        delivery = create(:delivery,
-                          delivery_reference: "old-ref",
-                          delivered_at: Time.zone.now,
-                          failed_at: Time.zone.now,
-                          failure_reason: "bounced")
-        create(:submission, form_document:, deliveries: [delivery])
-      end
-
-      it "clears the delivery status fields" do
-        updated_delivery = submission.deliveries.first.reload
-        expect(updated_delivery.delivery_reference).to eq(delivery_reference)
-        expect(updated_delivery.last_attempt_at).to be_within(1.second).of(@job_ran_at)
-        expect(updated_delivery.delivered_at).to be_nil
-        expect(updated_delivery.failed_at).to be_nil
-        expect(updated_delivery.failure_reason).to be_nil
-      end
-    end
   end
 
   context "when there is an error during processing" do
@@ -85,18 +111,18 @@ RSpec.describe SendSubmissionJob, type: :job do
 
       it "retries for the configured number of attempts" do
         assert_performed_jobs SendSubmissionJob::TOTAL_ATTEMPTS do
-          described_class.perform_later(submission)
+          described_class.perform_later(delivery)
         rescue Aws::SESV2::Errors::ServiceError # If we don't catch the error, the test aborts prematurely
           nil
         end
       end
 
       it "raises an error after all attempts fail" do
-        expect { described_class.new.perform(submission) }.to raise_error(Aws::SESV2::Errors::ServiceError)
+        expect { described_class.new.perform(delivery) }.to raise_error(Aws::SESV2::Errors::ServiceError)
       end
 
       it "sends cloudwatch metric for failure" do
-        described_class.new.perform(submission)
+        described_class.new.perform(delivery)
         expect(CloudWatchService).to have_received(:record_job_failure_metric).with("SendSubmissionJob")
       rescue Aws::SESV2::Errors::ServiceError # If we don't catch the error, the test aborts prematurely
         nil
@@ -110,18 +136,18 @@ RSpec.describe SendSubmissionJob, type: :job do
 
       it "doesn't retry" do
         assert_performed_jobs 1 do
-          described_class.perform_later(submission)
+          described_class.perform_later(delivery)
         rescue StandardError # If we don't catch the error, the test aborts prematurely
           nil
         end
       end
 
       it "raises an error immediately" do
-        expect { described_class.new.perform(submission) }.to raise_error(StandardError)
+        expect { described_class.new.perform(delivery) }.to raise_error(StandardError)
       end
 
       it "sends cloudwatch metric for failure" do
-        described_class.new.perform(submission)
+        described_class.new.perform(delivery)
         expect(CloudWatchService).to have_received(:record_job_failure_metric).with("SendSubmissionJob")
       rescue StandardError # If we don't catch the error, the test aborts prematurely
         nil
@@ -132,7 +158,7 @@ RSpec.describe SendSubmissionJob, type: :job do
   context "when the job was enqueued with Welsh locale" do
     it "uses English I18n translations in the submission email" do
       I18n.with_locale(:cy) do
-        described_class.perform_later(submission)
+        described_class.perform_later(delivery)
         perform_enqueued_jobs
       end
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/WMnjLlJV

In order to support sending submission by multiple delivery methods (email and S3), we need to support the Submission having multiple associated Delivery records with delivery_schedule of `immediate`.

Make the SendSubmissionJob and SendS3SubmissionJob accept a Delivery as an argument so that we can update the appropriate Delivery when the submission is sent.

Add in backwards compatibility for the job being called with a Submission to account for existing queued jobs, but this backwards compatibility can be removed shortly after this change is deployed and all existing jobs have been processed.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
