### PR TITLE
Handle MissingTemplate errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,14 @@ class ApplicationController < ActionController::Base
 
   add_flash_types :success
 
+  rescue_from ActionView::MissingTemplate do |exception|
+    if request.format && request.format != :html
+      head :not_acceptable
+    else
+      raise exception
+    end
+  end
+
   def accessibility_statement; end
 
   def cookies; end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -16,12 +16,17 @@ RSpec.describe ApplicationController do
     rescue RuntimeError
       raise "outer error"
     end
+
+    def missing_template
+      render "missing_template"
+    end
   end
 
   before do
     routes.draw do
       get "raise_error" => "anonymous#raise_error"
       get "raise_error_with_cause" => "anonymous#raise_error_with_cause"
+      get "missing_template" => "anonymous#missing_template"
     end
   end
 
@@ -84,6 +89,17 @@ RSpec.describe ApplicationController do
       get :raise_error
 
       expect(Sentry).to have_received(:capture_exception)
+    end
+  end
+
+  describe "missing template" do
+    it "returns 406 when request format is not HTML" do
+      get :missing_template, format: :json
+      expect(response).to have_http_status(:not_acceptable)
+    end
+
+    it "raises the error when the request format is HTML" do
+      expect { get :missing_template, format: :html }.to raise_error(ActionView::MissingTemplate)
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/rFP7pQ46/

If a MissingTemplate error is raised, and the format requested was not HTML, handle the error by returning a 406 Not Acceptable response.

If the format requested was HTML, re-raise the error as we should not expect to be missing templates for HTML requests handled by the ApplicationController.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
