### PR TITLE
Namespace compiled assets under app name

### DIFF
--- a/config/vite.json
+++ b/config/vite.json
@@ -9,7 +9,7 @@
     "additionalEntrypoints": [
       "node_modules/govuk-frontend/dist/govuk/assets/**/*"
     ],
-    "publicOutputDir": "assets",
+    "publicOutputDir": "assets/forms-runner",
     "assetsDir": "",
     "autoBuild": false
   },


### PR DESCRIPTION
## What
Changes Vite's `publicOutputDir` from `assets` to `assets/forms-runner`, so production assets compile to `public/assets/forms-runner/` and all generated asset URLs use the `/assets/forms-runner/` prefix.

## Why
We are working on serving production assets from a shared S3 bucket instead of from the Rails container. Multiple apps will upload their assets to the same bucket, so each app needs its own key prefix to avoid collisions. Syncing `public/assets/` to the bucket now produces the `assets/forms-runner/` namespace automatically.

This is the forms-runner equivalent of govuk-forms/forms-product-page#1243 and govuk-forms/forms-admin#2972.

## Notes
- Unlike forms-product-page, development and test do not override `publicOutputDir` here, so their build output moves to the same directory too. This is harmless: development is served by the Vite dev server, the directory is gitignored, and nothing references the old path.
- The compiled files still sit under `public/` at the same path as their URLs, so the Rails container can continue serving them directly until S3 serving is in place (and in review apps).
- Verified with a production build: `vite_asset_path` returns `/assets/forms-runner/application-<digest>.js`, and URLs inside the compiled CSS (fonts, images) use the new prefix too.
- The existing `.gitignore` entry `/public/assets` still covers the new output; no Dockerfile changes needed.