### PR TITLE
Raise an error if a live form submission has no delivery configs

### DIFF
--- a/app/services/form_submission_service.rb
+++ b/app/services/form_submission_service.rb
@@ -77,9 +77,14 @@ private
   end
 
   def enqueue_deliveries(submission)
-    form.delivery_configurations
-        .filter { |c| c.delivery_schedule == "immediate" }
-        .each { |c| enqueue_delivery(c, submission) }
+    delivery_configurations = form.delivery_configurations.filter { |c| c.delivery_schedule == "immediate" }
+
+    if delivery_configurations.blank? && mode.live?
+      submission.destroy!
+      raise StandardError, "Form id(#{form.id}) has no immediate delivery configurations" if delivery_configurations.blank? && mode.live?
+    end
+
+    delivery_configurations.each { |c| enqueue_delivery(c, submission) }
   end
 
   def enqueue_delivery(delivery_configuration, submission)

--- a/spec/services/form_submission_service_spec.rb
+++ b/spec/services/form_submission_service_spec.rb
@@ -336,6 +336,27 @@ RSpec.describe FormSubmissionService, :capture_logging do
         end
       end
 
+      context "when the form has no immediate delivery configurations" do
+        let(:delivery_configurations) { [build(:v2_delivery_configuration, :daily_email)] }
+
+        context "when the mode is live" do
+          it "raises an error" do
+            expect { service.submit }
+              .to not_change(Submission, :count)
+                    .and not_change(Delivery, :count)
+                           .and raise_error(StandardError, "Form id(#{form.id}) has no immediate delivery configurations")
+          end
+        end
+
+        context "when form being submitted is from previewed form" do
+          let(:mode) { Mode.new("preview-draft") }
+
+          it "does not raise an error" do
+            expect { service.submit }.not_to raise_error
+          end
+        end
+      end
+
       context "when form being submitted is from previewed form" do
         let(:mode) { Mode.new("preview-live") }
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/WMnjLlJV/245-allow-both-email-and-s3-submissions-simultaneously

Ensure that a user cannot complete a live form submission if it is not configured to be delivered to any destination. This shouldn't happen under normal circumstances, but we should protect against an unexpected state.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
