### PR TITLE
Store delivery_method and formats on delivery

### DIFF
--- a/app/jobs/schedule_daily_batch_deliveries_job.rb
+++ b/app/jobs/schedule_daily_batch_deliveries_job.rb
@@ -21,6 +21,8 @@ class ScheduleDailyBatchDeliveriesJob < ApplicationJob
 
       delivery = Delivery.create!(
         delivery_schedule: :daily,
+        delivery_method: "email",
+        formats: %w[csv],
         submissions: batch.submissions,
         batch_begin_at:,
       )

--- a/app/jobs/schedule_weekly_batch_deliveries_job.rb
+++ b/app/jobs/schedule_weekly_batch_deliveries_job.rb
@@ -20,6 +20,8 @@ class ScheduleWeeklyBatchDeliveriesJob < ApplicationJob
 
       delivery = Delivery.create!(
         delivery_schedule: :weekly,
+        delivery_method: "email",
+        formats: %w[csv],
         submissions: batch.submissions,
         batch_begin_at:,
       )

--- a/app/jobs/send_s3_submission_job.rb
+++ b/app/jobs/send_s3_submission_job.rb
@@ -1,6 +1,6 @@
 class SendS3SubmissionJob < SubmissionDeliveryJob
-  def perform(delivery_or_submission)
-    delivery, submission = resolve_delivery_and_submission(delivery_or_submission)
+  def perform(delivery)
+    submission = delivery.submissions.sole
     set_submission_logging_attributes(submission:, delivery:)
 
     delivery.new_attempt!

--- a/app/jobs/send_submission_job.rb
+++ b/app/jobs/send_submission_job.rb
@@ -4,11 +4,11 @@ class SendSubmissionJob < SubmissionDeliveryJob
 
   retry_on Aws::SESV2::Errors::ServiceError, wait: :polynomially_longer, attempts: TOTAL_ATTEMPTS
 
-  def perform(delivery_or_submission)
+  def perform(delivery)
     # The job will use the locale at the time it was created. Force it to be "en" as we always send submission emails in
     # English.
     I18n.with_locale("en") do
-      delivery, submission = resolve_delivery_and_submission(delivery_or_submission)
+      submission = delivery.submissions.sole
       set_submission_logging_attributes(submission:, delivery:)
 
       delivery.new_attempt!

--- a/app/jobs/submission_delivery_job.rb
+++ b/app/jobs/submission_delivery_job.rb
@@ -3,17 +3,6 @@ class SubmissionDeliveryJob < ApplicationJob
 
 private
 
-  def resolve_delivery_and_submission(argument)
-    case argument
-    when Delivery
-      [argument, argument.submissions.sole]
-    when Submission
-      [argument.single_submission_delivery, argument]
-    else
-      raise ArgumentError, "Expected a Delivery or Submission, got #{argument.class}"
-    end
-  end
-
   def record_submission_sent!
     milliseconds_since_scheduled = (Time.current - scheduled_at_or_enqueued_at).in_milliseconds.round
     EventLogger.log_form_event("submission_sent", { milliseconds_since_scheduled: })

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -17,6 +17,11 @@ class Delivery < ApplicationRecord
     weekly: "weekly",
   }
 
+  enum :delivery_method, {
+    email: "email",
+    s3: "s3",
+  }
+
   def status
     return :pending if delivered_at.nil? && failed_at.nil?
     return :delivered if delivered_at.present? && failed_at.nil?

--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -105,7 +105,11 @@ private
 
   def enqueue_deliver_submission_job(job_class)
     submission = create_submission_record
-    delivery = submission.deliveries.create!(delivery_schedule: :immediate)
+    delivery = submission.deliveries.create!(
+      delivery_schedule: :immediate,
+      delivery_method: form.submission_type,
+      formats: form.submission_format,
+    )
 
     job_class.perform_later(delivery) do |job|
       next if job.successfully_enqueued?

--- a/db/migrate/20260716114700_add_delivery_method_and_formats_to_deliveries.rb
+++ b/db/migrate/20260716114700_add_delivery_method_and_formats_to_deliveries.rb
@@ -1,0 +1,8 @@
+class AddDeliveryMethodAndFormatsToDeliveries < ActiveRecord::Migration[8.1]
+  def change
+    change_table :deliveries, bulk: true do |t|
+      t.string :delivery_method, null: true
+      t.string :formats, default: [], array: true, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_20_093250) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_16_114700) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -18,11 +18,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_20_093250) do
     t.datetime "batch_begin_at"
     t.datetime "created_at", null: false
     t.datetime "delivered_at"
+    t.string "delivery_method"
     t.string "delivery_reference"
     t.string "delivery_schedule", default: "immediate", null: false, comment: "Either 'immediate' if the delivery is for a single submission or a value representing the schedule for sending multiple submissions."
     t.datetime "failed_at"
     t.jsonb "failure_details"
     t.string "failure_reason"
+    t.string "formats", default: [], null: false, array: true
     t.datetime "last_attempt_at"
     t.datetime "updated_at", null: false
     t.index ["delivery_reference"], name: "index_deliveries_on_delivery_reference"

--- a/spec/jobs/send_s3_submission_job_spec.rb
+++ b/spec/jobs/send_s3_submission_job_spec.rb
@@ -103,27 +103,6 @@ RSpec.describe SendS3SubmissionJob, type: :job do
     end
   end
 
