### PR TITLE
Include blank attributes in log lines

### DIFF
--- a/app/models/current_job_logging_attributes.rb
+++ b/app/models/current_job_logging_attributes.rb
@@ -22,7 +22,7 @@ class CurrentJobLoggingAttributes < ActiveSupport::CurrentAttributes
       form_id:,
       form_name:,
       submission_reference:,
-      preview: preview.to_s,
+      preview: preview&.to_s,
       delivery_id:,
       delivery_reference:,
       delivery_schedule:,
@@ -32,6 +32,6 @@ class CurrentJobLoggingAttributes < ActiveSupport::CurrentAttributes
       confirmation_email_id:,
       sqs_message_id:,
       sns_message_timestamp:,
-    }.compact_blank
+    }.compact
   end
 end

--- a/app/models/current_request_logging_attributes.rb
+++ b/app/models/current_request_logging_attributes.rb
@@ -23,7 +23,7 @@ class CurrentRequestLoggingAttributes < ActiveSupport::CurrentAttributes
       request_id:,
       form_id:,
       form_name:,
-      preview: preview.to_s,
+      preview: preview&.to_s,
       step_id:,
       step_slug:,
       answer_type:,
@@ -36,6 +36,6 @@ class CurrentRequestLoggingAttributes < ActiveSupport::CurrentAttributes
       rescued_exception_trace:,
       validation_errors:,
       answer_metadata:,
-    }.compact_blank
+    }.compact
   end
 end

--- a/app/models/current_task_logging_attributes.rb
+++ b/app/models/current_task_logging_attributes.rb
@@ -4,6 +4,6 @@ class CurrentTaskLoggingAttributes < ActiveSupport::CurrentAttributes
   def as_hash
     {
       task_name:,
-    }.compact_blank
+    }.compact
   end
 end

--- a/spec/models/current_job_logging_attributes_spec.rb
+++ b/spec/models/current_job_logging_attributes_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe CurrentJobLoggingAttributes do
+  subject(:current) { described_class.new }
+
+  describe "#as_hash" do
+    it "includes only properties that are set" do
+      current.job_class = "AClass"
+      expect(current.as_hash).to eq({ job_class: "AClass" })
+    end
+
+    it "includes all properties when they are set" do
+      current.job_class = "AClass"
+      current.job_id = "xyz789"
+      current.form_id = 456
+      current.form_name = "A form"
+      current.submission_reference = "ABC123"
+      current.preview = true
+      current.delivery_id = 123
+      current.delivery_reference = "REF123"
+      current.delivery_schedule = "immediate"
+      current.delivery_method = "email"
+      current.delivery_formats = %w[csv json]
+      current.batch_begin_at = Time.zone.parse("2026-01-01 12:00")
+      current.confirmation_email_id = "CONF123"
+      current.sqs_message_id = "SQS123"
+      current.sns_message_timestamp = "2025-05-09T10:25:43.972Z"
+
+      expect(current.as_hash).to eq({
+        job_class: "AClass",
+        job_id: "xyz789",
+        form_id: 456,
+        form_name: "A form",
+        submission_reference: "ABC123",
+        preview: "true",
+        delivery_id: 123,
+        delivery_reference: "REF123",
+        delivery_schedule: "immediate",
+        delivery_method: "email",
+        delivery_formats: %w[csv json],
+        batch_begin_at: Time.zone.parse("2026-01-01 12:00"),
+        confirmation_email_id: "CONF123",
+        sqs_message_id: "SQS123",
+        sns_message_timestamp: "2025-05-09T10:25:43.972Z",
+      })
+    end
+
+    it "includes the delivery_formats when set to an empty array (this is used by Splunk reports)" do
+      current.delivery_formats = []
+
+      expect(current.as_hash).to eq({ delivery_formats: [] })
+    end
+  end
+end

--- a/spec/models/current_request_logging_attributes_spec.rb
+++ b/spec/models/current_request_logging_attributes_spec.rb
@@ -52,15 +52,5 @@ RSpec.describe CurrentRequestLoggingAttributes, type: :model do
     it "does not include nil confirmation_email_reference" do
       expect(current.as_hash.key?(:confirmation_email_reference)).to be false
     end
-
-    it "does not include the validation errors array if empty" do
-      current.validation_errors = []
-      expect(current.as_hash.keys).not_to include :validation_errors
-    end
-
-    it "does not include the answer metadata if hash is empty" do
-      current.answer_metadata = {}
-      expect(current.as_hash.keys).not_to include :answer_metadata
-    end
   end
 end


### PR DESCRIPTION
Previously, we were calling `compact_blank` on the attributes hash because we were including a nested hash of attributes associated with the Notify request that wasn't always populated. Now, we only set attributes on the CurrentAttributes when they are present/relevant.

Include blank attributes as it's easier to use the log lines in Splunk for attributes that can have an empty array, such as the `delivery_formats` attribute for jobs.