### PR TITLE
Make footer copyright holder configurable

### DIFF
--- a/app/components/custom_branding_component/_index.scss
+++ b/app/components/custom_branding_component/_index.scss
@@ -35,3 +35,7 @@
 .app-custom-branding .govuk-footer {
   border-top-color: var(--custom-border-colour);
 }
+
+.app-custom-branding .govuk-footer__crown {
+  display: none;
+}

--- a/app/components/footer_component/view.html.erb
+++ b/app/components/footer_component/view.html.erb
@@ -1,9 +1,31 @@
-<%= govuk_footer(meta_items_title: t("footer.helpful_links"), copyright_text: t("footer.copyright"), meta_items: meta_links) do |footer| %>
-  <% footer.with_meta_licence_html do %>
-    <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
-      <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
-    </svg>
+<% if custom_branding? %>
+  <%= govuk_footer do |footer| %>
+    <% footer.with_meta do %>
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        <h2 class="govuk-visually-hidden"><%= t("footer.helpful_links") %></h2>
 
-    <span class="govuk-footer__licence-description"><%= t("footer.licence", link: govuk_footer_link_to(t("footer.licence_link_text"), t("footer.licence_link_url"))).html_safe %></span>
+        <ul class="govuk-footer__inline-list">
+          <% meta_links.each do |text, href| %>
+            <li class="govuk-footer__inline-list-item">
+              <%= govuk_footer_link_to text, href %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+
+      <% if copyright_holder.present? %>
+        <div class="govuk-footer__meta-item">© <%= copyright_holder %></div>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= govuk_footer(meta_items_title: t("footer.helpful_links"), copyright_text: t("footer.copyright"), meta_items: meta_links) do |footer| %>
+    <% footer.with_meta_licence_html do %>
+      <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+        <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+      </svg>
+
+      <span class="govuk-footer__licence-description"><%= t("footer.licence", link: govuk_footer_link_to(t("footer.licence_link_text"), t("footer.licence_link_url"))).html_safe %></span>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/footer_component/view.rb
+++ b/app/components/footer_component/view.rb
@@ -29,6 +29,14 @@ module FooterComponent
       I18n.locale if I18n.locale != I18n.default_locale
     end
 
+    def custom_branding?
+      @form.present? && @form.has_custom_branding?
+    end
+
+    def copyright_holder
+      @form.branding["copyright_holder"]
+    end
+
     def accessibility_statement
       if @form&.has_custom_branding?
         form_branded_accessibility_statement_path(mode: @mode, form_id: @form.id, form_slug: @form.form_slug)

--- a/config/branding.yml
+++ b/config/branding.yml
@@ -3,6 +3,7 @@ cheshire-east:
   border_colour: "#206c49"
   organisation_name: "Cheshire East Council"
   organisation_url: "https://www.cheshireeast.gov.uk"
+  copyright_holder: "Cheshire East Council"
   logo: /brand_assets/cheshire-east/logo.png
   favicon: /brand_assets/cheshire-east/favicon.ico
   opengraph: /brand_assets/cheshire-east/opengraph.jpg
@@ -11,5 +12,6 @@ south-gloucestershire:
   border_colour: "#396631"
   organisation_name: "South Gloucestershire Council"
   organisation_url: "https://www.southglos.gov.uk"
+  copyright_holder: "South Gloucestershire Council"
   logo: /brand_assets/south-gloucestershire/logo.png
   favicon: /brand_assets/south-gloucestershire/favicon.png

--- a/spec/components/footer_component/footer_component_preview.rb
+++ b/spec/components/footer_component/footer_component_preview.rb
@@ -8,4 +8,16 @@ class FooterComponent::FooterComponentPreview < ViewComponent::Preview
     form = OpenStruct.new(id: 1, name: "test", form_slug: "test")
     render(FooterComponent::View.new(mode:, form:))
   end
+
+  def with_custom_branding
+    mode = Mode.new
+    form = OpenStruct.new(id: 1,
+                          name: "test",
+                          form_slug: "test",
+                          has_custom_branding?: true,
+                          branding: {
+                            "copyright_holder" => "Cheshire East Council",
+                          })
+    render(FooterComponent::View.new(mode:, form:))
+  end
 end

--- a/spec/components/footer_component/view_spec.rb
+++ b/spec/components/footer_component/view_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe FooterComponent::View, type: :component do
     it "includes the licence link" do
       expect(page).to have_link(I18n.t("footer.licence_link_text"), href: I18n.t("footer.licence_link_url"))
     end
+
+    it "includes the Crown copyright link" do
+      expect(page).to have_link(I18n.t("footer.copyright"))
+    end
   end
 
   context "when the locale is cy" do
@@ -54,6 +58,39 @@ RSpec.describe FooterComponent::View, type: :component do
 
       it "includes a link to the branded accessbility statement" do
         expect(page).to have_link("Accessibility statement", href: form_branded_accessibility_statement_path(mode:, form_id: form.id, form_slug: form.form_slug))
+      end
+
+      it "includes the cookies link" do
+        expect(page).to have_link("Cookies", href: cookies_path)
+      end
+
+      it "includes the privacy link" do
+        expect(page).to have_link("Privacy", href: form_privacy_path(mode:, form_id: form.id, form_slug: form.form_slug))
+      end
+
+      it "shows the copyright holder's copyright notice without a link" do
+        expect(page).to have_text("© Cheshire East Council")
+        expect(page).not_to have_link("© Cheshire East Council")
+      end
+
+      it "does not show Crown copyright" do
+        expect(page).not_to have_text(I18n.t("footer.copyright"))
+      end
+
+      it "does not show the licence" do
+        expect(page).not_to have_link(I18n.t("footer.licence_link_text"))
+      end
+
+      context "when the brand has no copyright holder" do
+        let(:form) do
+          build(:form, brand_id: "cheshire-east", id: 1).tap do |form|
+            allow(form).to receive(:branding).and_return({})
+          end
+        end
+
+        it "does not show a copyright notice" do
+          expect(page).not_to have_text("©")
+        end
       end
     end
   end


### PR DESCRIPTION
Custom branding can be used by non-crown organisations, but the footer still showed "© Crown copyright" and the Open Government Licence v3.0 line. Both can be wrong for a branded form: Crown copyright (s163 CDPA 1988) only covers works made by servants of the Crown, so a non-crown organisation's form content belongs to that organisation. Also we cannot license their content under the OGL on their behalf.

Each brand now sets a `copyright_holder` in `config/branding.yml`, rendered in the footer as an unlinked "© <holder>" (omitted if unset). It's a separate field rather than being derived from `organisation_name` because the display name and the legal entity that owns the copyright aren't always the same. Branded forms show no content licence line at all. The `govuk_footer` helper always renders its copyright as a link to the National Archives with the crown logo and offers no unlinked option, so branded forms render the footer meta area themselves through the component's `with_meta` slot; unbranded forms are unchanged.

The footer also turned out to always render the royal crest, which the gem can't suppress either, so it's now hidden for branded forms via the custom branding stylesheet.

Previously:

<img width="1154" height="604" alt="image" src="https://github.com/user-attachments/assets/1f01321b-33e9-4681-852b-9348c768184d" />


Now:


<img width="1173" height="405" alt="image" src="https://github.com/user-attachments/assets/76167162-0517-454c-95ca-334ba6a616c1" />