-  context "when the job is processed with a Submission argument (backwards compatibility)" do
-    it "submits via S3" do
-      perform_enqueued_jobs do
-        described_class.perform_later(submission)
-      end
-
-      expect(S3SubmissionService).to have_received(:new).with(submission:)
-      expect(s3_submission_service_spy).to have_received(:submit)
-    end
-
-    it "sets the delivery reference" do
-      freeze_time do
-        perform_enqueued_jobs do
-          described_class.perform_later(submission)
-        end
-
-        expect(submission.reload.deliveries.sole.delivery_reference).to eq(delivery_reference)
-      end
-    end
-  end
-
   context "when there is an error during processing" do
     before do
       allow(s3_submission_service_spy).to receive(:submit).and_raise(StandardError, "Test error")

--- a/spec/jobs/send_submission_job_spec.rb
+++ b/spec/jobs/send_submission_job_spec.rb
@@ -76,31 +76,6 @@ RSpec.describe SendSubmissionJob, type: :job do
     end
   end
 
-  context "when the job is processed with a Submission argument (backwards compatibility)" do
-    before do
-      allow(AwsSesSubmissionService).to receive(:new).with(submission:).and_return(aws_ses_submission_service_spy)
-      allow(aws_ses_submission_service_spy).to receive(:submit).and_return(delivery_reference)
-
-      described_class.perform_later(submission)
-      travel 5.seconds do
-        @job_ran_at = Time.zone.now
-        perform_enqueued_jobs
-      end
-    end
-
-    it "submits via AWS SES" do
-      expect(aws_ses_submission_service_spy).to have_received(:submit)
-    end
-
-    it "sets the delivery reference on the existing delivery record" do
-      expect(submission.reload.deliveries.first.delivery_reference).to eq(delivery_reference)
-    end
-
-    it "sets the last attempt time on the existing delivery record" do
-      expect(submission.reload.deliveries.first.last_attempt_at).to be_within(1.second).of(@job_ran_at)
-    end
-  end
-
   context "when there is an error during processing" do
     context "and the error is an Aws::SESV2::Errors::ServiceError" do
       before do

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -143,6 +143,9 @@ RSpec.describe FormSubmissionService, :capture_logging do
             expect(Submission.last.deliveries.sole).to have_attributes(
               delivery_reference: nil,
               last_attempt_at: nil,
+              delivery_method: "s3",
+              delivery_schedule: "immediate",
+              formats: %w[csv],
             )
           end
         end
@@ -176,7 +179,7 @@ RSpec.describe FormSubmissionService, :capture_logging do
 
       context "when the submission type is email" do
         let(:submission_type) { "email" }
-        let(:submission_format) { [] }
+        let(:submission_format) { %w[json] }
         let(:aws_ses_submission_service_spy) { instance_double(AwsSesSubmissionService) }
         let(:mail_message_id) { "1234" }
 
@@ -222,6 +225,9 @@ RSpec.describe FormSubmissionService, :capture_logging do
           delivery = Submission.last.deliveries.sole
           expect(delivery.delivery_reference).to be_nil
           expect(delivery.last_attempt_at).to be_nil
+          expect(delivery.delivery_method).to eq "email"
+          expect(delivery.delivery_schedule).to eq "immediate"
+          expect(delivery.formats).to eq %w[json]
         end
 
         context "when the job fails to enqueue" do

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -119,7 +119,10 @@ RSpec.describe FormSubmissionService, :capture_logging do
     end
 
     describe "submitting the form to the processing team" do
-      shared_examples "submits via AWS S3" do
+      context "when the submission type is s3" do
+        let(:submission_type) { "s3" }
+        let(:submission_format) { %w[csv] }
+
         it "enqueues a job to send the submission to S3" do
           assert_enqueued_with(job: SendS3SubmissionJob) do
             service.submit
@@ -167,9 +170,13 @@ RSpec.describe FormSubmissionService, :capture_logging do
             end
           end
         end
+
+        include_examples "logging"
       end
 
-      shared_examples "submits via AWS SES" do
+      context "when the submission type is email" do
+        let(:submission_type) { "email" }
+        let(:submission_format) { [] }
         let(:aws_ses_submission_service_spy) { instance_double(AwsSesSubmissionService) }
         let(:mail_message_id) { "1234" }
 
@@ -240,40 +247,6 @@ RSpec.describe FormSubmissionService, :capture_logging do
             end
           end
         end
-      end
-
-      context "when the submission type is s3" do
-        let(:submission_type) { "s3" }
-        let(:submission_format) { %w[csv] }
-
-        include_examples "submits via AWS S3"
-
-        include_examples "logging"
-      end
-
-      context "when the submission type is s3 with json" do
-        let(:submission_type) { "s3" }
-        let(:submission_format) { %w[json] }
-
-        include_examples "submits via AWS S3"
-
-        include_examples "logging"
-      end
-
-      context "when the submission type is email" do
-        let(:submission_type) { "email" }
-        let(:submission_format) { [] }
-
-        include_examples "submits via AWS SES"
-
-        include_examples "logging"
-      end
-
-      context "when the submission type is email with csv" do
-        let(:submission_type) { "email" }
-        let(:submission_format) { %w[csv] }
-
-        include_examples "submits via AWS SES"
 
         include_examples "logging"
       end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/WMnjLlJV

Store the `delivery_method` and `formats` on Deliveries. See the individual commit messages for details.

Also removes the backwards compatibility for support submissions jobs enqueued with a Submission as the argument rather than a Delivery.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
